### PR TITLE
Add autonomous creator bots to SocialSquare feed

### DIFF
--- a/socialsquare/app.js
+++ b/socialsquare/app.js
@@ -1,0 +1,550 @@
+const STORAGE_KEY = 'socialsquare-posts-v1';
+const BOOKMARK_KEY = 'socialsquare-bookmarks-v1';
+
+const postTemplate = document.getElementById('postTemplate');
+const feedEl = document.getElementById('feed');
+const postForm = document.getElementById('postForm');
+const postContent = document.getElementById('postContent');
+const mediaUpload = document.getElementById('mediaUpload');
+const tabs = document.querySelectorAll('.tab');
+const menuButtons = document.querySelectorAll('.menu-item');
+const panels = document.querySelectorAll('.panel');
+const statPosts = document.getElementById('stat-posts');
+const search = document.getElementById('search');
+
+let activeTab = 'for-you';
+let activeSection = 'feed';
+const openComments = new Set();
+
+const defaultPosts = [
+  {
+    id: crypto.randomUUID(),
+    author: 'Jamie Doe',
+    handle: '@jamiedoe',
+    avatar: 'https://avatars.dicebear.com/api/initials/JD.svg',
+    content: 'Exploring motion in UI design this week. Micro-interactions make such a difference! ✨',
+    timestamp: Date.now() - 1000 * 60 * 60 * 3,
+    likes: 32,
+    liked: false,
+    bookmarked: false,
+    following: true,
+    comments: [
+      {
+        id: crypto.randomUUID(),
+        author: 'Alex Rivers',
+        handle: '@arivers',
+        avatar: 'https://avatars.dicebear.com/api/initials/AR.svg',
+        content: 'Totally! The little details create big delight.',
+        timestamp: Date.now() - 1000 * 60 * 60 * 2,
+      },
+    ],
+  },
+  {
+    id: crypto.randomUUID(),
+    author: 'Taylor Green',
+    handle: '@taylorgreen',
+    avatar: 'https://avatars.dicebear.com/api/initials/TG.svg',
+    content: 'Just wrapped our product beta! Huge thanks to everyone who tested and shared feedback. 🚀',
+    timestamp: Date.now() - 1000 * 60 * 60 * 8,
+    likes: 54,
+    liked: false,
+    bookmarked: true,
+    following: false,
+    comments: [],
+  },
+  {
+    id: crypto.randomUUID(),
+    author: 'Lena Nguyen',
+    handle: '@lena.designs',
+    avatar: 'https://avatars.dicebear.com/api/initials/LN.svg',
+    content: 'Morning walk inspo: the city skyline, soft fog, and a warm cappuccino. ☕️🌆',
+    media:
+      'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=900&q=80',
+    timestamp: Date.now() - 1000 * 60 * 60 * 24,
+    likes: 97,
+    liked: true,
+    bookmarked: false,
+    following: true,
+    comments: [
+      {
+        id: crypto.randomUUID(),
+        author: 'Jamie Doe',
+        handle: '@jamiedoe',
+        avatar: 'https://avatars.dicebear.com/api/initials/JD.svg',
+        content: 'This photo is stunning. Captured the vibe perfectly!',
+        timestamp: Date.now() - 1000 * 60 * 60 * 20,
+      },
+    ],
+  },
+];
+
+const loadState = () => {
+  const storedPosts = localStorage.getItem(STORAGE_KEY);
+  let posts = storedPosts ? JSON.parse(storedPosts) : defaultPosts;
+
+  // Ensure shape matches defaults (handles migrations).
+  posts = posts.map((post) => ({
+    likes: 0,
+    liked: false,
+    bookmarked: false,
+    following: false,
+    comments: [],
+    ...post,
+  }));
+
+  const storedBookmarks = localStorage.getItem(BOOKMARK_KEY);
+  const bookmarkSet = new Set(storedBookmarks ? JSON.parse(storedBookmarks) : []);
+
+  posts = posts.map((post) => ({
+    ...post,
+    bookmarked: bookmarkSet.has(post.id) || post.bookmarked,
+  }));
+
+  return posts.sort((a, b) => b.timestamp - a.timestamp);
+};
+
+let posts = loadState();
+
+const MAX_POSTS = 60;
+const BOT_MIN_DELAY = 35000;
+const BOT_MAX_DELAY = 90000;
+const BOT_INITIAL_MIN_DELAY = 6000;
+const BOT_INITIAL_MAX_DELAY = 18000;
+
+const randomBetween = (min, max) =>
+  Math.floor(Math.random() * (max - min + 1)) + min;
+
+const randomChoice = (array) => array[Math.floor(Math.random() * array.length)];
+
+const saveState = () => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(posts));
+  const bookmarkedIds = posts.filter((post) => post.bookmarked).map((post) => post.id);
+  localStorage.setItem(BOOKMARK_KEY, JSON.stringify(bookmarkedIds));
+};
+
+const formatTime = (timestamp) => {
+  const diff = Date.now() - timestamp;
+  const minutes = Math.floor(diff / (1000 * 60));
+  if (minutes < 1) return 'Just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const date = new Date(timestamp);
+  return date.toLocaleDateString();
+};
+
+const renderPosts = () => {
+  feedEl.innerHTML = '';
+  let filtered = posts;
+  if (activeTab === 'following') {
+    filtered = posts.filter((post) => post.following);
+  } else if (activeTab === 'bookmarked') {
+    filtered = posts.filter((post) => post.bookmarked);
+  }
+
+  if (filtered.length === 0) {
+    feedEl.innerHTML = `<div class="empty">No posts here yet. Be the first to share something!</div>`;
+    return;
+  }
+
+  filtered.forEach((post) => {
+    const clone = postTemplate.content.firstElementChild.cloneNode(true);
+
+    const avatar = clone.querySelector('.post-avatar');
+    avatar.src = post.avatar;
+    avatar.alt = `${post.author} avatar`;
+
+    clone.querySelector('.user-name').textContent = post.author;
+    clone.querySelector('.user-handle').textContent = post.handle;
+    clone.querySelector('.timestamp').textContent = formatTime(post.timestamp);
+    clone.dataset.id = post.id;
+
+    clone.querySelector('.post-content').textContent = post.content;
+
+    const mediaEl = clone.querySelector('.post-media');
+    if (post.media) {
+      mediaEl.src = post.media;
+      mediaEl.classList.remove('hidden');
+    } else {
+      mediaEl.classList.add('hidden');
+    }
+
+    const likeButton = clone.querySelector('.like-button');
+    likeButton.querySelector('span').textContent = post.likes;
+    if (post.liked) {
+      likeButton.classList.add('active');
+    }
+
+    const commentToggle = clone.querySelector('.comment-toggle');
+    commentToggle.querySelector('span').textContent = post.comments.length;
+
+    const bookmarkButton = clone.querySelector('.bookmark-button');
+    if (post.bookmarked) {
+      bookmarkButton.classList.add('active');
+    }
+
+    const commentsList = clone.querySelector('.comments-list');
+    post.comments.forEach((comment) => {
+      const commentEl = document.createElement('div');
+      commentEl.className = 'comment';
+      commentEl.innerHTML = `
+        <img class="comment-avatar" src="${comment.avatar}" alt="${comment.author} avatar" />
+        <div>
+          <p class="user-name">${comment.author} <span class="user-handle">${comment.handle}</span></p>
+          <p>${comment.content}</p>
+          <p class="timestamp">${formatTime(comment.timestamp)}</p>
+        </div>
+      `;
+      commentsList.appendChild(commentEl);
+    });
+
+    const commentSection = clone.querySelector('.comments');
+    if (openComments.has(post.id)) {
+      commentSection.classList.remove('hidden');
+    } else {
+      commentSection.classList.add('hidden');
+    }
+
+    feedEl.appendChild(clone);
+  });
+
+  statPosts.textContent = posts.length;
+};
+
+const addPostToFeed = (post) => {
+  posts = [post, ...posts];
+  if (posts.length > MAX_POSTS) {
+    posts = posts.slice(0, MAX_POSTS);
+  }
+  saveState();
+  renderPosts();
+};
+
+const resetComposer = () => {
+  postContent.value = '';
+  mediaUpload.value = '';
+};
+
+const handleNewPost = async (event) => {
+  event.preventDefault();
+  const text = postContent.value.trim();
+  if (!text) return;
+
+  const file = mediaUpload.files[0];
+  let mediaUrl = null;
+
+  if (file) {
+    mediaUrl = await new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.readAsDataURL(file);
+    });
+  }
+
+  const newPost = {
+    id: crypto.randomUUID(),
+    author: 'Alex Rivers',
+    handle: '@arivers',
+    avatar: 'https://avatars.dicebear.com/api/initials/AR.svg',
+    content: text,
+    timestamp: Date.now(),
+    likes: 0,
+    liked: false,
+    bookmarked: false,
+    following: true,
+    media: mediaUrl,
+    comments: [],
+  };
+
+  addPostToFeed(newPost);
+  resetComposer();
+};
+
+const findPost = (id) => posts.find((post) => post.id === id);
+
+feedEl.addEventListener('click', (event) => {
+  const article = event.target.closest('.post');
+  if (!article) return;
+  const postId = article.dataset.id;
+  const post = findPost(postId);
+  if (!post) return;
+
+  if (event.target.closest('.like-button')) {
+    post.liked = !post.liked;
+    post.likes += post.liked ? 1 : -1;
+    saveState();
+    renderPosts();
+  }
+
+  if (event.target.closest('.bookmark-button')) {
+    post.bookmarked = !post.bookmarked;
+    saveState();
+    renderPosts();
+  }
+
+  if (event.target.closest('.comment-toggle')) {
+    if (openComments.has(post.id)) {
+      openComments.delete(post.id);
+    } else {
+      openComments.add(post.id);
+    }
+    renderPosts();
+  }
+});
+
+feedEl.addEventListener('submit', (event) => {
+  if (!event.target.matches('.comment-form')) return;
+  event.preventDefault();
+
+  const article = event.target.closest('.post');
+  const postId = article.dataset.id;
+  const post = findPost(postId);
+  if (!post) return;
+
+  const input = event.target.querySelector('input[name="comment"]');
+  const text = input.value.trim();
+  if (!text) return;
+
+  post.comments.push({
+    id: crypto.randomUUID(),
+    author: 'Alex Rivers',
+    handle: '@arivers',
+    avatar: 'https://avatars.dicebear.com/api/initials/AR.svg',
+    content: text,
+    timestamp: Date.now(),
+  });
+
+  saveState();
+  renderPosts();
+});
+
+postForm.addEventListener('submit', handleNewPost);
+
+mediaUpload.addEventListener('change', () => {
+  const labelSpan = mediaUpload.closest('label').querySelector('span');
+  if (!mediaUpload.files[0]) {
+    labelSpan.textContent = '📷 Add photo';
+    return;
+  }
+  const fileName = mediaUpload.files[0].name;
+  labelSpan.textContent = `📷 ${fileName}`;
+});
+
+if (search) {
+  search.addEventListener('input', (event) => {
+    const term = event.target.value.toLowerCase();
+    const articles = feedEl.querySelectorAll('.post');
+    articles.forEach((article) => {
+      const content = article.querySelector('.post-content').textContent.toLowerCase();
+      const author = article.querySelector('.user-name').textContent.toLowerCase();
+      const handle = article.querySelector('.user-handle').textContent.toLowerCase();
+      const match = content.includes(term) || author.includes(term) || handle.includes(term);
+      article.classList.toggle('hidden', term && !match);
+    });
+  });
+}
+
+menuButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    menuButtons.forEach((btn) => btn.classList.remove('active'));
+    button.classList.add('active');
+    activeSection = button.dataset.section;
+
+    panels.forEach((panel) => {
+      if (panel.id === activeSection) {
+        panel.classList.remove('hidden');
+      } else {
+        panel.classList.add('hidden');
+      }
+    });
+
+    feedEl.classList.toggle('hidden', activeSection !== 'feed');
+    if (activeSection === 'feed') {
+      renderPosts();
+    }
+  });
+});
+
+const sharedVocabulary = {
+  emoji: ['✨', '🚀', '🎨', '🌟', '🔥', '💡', '📸', '🤖', '🌿', '🎧'],
+  mood: ['focus', 'momentum', 'curiosity', 'calm energy', 'flow state'],
+  location: [
+    'the downtown studio',
+    'a rooftop workspace',
+    'the light-filled loft',
+    'the co-working lab',
+    'the riverside park bench',
+  ],
+};
+
+const botAccounts = [
+  {
+    id: 'nova-sparks',
+    name: 'Nova Sparks',
+    handle: '@nova.codes',
+    avatar: 'https://avatars.dicebear.com/api/initials/NS.svg',
+    vocabulary: {
+      project: ['NebulaUI', 'LumenKit', 'Pulseboard', 'OrbitOps dashboard'],
+      feature: ['real-time collaboration', 'adaptive theming', 'edge caching'],
+      stack: ['TypeScript', 'Svelte', 'WebGL accents', 'serverless functions'],
+      insight: [
+        'keeping renders at 60fps',
+        'aligning gradients with accessibility',
+        'mapping journeys end-to-end',
+      ],
+    },
+    prompts: [
+      {
+        template: 'Shipped a new {project} build focused on {feature}. {emoji}',
+        likes: [38, 120],
+      },
+      {
+        template: 'Prototyping {project} with a mix of {stack} — {insight}. {emoji}',
+        likes: [24, 80],
+      },
+      {
+        template: 'Sneak peek of tomorrow\'s {project} review from {location}. {emoji}',
+        mediaPool: [
+          'https://images.unsplash.com/photo-1555066931-4365d14bab8c?auto=format&fit=crop&w=1000&q=80',
+          'https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1000&q=80',
+          'https://images.unsplash.com/photo-1551292831-023188e78222?auto=format&fit=crop&w=1000&q=80',
+        ],
+        likes: [42, 130],
+      },
+    ],
+  },
+  {
+    id: 'milo-hart',
+    name: 'Milo Hart',
+    handle: '@milohart',
+    avatar: 'https://avatars.dicebear.com/api/initials/MH.svg',
+    vocabulary: {
+      project: ['Wanderlight series', 'City Pulse photo essay', 'Analog Echo zine'],
+      feature: ['soft light', 'long exposures', 'monochrome edits'],
+      journey: ['sunrise ride', 'evening stroll', 'late-night wander'],
+    },
+    prompts: [
+      {
+        template: '{journey} through {location} today — chasing {feature}. {emoji}',
+        mediaPool: [
+          'https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?auto=format&fit=crop&w=1000&q=80',
+          'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1000&q=80',
+          'https://images.unsplash.com/photo-1472214103451-9374bd1c798e?auto=format&fit=crop&w=1000&q=80',
+        ],
+        likes: [55, 160],
+      },
+      {
+        template: 'Sequencing shots for {project}. Keeping notes on {feature}. {emoji}',
+        likes: [31, 90],
+      },
+      {
+        template: 'Printed a proof for {project} — the tones landed exactly where I hoped. {emoji}',
+        likes: [26, 75],
+      },
+    ],
+  },
+  {
+    id: 'chloe-winters',
+    name: 'Chloe Winters',
+    handle: '@chloewell',
+    avatar: 'https://avatars.dicebear.com/api/initials/CW.svg',
+    vocabulary: {
+      project: ['Quiet Morning playlist', 'Breathwork loop', 'Skyline yoga flow'],
+      feature: ['slow tempo layers', 'grounding cues', 'gentle resets'],
+      ritual: ['sunrise session', 'lunch break reset', 'twilight cooldown'],
+      ingredient: ['citrus + mint water', 'lavender steam', 'eucalyptus mist'],
+    },
+    prompts: [
+      {
+        template: '{ritual} complete with {ingredient}. Drafting notes for {project}. {emoji}',
+        likes: [20, 70],
+      },
+      {
+        template: 'Layered {feature} into the next {project}. {emoji}',
+        likes: [18, 60],
+      },
+      {
+        template: 'Captured the mood board for {project}. {emoji}',
+        mediaPool: [
+          'https://images.unsplash.com/photo-1487412720507-e7ab37603c6f?auto=format&fit=crop&w=1000&q=80',
+          'https://images.unsplash.com/photo-1515871204537-9d3b18b8cdf4?auto=format&fit=crop&w=1000&q=80',
+          'https://images.unsplash.com/photo-1506126613408-eca07ce68773?auto=format&fit=crop&w=1000&q=80',
+        ],
+        likes: [34, 95],
+      },
+    ],
+  },
+];
+
+const buildContent = (template, replacements) =>
+  template.replace(/\{(\w+)\}/g, (_, key) => {
+    const replacement = replacements[key];
+    if (!replacement) return '';
+    if (Array.isArray(replacement)) {
+      return randomChoice(replacement);
+    }
+    if (typeof replacement === 'function') {
+      return replacement();
+    }
+    return replacement;
+  });
+
+const generateBotPost = (bot) => {
+  const prompt = randomChoice(bot.prompts);
+  const replacements = { ...sharedVocabulary, ...bot.vocabulary };
+  let media = null;
+
+  if (prompt.mediaPool && prompt.mediaPool.length > 0) {
+    const shouldAttach = Math.random() > 0.25;
+    if (shouldAttach) {
+      media = randomChoice(prompt.mediaPool);
+    }
+  }
+
+  const content = buildContent(prompt.template, replacements);
+  const likeRange = prompt.likes || [18, 60];
+
+  return {
+    id: crypto.randomUUID(),
+    author: bot.name,
+    handle: bot.handle,
+    avatar: bot.avatar,
+    content,
+    timestamp: Date.now(),
+    likes: randomBetween(likeRange[0], likeRange[1]),
+    liked: false,
+    bookmarked: false,
+    following: true,
+    media,
+    comments: [],
+  };
+};
+
+const scheduleBotPost = (bot, minDelay, maxDelay) => {
+  const delay = randomBetween(minDelay, maxDelay);
+  setTimeout(() => {
+    const newPost = generateBotPost(bot);
+    addPostToFeed(newPost);
+    scheduleBotPost(bot, BOT_MIN_DELAY, BOT_MAX_DELAY);
+  }, delay);
+};
+
+const initializeBots = () => {
+  botAccounts.forEach((bot) => {
+    scheduleBotPost(bot, BOT_INITIAL_MIN_DELAY, BOT_INITIAL_MAX_DELAY);
+  });
+};
+
+tabs.forEach((tab) => {
+  tab.addEventListener('click', () => {
+    tabs.forEach((btn) => btn.classList.remove('active'));
+    tab.classList.add('active');
+    activeTab = tab.dataset.tab;
+    renderPosts();
+  });
+});
+
+renderPosts();
+initializeBots();

