### PR TITLE
Simplify Overrated deck for mobile swipe flow

### DIFF
--- a/overrated/index.html
+++ b/overrated/index.html
@@ -2,112 +2,52 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="A tongue-in-cheek look at the most overrated video game trends."
+      content="Swipe through culture picks one at a time and decide if they're overrated."
     />
-    <title>Overrated | JBT Games</title>
+    <title>Overrated? | Swipe Your Take</title>
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <header>
-      <h1>Overrated</h1>
-      <p>
-        A lovingly sarcastic tribute to the trends that dominate the gaming
-        scene. Tap on a card to discover why these fads deserve a time-out.
-      </p>
-    </header>
-
-    <main>
-      <article class="game-card">
-        <h2>Endless Battle Passes</h2>
-        <div class="game-meta">
-          <span class="meta-pill">grind fatigue</span>
-          <span>Introduced: 2017</span>
-          <span>Popularized by: Fortnite &amp; friends</span>
-        </div>
-        <p>
-          Battle passes promised rewarding progression, but the modern reality is
-          more like a part-time job.
-        </p>
-        <button class="toggle" aria-expanded="false" type="button">
-          Why it's overrated
-        </button>
-        <div class="toggle-panel" id="battle-pass-panel">
-          <p>
-            The pressure to log in daily can turn a hobby into a chore.
-            Meanwhile, the rewards often feel like virtual clutter.
+    <main class="app-shell">
+      <header class="app-header" role="banner">
+        <div class="brand-row">
+          <h1 class="brand-title">Overrated<span>?</span></h1>
+          <p class="brand-progress">
+            <span id="progress-current">0</span>/<span id="progress-total">0</span>
           </p>
-          <ul class="reasons">
-            <li>Artificial fear-of-missing-out tactics.</li>
-            <li>Confusing currencies and tier unlocks.</li>
-            <li>Cosmetics that rarely feel worth the grind.</li>
-          </ul>
         </div>
-      </article>
+        <p class="header-sub">Swipe the card or tap a button to call the hype.</p>
+      </header>
 
-      <article class="game-card">
-        <h2>Ultra-Realistic Mud Physics</h2>
-        <div class="game-meta">
-          <span class="meta-pill">tech flex</span>
-          <span>Introduced: 2015</span>
-          <span>Popularized by: Racing sims</span>
+      <section class="card-stage" aria-label="Vote on whether each pick is overrated">
+        <div class="card-stack" id="card-stack">
+          <article id="current-card" class="subject-card current" aria-live="polite"></article>
+          <article id="next-card" class="subject-card standby" aria-hidden="true"></article>
         </div>
-        <p>
-          Yes, the mud looks fantastic. No, it does not make the gameplay more
-          exciting.
-        </p>
-        <button class="toggle" aria-expanded="false" type="button">
-          Why it's overrated
-        </button>
-        <div class="toggle-panel" id="mud-physics-panel">
-          <p>
-            When studios brag about dirt realism more than track design, maybe
-            priorities need a patch.
-          </p>
-          <ul class="reasons">
-            <li>The novelty wears off after the first splash.</li>
-            <li>Often masks lackluster vehicle handling.</li>
-            <li>Consumes dev time better spent on smarter AI.</li>
-          </ul>
+        <div class="vote-actions" role="group" aria-label="Cast your vote">
+          <button id="vote-no" class="vote-button vote-no" type="button">
+            <span class="vote-icon" aria-hidden="true">👎</span>
+            <span class="vote-label">Not overrated</span>
+          </button>
+          <button id="vote-yes" class="vote-button vote-yes" type="button">
+            <span class="vote-icon" aria-hidden="true">🔥</span>
+            <span class="vote-label">Overrated</span>
+          </button>
         </div>
-      </article>
+      </section>
 
