### PR TITLE
Add Overrated daily game environment

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,6 +154,18 @@
     .duos { background-image:url("duos.png"); }
     .oddity { background-image:url("oddity.png"); }
     .decode { background-image:url("decode.png"); }
+    .overrated {
+      background:linear-gradient(135deg,#8b5cf6 0%,#4330c1 45%,#281671 100%);
+      border-color:#281671;
+      color:#fff;
+    }
+    .overrated span {
+      font-family:"Baloo 2", system-ui, sans-serif;
+      font-size:28px;
+      text-transform:uppercase;
+      letter-spacing:1.2px;
+      text-shadow:0 4px 12px rgba(0,0,0,0.4);
+    }
 
     /* Completed overlay */
     .card.completed::after {
@@ -213,6 +225,7 @@
         <a class="card duos" href="duos/"></a>
         <a class="card oddity" href="oddity/"></a>
         <a class="card decode" href="decode/"></a>
+        <a class="card overrated" href="overrated/"><span>Overrated</span></a>
       </div>
     </div>
 

--- a/overrated/index.html
+++ b/overrated/index.html
@@ -1,1 +1,491 @@
-!
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,viewport-fit=cover,user-scalable=no" />
+  <title>Overrated — JBTgames</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bungee&family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --ink:#1a1325;
+      --bg:#f5f3ff;
+      --accent:#7f5af0;
+      --accent-dark:#6141c2;
+      --surface:#ffffff;
+      --correct:#22b34b;
+      --wrong:#ff4b6e;
+      --muted:#7c7a8c;
+      --card1:#f4d9ff;
+      --card2:#ffe7d3;
+      --card3:#d8f5ff;
+      --card4:#fff3d6;
+      --radius:18px;
+      color-scheme:only light;
+    }
+
+    * { box-sizing:border-box; }
+
+    body {
+      margin:0;
+      min-height:100dvh;
+      font-family:'Inter',system-ui,sans-serif;
+      background:radial-gradient(circle at top,#ffffff 0%,#f3f1ff 55%,#ece8ff 100%);
+      color:var(--ink);
+      display:flex;
+      justify-content:center;
+    }
+
+    .wrapper {
+      width:100%;
+      max-width:480px;
+      min-height:100dvh;
+      display:flex;
+      flex-direction:column;
+      padding:18px 18px 28px;
+      gap:18px;
+    }
+
+    header {
+      display:flex;
+      flex-direction:column;
+      gap:6px;
+      align-items:center;
+      text-align:center;
+    }
+
+    .logo {
+      font-family:'Bungee',cursive;
+      font-size:46px;
+      letter-spacing:2px;
+      color:var(--accent);
+      text-shadow:0 4px 14px rgba(127,90,240,0.25);
+    }
+
+    .tagline {
+      font-size:16px;
+      font-weight:600;
+      text-transform:uppercase;
+      letter-spacing:1.5px;
+      color:var(--muted);
+    }
+
+    #progress {
+      font-size:14px;
+      font-weight:700;
+      color:var(--ink);
+      background:rgba(127,90,240,0.1);
+      padding:6px 14px;
+      border-radius:999px;
+    }
+
+    main {
+      flex:1;
+      display:flex;
+      flex-direction:column;
+      gap:16px;
+    }
+
+    .prompt-box {
+      background:linear-gradient(135deg,rgba(127,90,240,0.12),rgba(127,90,240,0));
+      border-radius:var(--radius);
+      padding:14px 16px 18px;
+      box-shadow:0 12px 35px rgba(26,19,37,0.08);
+      display:flex;
+      flex-direction:column;
+      gap:6px;
+    }
+
+    #stageLabel {
+      font-size:13px;
+      font-weight:800;
+      letter-spacing:1.6px;
+      text-transform:uppercase;
+      color:var(--accent-dark);
+    }
+
+    #prompt {
+      font-size:18px;
+      line-height:1.4;
+      margin:0;
+    }
+
+    #options {
+      display:grid;
+      grid-template-columns:repeat(2,minmax(0,1fr));
+      gap:14px;
+      flex:1;
+    }
+
+    .choice {
+      position:relative;
+      border-radius:var(--radius);
+      padding:16px;
+      background:var(--surface);
+      border:3px solid transparent;
+      box-shadow:0 14px 30px rgba(26,19,37,0.08);
+      display:flex;
+      flex-direction:column;
+      gap:10px;
+      cursor:pointer;
+      transition:transform .18s ease, box-shadow .18s ease, border-color .18s ease;
+    }
+
+    .choice:hover { transform:translateY(-4px); box-shadow:0 18px 36px rgba(26,19,37,0.12); }
+    .choice:active { transform:translateY(-1px); }
+
+    .choice:nth-child(1) { background:var(--card1); }
+    .choice:nth-child(2) { background:var(--card2); }
+    .choice:nth-child(3) { background:var(--card3); }
+    .choice:nth-child(4) { background:var(--card4); }
+
+    .choice h3 {
+      font-size:17px;
+      margin:0;
+      font-weight:800;
+    }
+
+    .scores {
+      display:flex;
+      justify-content:space-between;
+      font-size:13px;
+      font-weight:600;
+    }
+
+    .scores span strong { display:block; font-size:21px; }
+
+    .note {
+      font-size:12px;
+      color:var(--muted);
+      font-weight:600;
+      line-height:1.3;
+    }
+
+    .choice.correct {
+      border-color:var(--correct);
+      box-shadow:0 18px 36px rgba(34,179,75,0.25);
+    }
+
+    .choice.wrong {
+      border-color:var(--wrong);
+      box-shadow:0 18px 36px rgba(255,75,110,0.25);
+      opacity:0.75;
+    }
+
+    .choice.disabled { pointer-events:none; }
+
+    footer {
+      text-align:center;
+      font-size:12px;
+      color:var(--muted);
+      line-height:1.5;
+      padding:8px 12px;
+    }
+
+    .overlay, .end-screen {
+      position:fixed;
+      inset:0;
+      background:rgba(18,12,32,0.78);
+      display:none;
+      align-items:center;
+      justify-content:center;
+      padding:20px;
+      z-index:20;
+    }
+
+    .overlay.show, .end-screen.show { display:flex; }
+
+    .modal {
+      background:var(--surface);
+      border-radius:22px;
+      padding:26px;
+      width:min(420px,calc(100% - 40px));
+      text-align:center;
+      box-shadow:0 16px 40px rgba(26,19,37,0.25);
+      display:flex;
+      flex-direction:column;
+      gap:14px;
+    }
+
+    .modal h1 {
+      margin:0;
+      font-family:'Bungee',cursive;
+      font-size:28px;
+      letter-spacing:1px;
+      color:var(--accent);
+    }
+
+    .modal p {
+      margin:0;
+      font-size:15px;
+      line-height:1.45;
+      color:var(--ink);
+    }
+
+    button {
+      border:none;
+      border-radius:999px;
+      padding:12px 20px;
+      font-size:15px;
+      font-weight:700;
+      cursor:pointer;
+      font-family:'Inter',system-ui,sans-serif;
+      background:var(--accent);
+      color:#fff;
+      transition:transform .15s ease, background .15s ease;
+    }
+
+    button:hover { background:var(--accent-dark); }
+    button:active { transform:translateY(1px); }
+
+    #shareBtn { display:none; }
+
+    #shareNotice {
+      font-size:12px;
+      color:var(--muted);
+      min-height:16px;
+    }
+
+    @media (max-width:420px) {
+      .wrapper { padding:16px 14px 24px; }
+      .logo { font-size:40px; }
+      .choice { padding:14px; }
+      .scores span strong { font-size:18px; }
+      #prompt { font-size:17px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <header>
+      <div class="logo">OVERRATED</div>
+      <div class="tagline">Critics swooned. Audiences shrugged.</div>
+      <div id="progress">Loading…</div>
+    </header>
+
+    <main>
+      <div class="prompt-box">
+        <div id="stageLabel">Warmup</div>
+        <p id="prompt">Fetching today's matchups…</p>
+      </div>
+      <div id="options"></div>
+    </main>
+
+    <footer id="footerInfo">Rotten Tomatoes score snapshots for fun only.</footer>
+  </div>
+
+  <div id="overlay" class="overlay">
+    <div class="modal">
+      <h1 id="result">Nice!</h1>
+      <p id="explanation"></p>
+      <button id="continueBtn">Next matchup</button>
+    </div>
+  </div>
+
+  <div id="endScreen" class="end-screen">
+    <div class="modal">
+      <h1>Final Verdict</h1>
+      <div id="endIcons" style="font-size:28px; letter-spacing:6px;"></div>
+      <p id="endText"></p>
+      <p id="endComment" style="color:var(--muted);"></p>
+      <button id="shareBtn">Share my verdict</button>
+      <div id="shareNotice"></div>
+      <button id="playAgainBtn" style="background:var(--surface); color:var(--accent); border:2px solid var(--accent);">Play again tomorrow</button>
+    </div>
+  </div>
+
+  <script>
+    const DATA_URL = "puzzles.json";
+    const STAGES = [
+      { key: "easy", label: "Warmup" },
+      { key: "medium", label: "Main Event" },
+      { key: "hard", label: "Finale" }
+    ];
+
+    const progressEl = document.getElementById('progress');
+    const stageLabel = document.getElementById('stageLabel');
+    const promptEl = document.getElementById('prompt');
+    const optionsEl = document.getElementById('options');
+    const footerInfo = document.getElementById('footerInfo');
+
+    const overlay = document.getElementById('overlay');
+    const resultEl = document.getElementById('result');
+    const explanationEl = document.getElementById('explanation');
+    const continueBtn = document.getElementById('continueBtn');
+
+    const endScreen = document.getElementById('endScreen');
+    const endIcons = document.getElementById('endIcons');
+    const endText = document.getElementById('endText');
+    const endComment = document.getElementById('endComment');
+    const shareBtn = document.getElementById('shareBtn');
+    const shareNotice = document.getElementById('shareNotice');
+    const playAgainBtn = document.getElementById('playAgainBtn');
+
+    let puzzles = [];
+    let todaySet;
+    let level = 0;
+    let results = [];
+
+    const comments = {
+      0: [
+        "A clean sweep of terrible takes. Critics everywhere are sobbing.",
+        "You picked zero. That’s a perfect display of contrarian chaos.",
+        "Utter meltdown. Maybe check the scores next time?"
+      ],
+      1: [
+        "One right. Statistically, that’s almost a fluke.",
+        "You found a single overrated pick. The critics still have your number.",
+        "1/3 — barely a blip on the snob radar."
+      ],
+      2: [
+        "Two correct! You’re reading the room… mostly.",
+        "Solid instincts. Just one critic darling slipped past you.",
+        "Almost perfect. Rotten Tomatoes might call you for backup."
+      ],
+      3: [
+        "Flawless taste. You’re the voice of the people now.",
+        "3/3 — the critics can’t hide from you.",
+        "Perfect score! Hollywood’s hype machine fears you."
+      ]
+    };
+
+    init();
+
+    async function init() {
+      try {
+        await loadPuzzles();
+        footerInfo.textContent = todaySet.footer || 'Score data gathered from public Rotten Tomatoes listings.';
+        level = 0;
+        results = [];
+        renderLevel();
+      } catch (err) {
+        console.error(err);
+        progressEl.textContent = 'Failed to load puzzles. Try refreshing.';
+        promptEl.textContent = 'We could not reach the score vault right now.';
+      }
+    }
+
+    function ymd() {
+      const d = new Date();
+      return d.getFullYear() + String(d.getMonth() + 1).padStart(2, '0') + String(d.getDate()).padStart(2, '0');
+    }
+
+    function ymdDash() {
+      return new Date().toISOString().split('T')[0];
+    }
+
+    async function loadPuzzles() {
+      const res = await fetch(`${DATA_URL}?v=${ymd()}`, { cache: 'no-store' });
+      if (!res.ok) throw new Error('Network error loading puzzles');
+      const data = await res.json();
+      puzzles = data.days;
+      const index = parseInt(ymd(), 10) % puzzles.length;
+      todaySet = puzzles[index];
+    }
+
+    function renderLevel() {
+      const stage = STAGES[level];
+      const puzzle = todaySet[stage.key];
+      stageLabel.textContent = stage.label;
+      promptEl.textContent = puzzle.prompt;
+      progressEl.textContent = `Match ${level + 1} of ${STAGES.length}`;
+
+      optionsEl.innerHTML = '';
+      puzzle.items.forEach((item) => {
+        const card = document.createElement('div');
+        card.className = 'choice';
+        card.dataset.title = item.title;
+        card.innerHTML = `
+          <h3>${item.title}</h3>
+          <div class="scores">
+            <span>Critics<strong>${item.critics}%</strong></span>
+            <span>Audience<strong>${item.audience}%</strong></span>
+          </div>
+          <div class="note">${item.note}</div>
+        `;
+        card.onclick = () => evaluateChoice(item, card);
+        optionsEl.appendChild(card);
+      });
+    }
+
+    function evaluateChoice(item, card) {
+      const stage = STAGES[level];
+      const puzzle = todaySet[stage.key];
+      const correctTitle = puzzle.answer;
+      const cards = Array.from(optionsEl.children);
+      cards.forEach((c) => {
+        c.classList.add('disabled');
+        c.onclick = null;
+      });
+
+      const isCorrect = item.title === correctTitle;
+      card.classList.add(isCorrect ? 'correct' : 'wrong');
+      if (!isCorrect) {
+        const correctCard = cards.find((c) => c.dataset.title === correctTitle);
+        if (correctCard) {
+          correctCard.classList.add('correct');
+          correctCard.classList.remove('wrong');
+        }
+      }
+
+      results.push(isCorrect ? '✅' : '❌');
+      const header = isCorrect ? randomFrom(['Spot on!', 'Nice call!', 'Dead accurate!']) : randomFrom(['Not quite!', 'Close miss!', 'Off the mark!']);
+      resultEl.textContent = header;
+      explanationEl.textContent = puzzle.explanation;
+      continueBtn.textContent = level === STAGES.length - 1 ? 'See final verdict' : 'Next matchup';
+
+      overlay.classList.add('show');
+    }
+
+    continueBtn.onclick = () => {
+      overlay.classList.remove('show');
+      level += 1;
+      if (level < STAGES.length) {
+        renderLevel();
+      } else {
+        finishGame();
+      }
+    };
+
+    function finishGame() {
+      endIcons.textContent = results.join(' ');
+      const score = results.filter((r) => r === '✅').length;
+      endText.textContent = `You spotted ${score} out of ${STAGES.length} critic darlings.`;
+      const pool = comments[score] || comments[0];
+      endComment.textContent = randomFrom(pool);
+      shareBtn.style.display = 'inline-flex';
+      shareNotice.textContent = '';
+      endScreen.classList.add('show');
+    }
+
+    shareBtn.onclick = async () => {
+      const score = results.filter((r) => r === '✅').length;
+      const shareText = `Overrated ${ymdDash()} — ${results.join(' ')} (${score}/${STAGES.length})\n${location.href}`;
+      if (navigator.share) {
+        try {
+          await navigator.share({ title: 'Overrated — JBTgames', text: shareText, url: location.href });
+          shareNotice.textContent = 'Shared! May your hot takes spread far.';
+        } catch (err) {
+          console.warn('Share cancelled', err);
+        }
+      } else if (navigator.clipboard && navigator.clipboard.writeText) {
+        try {
+          await navigator.clipboard.writeText(shareText);
+          shareNotice.textContent = 'Copied to clipboard. Paste it where the people gather.';
+        } catch (err) {
+          shareNotice.textContent = 'Copy failed — try selecting the text manually.';
+        }
+      } else {
+        shareNotice.textContent = shareText;
+      }
+    };
+
+    playAgainBtn.onclick = () => {
+      endScreen.classList.remove('show');
+    };
+
+    function randomFrom(arr) {
+      return arr[Math.floor(Math.random() * arr.length)];
+    }
+  </script>
+</body>
+</html>

--- a/overrated/puzzles.json
+++ b/overrated/puzzles.json
@@ -1,0 +1,256 @@
+{
+  "days": [
+    {
+      "footer": "Critic and audience scores pulled from Rotten Tomatoes snapshots (Jan 2024).",
+      "easy": {
+        "prompt": "Which blockbuster had the widest gap where critics cheered but audiences booed?",
+        "items": [
+          {"title": "Star Wars: The Last Jedi", "critics": 91, "audience": 42, "note": "2017, dir. Rian Johnson"},
+          {"title": "Mulan (2020)", "critics": 73, "audience": 47, "note": "Live-action remake"},
+          {"title": "The Irishman", "critics": 95, "audience": 86, "note": "Scorsese's Netflix epic"},
+          {"title": "The Shape of Water", "critics": 92, "audience": 72, "note": "Best Picture winner"}
+        ],
+        "answer": "Star Wars: The Last Jedi",
+        "explanation": "Critics scored The Last Jedi at 91% while audiences sat at 42% — a 49-point gulf." 
+      },
+      "medium": {
+        "prompt": "Prestige streamers galore. Which film kept critics far ahead of viewers?",
+        "items": [
+          {"title": "The Power of the Dog", "critics": 94, "audience": 76, "note": "Jane Campion's western slow-burn"},
+          {"title": "Nomadland", "critics": 93, "audience": 81, "note": "Oscars 2021 champion"},
+          {"title": "Roma", "critics": 96, "audience": 85, "note": "Cuarón's black-and-white opus"},
+          {"title": "Green Book", "critics": 77, "audience": 86, "note": "Crowd-pleaser surprise winner"}
+        ],
+        "answer": "The Power of the Dog",
+        "explanation": "The Power of the Dog sits at 94% with critics versus 76% with audiences — an 18-point edge." 
+      },
+      "hard": {
+        "prompt": "Awards darlings collide. Which one lost fans fastest?",
+        "items": [
+          {"title": "Birdman", "critics": 91, "audience": 78, "note": "2015 Best Picture"},
+          {"title": "La La Land", "critics": 91, "audience": 81, "note": "City of stars"},
+          {"title": "The Fabelmans", "critics": 92, "audience": 82, "note": "Spielberg's memoir"},
+          {"title": "Her", "critics": 94, "audience": 82, "note": "Spike Jonze future romance"}
+        ],
+        "answer": "Birdman",
+        "explanation": "Birdman holds a 91% critics score against a 78% audience score — a 13-point slide." 
+      }
+    },
+    {
+      "footer": "Critic and audience scores pulled from Rotten Tomatoes snapshots (Jan 2024).",
+      "easy": {
+        "prompt": "Festival favorites. Which eerie indie spooked audiences far less than critics?",
+        "items": [
+          {"title": "The Witch", "critics": 90, "audience": 59, "note": "Folk horror breakout"},
+          {"title": "Lady Bird", "critics": 99, "audience": 79, "note": "Gerwig's coming-of-age"},
+          {"title": "Call Me By Your Name", "critics": 94, "audience": 86, "note": "Sun-drenched romance"},
+          {"title": "Moonlight", "critics": 98, "audience": 79, "note": "Best Picture 2016"}
+        ],
+        "answer": "The Witch",
+        "explanation": "The Witch boasts a 90% critics score but only 59% from audiences — a 31-point split." 
+      },
+      "medium": {
+        "prompt": "Awards circuit obsessions. Which one is the biggest critic darling?",
+        "items": [
+          {"title": "The Favourite", "critics": 93, "audience": 61, "note": "Period satire"},
+          {"title": "Licorice Pizza", "critics": 91, "audience": 62, "note": "PTA's San Fernando hangout"},
+          {"title": "The Lighthouse", "critics": 90, "audience": 72, "note": "Two men and a lighthouse"},
+          {"title": "Tár", "critics": 90, "audience": 73, "note": "Cate Blanchett conducts chaos"}
+        ],
+        "answer": "The Favourite",
+        "explanation": "The Favourite sits 32 points higher with critics (93%) than with audiences (61%)." 
+      },
+      "hard": {
+        "prompt": "Auteur fever dreams. Which film's praise-to-popcorn gap is widest?",
+        "items": [
+          {"title": "First Reformed", "critics": 93, "audience": 68, "note": "Schrader's crisis of faith"},
+          {"title": "Phantom Thread", "critics": 91, "audience": 71, "note": "Fashion and obsession"},
+          {"title": "Hereditary", "critics": 90, "audience": 68, "note": "Ari Aster terror"},
+          {"title": "Annihilation", "critics": 88, "audience": 66, "note": "Cosmic shimmer"}
+        ],
+        "answer": "First Reformed",
+        "explanation": "First Reformed keeps critics at 93% while audiences linger at 68% — a 25-point chasm." 
+      }
+    },
+    {
+      "footer": "Critic and audience scores pulled from Rotten Tomatoes snapshots (Jan 2024).",
+      "easy": {
+        "prompt": "Horror that divided sleepovers. Which title suffered the sharpest audience drop?",
+        "items": [
+          {"title": "It Comes at Night", "critics": 88, "audience": 44, "note": "Post-apocalyptic paranoia"},
+          {"title": "The Babadook", "critics": 95, "audience": 72, "note": "Monster in the closet"},
+          {"title": "The Blair Witch Project", "critics": 86, "audience": 56, "note": "Found-footage phenomenon"},
+          {"title": "Us", "critics": 93, "audience": 60, "note": "Jordan Peele's doppelgängers"}
+        ],
+        "answer": "It Comes at Night",
+        "explanation": "It Comes at Night drops from 88% with critics to 44% with audiences — a 44-point fall." 
+      },
+      "medium": {
+        "prompt": "Which supernatural scare kept critics 30+ points ahead of viewers?",
+        "items": [
+          {"title": "It Follows", "critics": 95, "audience": 62, "note": "Relentless urban legend"},
+          {"title": "The Ring", "critics": 71, "audience": 48, "note": "Seven days of fear"},
+          {"title": "Paranormal Activity 3", "critics": 66, "audience": 59, "note": "Third-night terrors"},
+          {"title": "Insidious", "critics": 66, "audience": 62, "note": "Astral projection chills"}
+        ],
+        "answer": "It Follows",
+        "explanation": "It Follows holds a 95% critics score against a 62% audience score — a 33-point spread." 
+      },
+      "hard": {
+        "prompt": "Cult horror picks. Which release left general audiences the coldest?",
+        "items": [
+          {"title": "The Endless", "critics": 92, "audience": 67, "note": "UFO cult mystery"},
+          {"title": "A Cure for Wellness", "critics": 43, "audience": 24, "note": "Gothic spa nightmare"},
+          {"title": "The Invitation", "critics": 89, "audience": 70, "note": "Dinner party dread"},
+          {"title": "The Others", "critics": 84, "audience": 77, "note": "Victorian ghost tale"}
+        ],
+        "answer": "The Endless",
+        "explanation": "The Endless keeps critics at 92% while audiences linger at 67% — a 25-point difference." 
+      }
+    },
+    {
+      "footer": "Critic and audience scores pulled from Rotten Tomatoes snapshots (Jan 2024).",
+      "easy": {
+        "prompt": "Spacey sci-fi. Which cerebral trip did mainstream audiences resist most?",
+        "items": [
+          {"title": "High Life", "critics": 82, "audience": 41, "note": "Claire Denis goes cosmic"},
+          {"title": "Ad Astra", "critics": 83, "audience": 72, "note": "Brad Pitt deep space odyssey"},
+          {"title": "Arrival", "critics": 94, "audience": 82, "note": "Linguistics vs aliens"},
+          {"title": "Ex Machina", "critics": 92, "audience": 86, "note": "AI house arrest"}
+        ],
+        "answer": "High Life",
+        "explanation": "High Life charts an 82% critics score but just 41% with audiences — a 41-point plunge." 
+      },
+      "medium": {
+        "prompt": "Mind-bending visions. Which release left critics 20+ points ahead?",
+        "items": [
+          {"title": "Annihilation", "critics": 88, "audience": 66, "note": "Shimmering annihilation"},
+          {"title": "Blade Runner 2049", "critics": 88, "audience": 81, "note": "Synthwave noir"},
+          {"title": "Tenet", "critics": 69, "audience": 76, "note": "Time inversion chaos"},
+          {"title": "The Matrix Resurrections", "critics": 63, "audience": 63, "note": "Meta reboot"}
+        ],
+        "answer": "Annihilation",
+        "explanation": "Annihilation posts 88% with critics versus 66% with viewers — a 22-point spread." 
+      },
+      "hard": {
+        "prompt": "Sci-fi canon. Which classic still reads as most overrated to audiences?",
+        "items": [
+          {"title": "Her", "critics": 94, "audience": 82, "note": "AI relationship"},
+          {"title": "2001: A Space Odyssey", "critics": 92, "audience": 89, "note": "Kubrick monolith"},
+          {"title": "Solaris (1972)", "critics": 96, "audience": 90, "note": "Tarkovsky's meditation"},
+          {"title": "Brazil", "critics": 98, "audience": 90, "note": "Gilliam's dystopia"}
+        ],
+        "answer": "Her",
+        "explanation": "Her sits at 94% with critics but 82% with audiences — a 12-point gap, the widest here." 
+      }
+    },
+    {
+      "footer": "Critic and audience scores pulled from Rotten Tomatoes snapshots (Jan 2024).",
+      "easy": {
+        "prompt": "Awards season 2022. Which nominee left general audiences the coldest?",
+        "items": [
+          {"title": "The Banshees of Inisherin", "critics": 96, "audience": 76, "note": "Feckin' feud"},
+          {"title": "Top Gun: Maverick", "critics": 96, "audience": 99, "note": "Mach 10 crowd-pleaser"},
+          {"title": "Avatar: The Way of Water", "critics": 78, "audience": 92, "note": "Pandora's sequel"},
+          {"title": "Elvis", "critics": 77, "audience": 94, "note": "Baz Luhrmann biopic"}
+        ],
+        "answer": "The Banshees of Inisherin",
+        "explanation": "The Banshees of Inisherin lands at 96% with critics yet 76% with viewers — a 20-point gap." 
+      },
+      "medium": {
+        "prompt": "Which awards contender kept critics a solid 15+ points ahead?",
+        "items": [
+          {"title": "Tár", "critics": 90, "audience": 73, "note": "Symphonic scandal"},
+          {"title": "Women Talking", "critics": 90, "audience": 80, "note": "Barn-raising debate"},
+          {"title": "Triangle of Sadness", "critics": 72, "audience": 69, "note": "Yacht satire"},
+          {"title": "The Whale", "critics": 64, "audience": 91, "note": "Fraser's comeback"}
+        ],
+        "answer": "Tár",
+        "explanation": "Tár carries a 17-point split: 90% critics vs 73% audience." 
+      },
+      "hard": {
+        "prompt": "Cannes faves. Which slow burn has the steepest approval drop?",
+        "items": [
+          {"title": "Aftersun", "critics": 96, "audience": 81, "note": "Father-daughter memory"},
+          {"title": "All Quiet on the Western Front", "critics": 90, "audience": 90, "note": "Oscar-winning remake"},
+          {"title": "The Fabelmans", "critics": 92, "audience": 82, "note": "Spielberg's memoir"},
+          {"title": "Living", "critics": 96, "audience": 86, "note": "Kazuo Ishiguro adaptation"}
+        ],
+        "answer": "Aftersun",
+        "explanation": "Aftersun holds critics at 96% against audiences at 81% — a 15-point difference." 
+      }
+    },
+    {
+      "footer": "Critic and audience scores pulled from Rotten Tomatoes snapshots (Jan 2024).",
+      "easy": {
+        "prompt": "Heist and thriller fare. Which title screamed \"overrated\" to viewers?",
+        "items": [
+          {"title": "Widows", "critics": 91, "audience": 60, "note": "Steve McQueen's Chicago caper"},
+          {"title": "Nightcrawler", "critics": 95, "audience": 85, "note": "News stringer nightmare"},
+          {"title": "Sicario", "critics": 92, "audience": 85, "note": "Borderland tension"},
+          {"title": "Se7en", "critics": 82, "audience": 95, "note": "What's in the box?"}
+        ],
+        "answer": "Widows",
+        "explanation": "Widows plunges from 91% with critics to 60% with audiences — a 31-point swing." 
+      },
+      "medium": {
+        "prompt": "Modern war dramas. Which one kept critics a baker's dozen ahead?",
+        "items": [
+          {"title": "The Hurt Locker", "critics": 97, "audience": 84, "note": "Bomb squad intensity"},
+          {"title": "Zero Dark Thirty", "critics": 91, "audience": 80, "note": "Bin Laden manhunt"},
+          {"title": "Argo", "critics": 96, "audience": 90, "note": "Hollywood rescue"},
+          {"title": "Captain Phillips", "critics": 93, "audience": 89, "note": "Somali pirate standoff"}
+        ],
+        "answer": "The Hurt Locker",
+        "explanation": "The Hurt Locker posts 97% with critics and 84% with audiences — a 13-point cushion." 
+      },
+      "hard": {
+        "prompt": "Spycraft sequels. Which entry saw the biggest enthusiasm drop?",
+        "items": [
+          {"title": "Sicario: Day of the Soldado", "critics": 62, "audience": 47, "note": "Cartel escalation"},
+          {"title": "Bridge of Spies", "critics": 91, "audience": 87, "note": "Spielberg spy swap"},
+          {"title": "Tinker Tailor Soldier Spy", "critics": 83, "audience": 79, "note": "Le Carré labyrinth"},
+          {"title": "The Constant Gardener", "critics": 83, "audience": 80, "note": "Corporate conspiracy"}
+        ],
+        "answer": "Sicario: Day of the Soldado",
+        "explanation": "Sicario: Day of the Soldado slips 15 points from critics (62%) to audiences (47%)." 
+      }
+    },
+    {
+      "footer": "Critic and audience scores pulled from Rotten Tomatoes snapshots (Jan 2024).",
+      "easy": {
+        "prompt": "Animated crowd-pleasers. Which release baffled family audiences most?",
+        "items": [
+          {"title": "Turning Red", "critics": 95, "audience": 72, "note": "Teen panda pandemonium"},
+          {"title": "Soul", "critics": 95, "audience": 88, "note": "Existential jazz"},
+          {"title": "Encanto", "critics": 91, "audience": 93, "note": "Casita con encanto"},
+          {"title": "Luca", "critics": 91, "audience": 86, "note": "Italian summer"}
+        ],
+        "answer": "Turning Red",
+        "explanation": "Turning Red stays at 95% with critics but only 72% with audiences — a 23-point gap." 
+      },
+      "medium": {
+        "prompt": "Which Pixar outing kept critics a dozen points ahead?",
+        "items": [
+          {"title": "The Good Dinosaur", "critics": 76, "audience": 65, "note": "Prehistoric road trip"},
+          {"title": "Onward", "critics": 88, "audience": 95, "note": "Brothers on a quest"},
+          {"title": "Brave", "critics": 78, "audience": 75, "note": "Merida's stand"},
+          {"title": "Finding Dory", "critics": 94, "audience": 88, "note": "Ocean reunion"}
+        ],
+        "answer": "The Good Dinosaur",
+        "explanation": "The Good Dinosaur holds a modest 76% with critics versus 65% with audiences — an 11-point lead." 
+      },
+      "hard": {
+        "prompt": "Pixar classics showdown. Which one loses audiences by the widest margin?",
+        "items": [
+          {"title": "Ratatouille", "critics": 96, "audience": 87, "note": "Parisian kitchen dream"},
+          {"title": "WALL·E", "critics": 95, "audience": 90, "note": "Lonely robot love story"},
+          {"title": "Up", "critics": 98, "audience": 90, "note": "Adventure is out there"},
+          {"title": "Toy Story 4", "critics": 97, "audience": 94, "note": "Forky's existential crisis"}
+        ],
+        "answer": "Ratatouille",
+        "explanation": "Ratatouille keeps critics at 96% while audiences sit at 87% — a 9-point difference." 
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- build a fully styled Overrated daily game page with multi-round flow, result overlays, and sharing
- seed the game with seven days of critic-versus-audience matchup data
- surface the new mode from the homepage with a dedicated tile style

## Testing
- python - <<'PY'
import json, pathlib
path = pathlib.Path('overrated/puzzles.json')
data = json.loads(path.read_text())
for day in data['days']:
    for key in ['easy','medium','hard']:
        puzzle = day[key]
        diffs = {item['title']: item['critics']-item['audience'] for item in puzzle['items']}
        max_title = max(diffs, key=diffs.get)
        assert max_title == puzzle['answer'], (puzzle['prompt'], max_title, puzzle['answer'])
PY

------
https://chatgpt.com/codex/tasks/task_e_68e3d9b9bb0483229fe089c8966ef2e9