--- a/socialsquare/index.html
+++ b/socialsquare/index.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SocialSquare</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div class="app-shell">
+    <aside class="sidebar">
+      <div class="brand">SocialSquare</div>
+      <nav class="menu">
+        <button class="menu-item active" data-section="feed">Home</button>
+        <button class="menu-item" data-section="messages">Messages</button>
+        <button class="menu-item" data-section="trending">Trending</button>
+        <button class="menu-item" data-section="profile">Profile</button>
+      </nav>
+      <div class="user-card">
+        <img src="https://avatars.dicebear.com/api/initials/SocialSquare.svg" alt="User avatar" />
+        <div>
+          <p class="user-name">Alex Rivers</p>
+          <p class="user-handle">@arivers</p>
+        </div>
+      </div>
+    </aside>
+
+    <main class="main">
+      <header class="main-header">
+        <h1>Welcome back, Alex</h1>
+        <p>Share a moment, react to friends, and see what's trending.</p>
+      </header>
+
+      <section class="composer" aria-label="Create a post">
+        <form id="postForm">
+          <textarea id="postContent" placeholder="What's on your mind today?" rows="3" required></textarea>
+          <div class="composer-actions">
+            <div class="composer-meta">
+              <label>
+                <input type="file" id="mediaUpload" accept="image/*" />
+                <span>📷 Add photo</span>
+              </label>
+            </div>
+            <button type="submit" class="primary">Share</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="tabs" role="tablist">
+        <button class="tab active" data-tab="for-you">For you</button>
+        <button class="tab" data-tab="following">Following</button>
+        <button class="tab" data-tab="bookmarked">Bookmarked</button>
+      </section>
+
+      <section id="feed" class="feed" aria-live="polite"></section>
+
+      <section id="messages" class="panel hidden" aria-live="polite">
+        <h2>Messages</h2>
+        <div class="message-card">
+          <div class="message-card__header">
+            <img src="https://avatars.dicebear.com/api/initials/JD.svg" alt="Avatar" />
+            <div>
+              <p class="user-name">Jamie Doe</p>
+              <p class="timestamp">2h ago</p>
+            </div>
+          </div>
+          <p>Hey Alex! Loved your last post about the design sprint. Let's catch up this week?</p>
+          <div class="message-card__actions">
+            <button class="secondary">Reply</button>
+            <button class="ghost">Mark as read</button>
+          </div>
+        </div>
+        <div class="message-empty">No new messages right now. Send a hello to your friends!</div>
+      </section>
+
+      <section id="trending" class="panel hidden" aria-live="polite">
+        <h2>Trending Topics</h2>
+        <ul class="trending-list">
+          <li>
+            <span>#DesignSystems</span>
+            <span class="trend-count">12k posts</span>
+          </li>
+          <li>
+            <span>#CoffeeChat</span>
+            <span class="trend-count">8.9k posts</span>
+          </li>
+          <li>
+            <span>#ProductLaunch</span>
+            <span class="trend-count">5.3k posts</span>
+          </li>
+          <li>
+            <span>#CityWalks</span>
+            <span class="trend-count">2.1k posts</span>
+          </li>
+        </ul>
+      </section>
+
+      <section id="profile" class="panel hidden" aria-live="polite">
+        <h2>Your Profile</h2>
+        <div class="profile-card">
+          <img src="https://avatars.dicebear.com/api/initials/AR.svg" alt="Profile avatar" />
+          <div>
+            <p class="user-name">Alex Rivers</p>
+            <p class="user-handle">@arivers</p>
+            <p class="bio">Product designer exploring playful experiences. Amateur photographer and tea enthusiast.</p>
+          </div>
+        </div>
+        <div class="profile-stats">
+          <div>
+            <span class="stat-value" id="stat-posts">0</span>
+            <span class="stat-label">Posts</span>
+          </div>
+          <div>
+            <span class="stat-value">1,204</span>
+            <span class="stat-label">Followers</span>
+          </div>
+          <div>
+            <span class="stat-value">536</span>
+            <span class="stat-label">Following</span>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <aside class="rightbar">
+      <div class="widget search-widget">
+        <input type="search" id="search" placeholder="Search SocialSquare" />
+      </div>
+
+      <div class="widget suggestions">
+        <h3>Who to follow</h3>
+        <div class="suggestion">
+          <img src="https://avatars.dicebear.com/api/initials/LN.svg" alt="Lena" />
+          <div>
+            <p class="user-name">Lena Nguyen</p>
+            <p class="user-handle">@lena.designs</p>
+          </div>
+          <button class="secondary">Follow</button>
+        </div>
+        <div class="suggestion">
+          <img src="https://avatars.dicebear.com/api/initials/MC.svg" alt="Marcus" />
+          <div>
+            <p class="user-name">Marcus Clark</p>
+            <p class="user-handle">@marcus.codes</p>
+          </div>
+          <button class="secondary">Follow</button>
+        </div>
+        <div class="suggestion">
+          <img src="https://avatars.dicebear.com/api/initials/SM.svg" alt="Sara" />
+          <div>
+            <p class="user-name">Sara Malik</p>
+            <p class="user-handle">@saramalik</p>
+          </div>
+          <button class="secondary">Follow</button>
+        </div>
+      </div>
+
+      <div class="widget activity">
+        <h3>Latest Activity</h3>
+        <ul>
+          <li><strong>Jamie</strong> liked your post “Morning light ✨”</li>
+          <li><strong>Taylor</strong> started following you</li>
+          <li><strong>Avery</strong> added a new collection “Urban exploration”</li>
+        </ul>
+      </div>
+    </aside>
+  </div>
+
+  <template id="postTemplate">
+    <article class="post" aria-live="polite">
+      <header class="post-header">
+        <img class="post-avatar" alt="" />
+        <div>
+          <div class="post-user">
+            <span class="user-name"></span>
+            <span class="user-handle"></span>
+          </div>
+          <time class="timestamp"></time>
+        </div>
+        <button class="ghost post-menu" aria-label="More options">⋯</button>
+      </header>
+      <p class="post-content"></p>
+      <img class="post-media hidden" alt="Attached media" />
+      <footer class="post-footer">
+        <button class="ghost like-button">❤️ <span>0</span></button>
+        <button class="ghost comment-toggle">💬 <span>0</span></button>
+        <button class="ghost bookmark-button">🔖</button>
+      </footer>
+      <section class="comments hidden" aria-label="Comments">
+        <div class="comments-list"></div>
+        <form class="comment-form">
+          <input type="text" name="comment" placeholder="Add a comment" required />
+          <button type="submit" class="secondary">Post</button>
+        </form>
+      </section>
+    </article>
+  </template>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/socialsquare/styles.css
+++ b/socialsquare/styles.css
@@ -1,0 +1,434 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f6f7fb;
+  --surface: #ffffff;
+  --surface-dark: #101823;
+  --primary: #5b5bd6;
+  --primary-dark: #818cf8;
+  --text: #1c1f26;
+  --muted: #5b6070;
+  --border: #dbe0ea;
+  --radius: 18px;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: linear-gradient(160deg, rgba(91, 91, 214, 0.1), transparent 55%), var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr) 300px;
+  gap: 32px;
+  width: min(1200px, 100%);
+  padding: 32px;
+}
+
+.sidebar,
+.rightbar,
+.main {
+  background: var(--surface);
+  border-radius: var(--radius);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  padding: 24px;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.brand {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--primary);
+}
+
+.menu {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.menu-item {
+  border: none;
+  background: transparent;
+  text-align: left;
+  padding: 12px 16px;
+  border-radius: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.menu-item:hover,
+.menu-item.active {
+  background: rgba(91, 91, 214, 0.12);
+  color: var(--primary);
+}
+
+.user-card {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(91, 91, 214, 0.08);
+}
+
+.user-card img,
+.post-avatar,
+.profile-card img,
+.suggestion img {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+}
+
+.user-name {
+  font-weight: 600;
+}
+
+.user-handle,
+.timestamp,
+.stat-label {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.main-header h1 {
+  font-size: 2rem;
+  margin-bottom: 8px;
+}
+
+.composer {
+  background: rgba(91, 91, 214, 0.08);
+  border-radius: 16px;
+  padding: 18px;
+}
+
+#postContent {
+  width: 100%;
+  border: none;
+  padding: 8px;
+  border-radius: 12px;
+  resize: vertical;
+  font-family: inherit;
+  font-size: 1rem;
+}
+
+#postContent:focus {
+  outline: 2px solid rgba(91, 91, 214, 0.4);
+}
+
+.composer-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 12px;
+}
+
+.primary,
+.secondary,
+.ghost {
+  border-radius: 999px;
+  padding: 10px 18px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.primary {
+  background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+  color: white;
+  box-shadow: 0 10px 20px rgba(91, 91, 214, 0.25);
+}
+
+.primary:hover {
+  transform: translateY(-1px);
+}
+
+.secondary {
+  background: rgba(91, 91, 214, 0.15);
+  color: var(--primary);
+}
+
+.ghost {
+  background: transparent;
+  color: var(--muted);
+}
+
+.tabs {
+  display: flex;
+  gap: 12px;
+}
+
+.tab {
+  border: none;
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: rgba(91, 91, 214, 0.08);
+  color: var(--muted);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.tab.active {
+  background: var(--primary);
+  color: white;
+}
+
+.feed {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.empty {
+  padding: 40px;
+  border-radius: 18px;
+  text-align: center;
+  color: var(--muted);
+  background: rgba(91, 91, 214, 0.08);
+}
+
+.post {
+  padding: 20px;
+  border-radius: 18px;
+  background: linear-gradient(120deg, rgba(91, 91, 214, 0.1), transparent 50%), var(--surface);
+  border: 1px solid rgba(91, 91, 214, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.post-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.post-user {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.post-media {
+  width: 100%;
+  border-radius: 16px;
+  object-fit: cover;
+  max-height: 280px;
+}
+
+.post-footer {
+  display: flex;
+  gap: 16px;
+}
+
+.like-button.active {
+  color: #ef4444;
+}
+
+.bookmark-button.active {
+  color: #f59e0b;
+}
+
+.comments {
+  border-top: 1px solid rgba(91, 91, 214, 0.15);
+  padding-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.comment {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.comment .comment-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+}
+
+.comment-form {
+  display: flex;
+  gap: 8px;
+}
+
+.comment-form input {
+  flex: 1;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  padding: 8px 14px;
+  font: inherit;
+}
+
+.comment-form input:focus {
+  outline: 2px solid rgba(91, 91, 214, 0.3);
+}
+
+.panel.hidden {
+  display: none;
+}
+
+.rightbar {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.widget {
+  padding: 18px;
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(91, 91, 214, 0.08), transparent 70%), var(--surface);
+  border: 1px solid rgba(91, 91, 214, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.search-widget input {
+  width: 100%;
+  border-radius: 999px;
+  border: none;
+  padding: 12px 16px;
+  background: rgba(91, 91, 214, 0.08);
+}
+
+.suggestion {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.activity ul {
+  list-style: none;
+  display: grid;
+  gap: 8px;
+}
+
+.trending-list {
+  list-style: none;
+  display: grid;
+  gap: 12px;
+}
+
+.trending-list li {
+  display: flex;
+  justify-content: space-between;
+}
+
+.trend-count {
+  color: var(--muted);
+}
+
+.message-card {
+  border-radius: 16px;
+  padding: 16px;
+  background: rgba(91, 91, 214, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.message-card__header {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.message-card__actions {
+  display: flex;
+  gap: 12px;
+}
+
+.message-empty {
+  color: var(--muted);
+}
+
+.profile-card {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(91, 91, 214, 0.08);
+}
+
+.profile-stats {
+  margin-top: 16px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  text-align: center;
+}
+
+.stat-value {
+  font-size: 1.3rem;
+  font-weight: 700;
+}
+
+.hidden {
+  display: none !important;
+}
+
+@media (max-width: 1100px) {
+  .app-shell {
+    grid-template-columns: 220px minmax(0, 1fr);
+  }
+
+  .rightbar {
+    display: none;
+  }
+}
+
+@media (max-width: 820px) {
+  body {
+    padding: 16px;
+  }
+
+  .app-shell {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    align-items: center;
+    gap: 16px;
+    justify-content: space-between;
+  }
+
+  .menu {
+    flex-direction: row;
+    gap: 8px;
+  }
+
+  .user-card {
+    margin-top: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- add shared vocabulary and persona-driven prompts for three SocialSquare bot accounts
- schedule autonomous bot posts with random delays, likes, and optional media uploads
- centralize post insertion with a capped history to keep local storage manageable

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e3ea0b6c908322a2356678f1adc1b0