-      <article class="game-card">
-        <h2>Non-Stop Cinematic Cutscenes</h2>
-        <div class="game-meta">
-          <span class="meta-pill">passive play</span>
-          <span>Introduced: 2001</span>
-          <span>Popularized by: Prestige action titles</span>
-        </div>
-        <p>
-          Games that forget to let you actually play them? A bold creative
-          choice, sure.
-        </p>
-        <button class="toggle" aria-expanded="false" type="button">
-          Why it's overrated
+      <footer class="app-footer">
+        <button id="restart-button" class="ghost-button" type="button" hidden>
+          Shuffle another round
         </button>
-        <div class="toggle-panel" id="cutscene-panel">
-          <p>
-            Storytelling is great, but skipping 12-minute cutscenes to get back
-            to the action should not feel like a crime.
-          </p>
-          <ul class="reasons">
-            <li>Breaks the pacing and immersion.</li>
-            <li>Disrespects player agency.</li>
-            <li>Unskippable scenes are the real boss fights.</li>
-          </ul>
-        </div>
-      </article>
+        <p class="footer-note">Reload anytime for a fresh stack of debates.</p>
+      </footer>
     </main>
 
-    <footer>
-      <p>
-        Built with playful bias by the JBT Games crew. Share your own overrated
-        trends and let's commiserate.
-      </p>
-    </footer>
+    <div class="sr-only" aria-live="polite" id="sr-status"></div>
 
     <script src="script.js"></script>
   </body>

--- a/overrated/script.js
+++ b/overrated/script.js
@@ -1,29 +1,345 @@
-const cards = document.querySelectorAll(".game-card");
+const subjects = [
+  {
+    id: "midnight-pop",
+    name: "Midnight Aurora",
+    type: "Album",
+    year: 2022,
+    origin: "Nova Reign",
+    description:
+      "Synth-drenched pop that topped every playlist for a year straight. Is the neon glow still dazzling or starting to flicker?",
+    stats: [
+      { icon: "🎧", label: "Streams", value: "2.4B" },
+      { icon: "🏆", label: "Awards", value: "5 major wins" }
+    ],
+    accent:
+      "radial-gradient(circle at top right, rgba(255, 120, 196, 0.45), transparent 65%)"
+  },
+  {
+    id: "moonfall",
+    name: "Moonfall: Beyond the Rift",
+    type: "Movie",
+    year: 2021,
+    origin: "R. K. Vega",
+    description:
+      "The space opera that promised to redefine sci-fi blockbusters. Fans call it visionary, critics call it very loud.",
+    stats: [
+      { icon: "🍿", label: "Box Office", value: "$1.3B" },
+      { icon: "⭐", label: "Fan score", value: "91/100" }
+    ],
+    accent:
+      "radial-gradient(circle at top left, rgba(120, 176, 255, 0.4), transparent 60%)"
+  },
+  {
+    id: "spectrum-series",
+    name: "Spectrum High",
+    type: "Series",
+    year: 2020,
+    origin: "Channel Wave",
+    description:
+      "Teen drama turned cultural phenomenon. Eight seasons of cliffhangers, love triangles, and somehow still in high school.",
+    stats: [
+      { icon: "📺", label: "Seasons", value: "8 and counting" },
+      { icon: "💬", label: "Memes", value: "Trending weekly" }
+    ],
+    accent:
+      "radial-gradient(circle at bottom right, rgba(255, 180, 84, 0.45), transparent 60%)"
+  },
+  {
+    id: "pulse-festival",
+    name: "Pulsewave Festival",
+    type: "Live Show",
+    year: 2023,
+    origin: "Global",
+    description:
+      "Three days of lasers, bass drops, and tickets that sell out before the lineup even drops. Worth the scramble?",
+    stats: [
+      { icon: "🎟️", label: "Tickets", value: "250k sold" },
+      { icon: "🌐", label: "Livestream", value: "41M viewers" }
+    ],
+    accent:
+      "radial-gradient(circle at center, rgba(120, 255, 214, 0.4), transparent 65%)"
+  },
+  {
+    id: "retro-remake",
+    name: "Chrono Legend Remake",
+    type: "Game",
+    year: 2024,
+    origin: "Realmforge",
+    description:
+      "Beloved classic rebuilt with hyper-realistic graphics. Nostalgia says masterpiece, purists say leave the pixels alone.",
+    stats: [
+      { icon: "🕹️", label: "Preorders", value: "8.2M" },
+      { icon: "🗳️", label: "User polls", value: "74% hype" }
+    ],
+    accent:
+      "radial-gradient(circle at bottom left, rgba(196, 169, 255, 0.45), transparent 60%)"
+  },
+  {
+    id: "viral-single",
+    name: "Looped In (feat. June)",
+    type: "Single",
+    year: 2023,
+    origin: "Luna Kai",
+    description:
+      "A hook so catchy it practically lives on short-form video. Is it genius production or just algorithm fuel?",
+    stats: [
+      { icon: "🎵", label: "Clips made", value: "11M" },
+      { icon: "📈", label: "Chart run", value: "14 weeks #1" }
+    ],
+    accent:
+      "radial-gradient(circle at top, rgba(255, 132, 132, 0.42), transparent 70%)"
+  }
+];
 
-cards.forEach((card) => {
-  const toggle = card.querySelector(".toggle");
-  const panel = card.querySelector(".toggle-panel");
+const currentCardEl = document.getElementById("current-card");
+const nextCardEl = document.getElementById("next-card");
+const cardStackEl = document.getElementById("card-stack");
+const voteYesButton = document.getElementById("vote-yes");
+const voteNoButton = document.getElementById("vote-no");
+const restartButton = document.getElementById("restart-button");
+const progressCurrent = document.getElementById("progress-current");
+const progressTotal = document.getElementById("progress-total");
+const statusRegion = document.getElementById("sr-status");
 
-  if (!toggle || !panel) return;
+let deck = [];
+let activeIndex = 0;
+let locked = false;
+let activeCard = currentCardEl;
+let standbyCard = nextCardEl;
 
-  const updateState = (expanded) => {
-    toggle.setAttribute("aria-expanded", expanded);
-    panel.classList.toggle("open", expanded === "true");
-  };
+const pointerState = {
+  id: null,
+  active: false,
+  startX: 0
+};
 
-  toggle.addEventListener("click", () => {
-    const expanded = toggle.getAttribute("aria-expanded") === "true" ? "false" : "true";
-    updateState(expanded);
-  });
+startRound();
 
-  toggle.addEventListener("keydown", (event) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      const expanded = toggle.getAttribute("aria-expanded") === "true" ? "false" : "true";
-      updateState(expanded);
-    }
-  });
+voteYesButton.addEventListener("click", () => handleVote("overrated"));
+voteNoButton.addEventListener("click", () => handleVote("chill"));
+restartButton.addEventListener("click", () => startRound());
 
-  // Initialize collapsed state
-  updateState("false");
+document.addEventListener("keydown", (event) => {
+  if (locked || activeIndex >= deck.length) return;
+  if (event.key === "ArrowRight") {
+    event.preventDefault();
+    handleVote("overrated");
+  }
+  if (event.key === "ArrowLeft") {
+    event.preventDefault();
+    handleVote("chill");
+  }
 });
+
+cardStackEl.addEventListener("pointerdown", (event) => {
+  if (locked || activeIndex >= deck.length) return;
+  pointerState.active = true;
+  pointerState.id = event.pointerId;
+  pointerState.startX = event.clientX;
+  activeCard.setPointerCapture(pointerState.id);
+  activeCard.style.transition = "none";
+});
+
+cardStackEl.addEventListener("pointermove", (event) => {
+  if (!pointerState.active || event.pointerId !== pointerState.id) return;
+  const deltaX = event.clientX - pointerState.startX;
+  const rotation = deltaX / 14;
+  activeCard.style.transform = `translateX(${deltaX}px) rotate(${rotation}deg)`;
+  const fade = Math.min(Math.abs(deltaX) / 260, 0.4);
+  activeCard.style.opacity = `${1 - fade}`;
+});
+
+cardStackEl.addEventListener("pointerup", (event) => {
+  if (!pointerState.active || event.pointerId !== pointerState.id) return;
+  const deltaX = event.clientX - pointerState.startX;
+  finalizePointerGesture();
+  const threshold = cardStackEl.clientWidth * 0.25;
+  if (Math.abs(deltaX) > threshold) {
+    handleVote(deltaX > 0 ? "overrated" : "chill");
+  }
+});
+
+cardStackEl.addEventListener("pointercancel", (event) => {
+  if (!pointerState.active || event.pointerId !== pointerState.id) return;
+  finalizePointerGesture();
+});
+
+function finalizePointerGesture() {
+  if (!pointerState.active) return;
+  activeCard.releasePointerCapture(pointerState.id);
+  pointerState.active = false;
+  pointerState.id = null;
+  pointerState.startX = 0;
+  activeCard.style.transition = "";
+  activeCard.style.transform = "";
+  activeCard.style.opacity = "";
+}
+
+function startRound() {
+  deck = shuffle(subjects);
+  activeIndex = 0;
+  locked = false;
+  activeCard = currentCardEl;
+  standbyCard = nextCardEl;
+
+  progressTotal.textContent = deck.length;
+  progressCurrent.textContent = deck.length ? 1 : 0;
+
+  restartButton.hidden = true;
+  setButtonsDisabled(deck.length === 0);
+
+  prepareCard(activeCard, "current");
+  prepareCard(standbyCard, "standby");
+
+  if (!deck.length) {
+    renderCompletion(activeCard);
+    return;
+  }
+
+  renderSubject(activeCard, deck[0]);
+  announceSubject(deck[0]);
+
+  const upcoming = deck[1];
+  if (upcoming) {
+    renderSubject(standbyCard, upcoming);
+    standbyCard.classList.add("incoming");
+  } else {
+    clearCard(standbyCard);
+  }
+}
+
+function handleVote(vote) {
+  if (locked || activeIndex >= deck.length) return;
+
+  locked = true;
+  setButtonsDisabled(true);
+
+  const subject = deck[activeIndex];
+  announceVote(subject, vote);
+
+  const outgoing = activeCard;
+  const incoming = standbyCard;
+  const swipeClass = vote === "overrated" ? "swipe-right" : "swipe-left";
+  outgoing.classList.add("leaving", swipeClass);
+
+  window.setTimeout(() => {
+    outgoing.classList.remove("leaving", "swipe-right", "swipe-left");
+    prepareCard(outgoing, "standby");
+
+    activeIndex += 1;
+    const hasNext = activeIndex < deck.length;
+
+    if (hasNext) {
+      prepareCard(incoming, "current");
+      renderSubject(incoming, deck[activeIndex]);
+      announceSubject(deck[activeIndex]);
+      activeCard = incoming;
+      standbyCard = outgoing;
+      progressCurrent.textContent = activeIndex + 1;
+
+      const upcoming = deck[activeIndex + 1];
+      if (upcoming) {
+        prepareCard(standbyCard, "standby");
+        renderSubject(standbyCard, upcoming);
+        standbyCard.classList.add("incoming");
+      } else {
+        clearCard(standbyCard);
+      }
+
+      locked = false;
+      setButtonsDisabled(false);
+    } else {
+      activeCard = incoming;
+      standbyCard = outgoing;
+      prepareCard(activeCard, "current");
+      renderCompletion(activeCard);
+      progressCurrent.textContent = deck.length;
+      restartButton.hidden = false;
+      restartButton.focus();
+      locked = false;
+    }
+  }, 300);
+}
+
+function renderSubject(card, subject) {
+  card.style.setProperty("--card-accent", subject.accent);
+  const statsMarkup = subject.stats
+    .map((stat) => `<span>${stat.icon}<strong>${stat.value}</strong> ${stat.label}</span>`)
+    .join("");
+
+  card.innerHTML = `
+    <div class="subject-meta">
+      <span class="subject-type">${getTypeEmoji(subject.type)} ${subject.type}</span>
+      <span class="subject-year">${subject.year}</span>
+    </div>
+    <h2 class="subject-title">${subject.name}</h2>
+    <p class="subject-description">${subject.description}</p>
+    <div class="subject-stats">${statsMarkup}</div>
+    <span class="subject-origin">Claim to fame: ${subject.origin}</span>
+  `;
+}
+
+function renderCompletion(card) {
+  card.classList.add("finished");
+  card.style.removeProperty("--card-accent");
+  card.innerHTML = `
+    <div class="finished-inner">
+      <h2>That's the deck</h2>
+      <p>You've weighed in on every pick. Shuffle again to keep the takes coming.</p>
+    </div>
+  `;
+  setButtonsDisabled(true);
+  statusRegion.textContent = "Deck finished. Shuffle again for fresh subjects.";
+}
+
+function clearCard(card) {
+  prepareCard(card, "standby");
+  card.innerHTML = "";
+  card.classList.remove("incoming");
+}
+
+function prepareCard(card, role) {
+  card.className = role === "current" ? "subject-card current" : "subject-card standby";
+  if (role === "current") {
+    card.removeAttribute("aria-hidden");
+  } else {
+    card.setAttribute("aria-hidden", "true");
+  }
+  card.style.removeProperty("--card-accent");
+  card.innerHTML = "";
+}
+
+function setButtonsDisabled(state) {
+  voteYesButton.disabled = state;
+  voteNoButton.disabled = state;
+}
+
+function announceSubject(subject) {
+  statusRegion.textContent = `${subject.name}. ${subject.type} • ${subject.year}.`;
+}
+
+function announceVote(subject, vote) {
+  const label = vote === "overrated" ? "Overrated" : "Not overrated";
+  statusRegion.textContent = `You voted ${label} for ${subject.name}.`;
+}
+
+function shuffle(list) {
+  const arr = [...list];
+  for (let i = arr.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function getTypeEmoji(type) {
+  const map = {
+    Album: "🎶",
+    Movie: "🎬",
+    Series: "📺",
+    "Live Show": "🎤",
+    Game: "🕹️",
+    Single: "🎵"
+  };
+  return map[type] || "✨";
+}

--- a/overrated/style.css
+++ b/overrated/style.css
@@ -1,172 +1,365 @@
 :root {
-  --bg: #0f172a;
-  --card-bg: rgba(15, 23, 42, 0.85);
-  --accent: #f97316;
-  --accent-soft: rgba(249, 115, 22, 0.2);
-  --text: #f8fafc;
-  --muted: #cbd5f5;
-  --shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
-  --transition: 200ms ease-in-out;
+  --bg: #060613;
+  --bg-soft: rgba(18, 22, 45, 0.75);
+  --card: rgba(18, 22, 45, 0.9);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text: #f5f7ff;
+  --muted: #b6b9d7;
+  --accent-no: linear-gradient(135deg, #3cc9a7, #81e9d4);
+  --accent-yes: linear-gradient(135deg, #ff6b6b, #ff9a7a);
+  --shadow: 0 32px 80px rgba(6, 6, 19, 0.55);
+  --radius: 24px;
+  --transition: 240ms ease;
+  font-family: "Inter", "Segoe UI", Tahoma, sans-serif;
 }
 
-* {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
 html,
 body {
   margin: 0;
-  padding: 0;
   min-height: 100%;
-  font-family: "Poppins", "Segoe UI", Tahoma, sans-serif;
-  background: radial-gradient(circle at top, #1e293b 0, var(--bg) 40%);
+  background: radial-gradient(circle at top, #171b3b 0%, var(--bg) 70%);
   color: var(--text);
 }
 
 body {
+  min-height: 100dvh;
+}
+
+a {
+  color: inherit;
+}
+
+.app-shell {
+  min-height: 100dvh;
   display: flex;
   flex-direction: column;
+  padding: 0;
 }
 
-header {
-  padding: 3rem 1.5rem 2rem;
+.app-header {
+  padding: 2.2rem 1.5rem 1.5rem;
   text-align: center;
+  display: grid;
+  gap: 1rem;
 }
 
-header h1 {
+.brand-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.brand-title {
   margin: 0;
-  font-size: clamp(2.5rem, 7vw, 3.75rem);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  font-size: clamp(2rem, 8vw, 2.8rem);
+  letter-spacing: -0.01em;
 }
 
-header p {
-  margin: 0.5rem auto 0;
-  max-width: 540px;
+.brand-title span {
+  color: #ffaf7a;
+}
+
+.brand-progress {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.header-sub {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.card-stage {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 0 1.5rem clamp(2.5rem, 6vh, 3.5rem);
+}
+
+.card-stack {
+  position: relative;
+  width: min(100%, 380px);
+  min-height: clamp(340px, 60vh, 520px);
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: pan-y;
+}
+
+.subject-card {
+  position: absolute;
+  inset: 0;
+  border-radius: var(--radius);
+  padding: 1.9rem;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.08), rgba(7, 10, 26, 0.9)),
+    var(--card);
+  border: 1px solid var(--card-border);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  overflow: hidden;
+  transition: transform var(--transition), opacity var(--transition);
+}
+
+.subject-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--card-accent, radial-gradient(circle at top right, rgba(255, 255, 255, 0.18), transparent 65%));
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.subject-card.current {
+  z-index: 2;
+}
+
+.subject-card.standby {
+  z-index: 1;
+  transform: translateY(24px) scale(0.95);
+  opacity: 0;
+}
+
+.subject-card.standby.incoming {
+  opacity: 0.35;
+}
+
+.subject-card.leaving {
+  pointer-events: none;
+}
+
+.subject-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.subject-type {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.3);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+}
+
+.subject-year {
+  font-weight: 600;
+}
+
+.subject-title {
+  margin: 0;
+  font-size: clamp(1.75rem, 6vw, 2.4rem);
+  letter-spacing: -0.01em;
+}
+
+.subject-description {
+  margin: 0;
   color: var(--muted);
   line-height: 1.6;
 }
 
-main {
-  flex: 1;
-  display: grid;
-  gap: 2rem;
-  padding: 0 1.5rem 3rem;
-  max-width: 960px;
-  width: 100%;
-  margin: 0 auto;
-}
-
-.game-card {
-  background: var(--card-bg);
-  border-radius: 22px;
-  padding: 2rem;
-  box-shadow: var(--shadow);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
-}
-
-.game-card:hover,
-.game-card:focus-within {
-  transform: translateY(-6px);
-  box-shadow: 0 26px 60px rgba(15, 23, 42, 0.6);
-  border-color: rgba(249, 115, 22, 0.4);
-}
-
-.game-card h2 {
-  margin: 0 0 0.5rem;
-  font-size: 1.75rem;
-}
-
-.game-meta {
+.subject-stats {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem 1rem;
-  align-items: center;
-  margin-bottom: 1rem;
-  font-size: 0.95rem;
-  color: var(--muted);
-}
-
-.meta-pill {
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  background: var(--accent-soft);
-  color: var(--accent);
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  font-size: 0.75rem;
-}
-
-button.toggle {
-  margin-top: 1.25rem;
-  padding: 0.75rem 1.25rem;
-  border-radius: 999px;
-  border: none;
-  cursor: pointer;
-  background: var(--accent);
-  color: #111827;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  transition: transform var(--transition), background var(--transition), color var(--transition);
-}
-
-button.toggle:hover,
-button.toggle:focus {
-  transform: translateY(-2px);
-  background: #fb923c;
-  color: #0f172a;
-}
-
-button.toggle[aria-expanded="true"] {
-  background: transparent;
-  color: var(--accent);
-  border: 2px solid var(--accent);
-}
-
-.toggle-panel {
-  margin-top: 1rem;
-  line-height: 1.7;
-  max-height: 0;
-  overflow: hidden;
-  transition: max-height 280ms ease;
-}
-
-.toggle-panel.open {
-  max-height: 400px;
-}
-
-.toggle-panel p {
-  margin: 0.5rem 0;
-}
-
-ul.reasons {
-  margin: 0.75rem 0 0;
-  padding-left: 1.25rem;
-}
-
-ul.reasons li {
-  margin: 0.35rem 0;
-}
-
-footer {
-  text-align: center;
-  padding: 2rem 1.5rem 3rem;
-  color: var(--muted);
+  gap: 0.75rem 1.2rem;
+  color: rgba(255, 255, 255, 0.85);
   font-size: 0.9rem;
 }
 
-@media (max-width: 640px) {
-  header {
-    padding: 2.25rem 1.25rem 1.5rem;
+.subject-stats span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.subject-stats strong {
+  font-weight: 700;
+}
+
+.subject-origin {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+  letter-spacing: 0.03em;
+  margin-top: auto;
+}
+
+.vote-actions {
+  width: min(100%, 380px);
+  display: flex;
+  gap: 1rem;
+}
+
+.vote-button {
+  flex: 1;
+  border: 0;
+  border-radius: 999px;
+  padding: 1.1rem 1.2rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  color: #070714;
+  transition: transform var(--transition), box-shadow var(--transition), opacity var(--transition);
+}
+
+.vote-button .vote-icon {
+  font-size: 1.4rem;
+}
+
+.vote-button:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 4px;
+}
+
+.vote-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.vote-no {
+  background: var(--accent-no);
+  box-shadow: 0 18px 40px rgba(60, 201, 167, 0.4);
+}
+
+.vote-yes {
+  background: var(--accent-yes);
+  box-shadow: 0 18px 48px rgba(255, 107, 107, 0.45);
+}
+
+.vote-button:not(:disabled):active {
+  transform: scale(0.97);
+}
+
+.app-footer {
+  padding: 1.5rem 1.5rem calc(2.2rem + env(safe-area-inset-bottom, 0px));
+  display: grid;
+  gap: 0.9rem;
+  text-align: center;
+}
+
+.ghost-button {
+  justify-self: center;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: transparent;
+  color: var(--text);
+  border-radius: 999px;
+  padding: 0.75rem 1.4rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+
+.ghost-button:hover,
+.ghost-button:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.footer-note {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.finished-inner {
+  display: grid;
+  gap: 0.75rem;
+  text-align: center;
+}
+
+.finished-inner h2 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.finished-inner p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.subject-card.finished {
+  justify-content: center;
+}
+
+.swipe-left {
+  transform: translateX(-120%) rotate(-10deg);
+  opacity: 0;
+}
+
+.swipe-right {
+  transform: translateX(120%) rotate(10deg);
+  opacity: 0;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (min-width: 720px) {
+  .app-header {
+    padding-top: 3rem;
   }
 
-  .game-card {
-    padding: 1.75rem 1.5rem;
+  .card-stage {
+    padding-left: 2.5rem;
+    padding-right: 2.5rem;
   }
 
-  button.toggle {
-    width: 100%;
+  .card-stack,
+  .vote-actions {
+    width: min(100%, 420px);
+  }
+
+  .subject-card {
+    padding: 2.2rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
   }
 }


### PR DESCRIPTION
## Summary
- streamline the Overrated page into a single-card mobile deck with inline progress and restart controls
- implement touch-ready swipe gestures plus keyboard and button voting that remove the card after each choice
- refresh the styling for the mobile-first layout, floating actions, and finished state messaging

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e3e5bc12d08322906a2917c44be73b