### PR TITLE
Add most overrated leaderboard and expand deck

### DIFF
--- a/overrated/index.html
+++ b/overrated/index.html
@@ -2,112 +2,61 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="A tongue-in-cheek look at the most overrated video game trends."
+      content="Swipe through culture picks one at a time and decide if they're overrated."
     />
-    <title>Overrated | JBT Games</title>
+    <title>Overrated? | Swipe Your Take</title>
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <header>
-      <h1>Overrated</h1>
-      <p>
-        A lovingly sarcastic tribute to the trends that dominate the gaming
-        scene. Tap on a card to discover why these fads deserve a time-out.
-      </p>
-    </header>
-
-    <main>
-      <article class="game-card">
-        <h2>Endless Battle Passes</h2>
-        <div class="game-meta">
-          <span class="meta-pill">grind fatigue</span>
-          <span>Introduced: 2017</span>
-          <span>Popularized by: Fortnite &amp; friends</span>
-        </div>
-        <p>
-          Battle passes promised rewarding progression, but the modern reality is
-          more like a part-time job.
-        </p>
-        <button class="toggle" aria-expanded="false" type="button">
-          Why it's overrated
-        </button>
-        <div class="toggle-panel" id="battle-pass-panel">
-          <p>
-            The pressure to log in daily can turn a hobby into a chore.
-            Meanwhile, the rewards often feel like virtual clutter.
+    <main class="app-shell">
+      <header class="app-header" role="banner">
+        <div class="brand-row">
+          <h1 class="brand-title">Overrated<span>?</span></h1>
+          <p class="brand-progress">
+            <span id="progress-current">0</span>/<span id="progress-total">0</span>
           </p>
-          <ul class="reasons">
-            <li>Artificial fear-of-missing-out tactics.</li>
-            <li>Confusing currencies and tier unlocks.</li>
-            <li>Cosmetics that rarely feel worth the grind.</li>
-          </ul>
         </div>
-      </article>
+        <p class="header-sub">Swipe the card or tap a button to call the hype.</p>
+      </header>
 
-      <article class="game-card">
-        <h2>Ultra-Realistic Mud Physics</h2>
-        <div class="game-meta">
-          <span class="meta-pill">tech flex</span>
-          <span>Introduced: 2015</span>
-          <span>Popularized by: Racing sims</span>
+      <section class="card-stage" aria-label="Vote on whether each pick is overrated">
+        <div class="card-stack" id="card-stack">
+          <article id="current-card" class="subject-card current" aria-live="polite"></article>
+          <article id="next-card" class="subject-card standby" aria-hidden="true"></article>
         </div>
-        <p>
-          Yes, the mud looks fantastic. No, it does not make the gameplay more
-          exciting.
-        </p>
-        <button class="toggle" aria-expanded="false" type="button">
-          Why it's overrated
-        </button>
-        <div class="toggle-panel" id="mud-physics-panel">
-          <p>
-            When studios brag about dirt realism more than track design, maybe
-            priorities need a patch.
-          </p>
-          <ul class="reasons">
-            <li>The novelty wears off after the first splash.</li>
-            <li>Often masks lackluster vehicle handling.</li>
-            <li>Consumes dev time better spent on smarter AI.</li>
-          </ul>
+        <div class="vote-actions" role="group" aria-label="Cast your vote">
+          <button id="vote-no" class="vote-button vote-no" type="button">
+            <span class="vote-icon" aria-hidden="true">👎</span>
+            <span class="vote-label">Not overrated</span>
+          </button>
+          <button id="vote-yes" class="vote-button vote-yes" type="button">
+            <span class="vote-icon" aria-hidden="true">🔥</span>
+            <span class="vote-label">Overrated</span>
+          </button>
         </div>
-      </article>
+      </section>
 
-      <article class="game-card">
-        <h2>Non-Stop Cinematic Cutscenes</h2>
-        <div class="game-meta">
-          <span class="meta-pill">passive play</span>
-          <span>Introduced: 2001</span>
-          <span>Popularized by: Prestige action titles</span>
+      <section class="top-overrated" aria-label="Most overrated picks right now">
+        <div class="top-shell">
+          <h2 class="top-title">Most overrated this week</h2>
+          <p class="top-sub">Stacked by community swipe heat.</p>
+          <ol id="top-list" class="top-list"></ol>
+          <p class="top-note">Tap a card to decide if these deserve the crown.</p>
         </div>
-        <p>
-          Games that forget to let you actually play them? A bold creative
-          choice, sure.
-        </p>
-        <button class="toggle" aria-expanded="false" type="button">
-          Why it's overrated
+      </section>
+
+      <footer class="app-footer">
+        <button id="restart-button" class="ghost-button" type="button" hidden>
+          Shuffle another round
         </button>
-        <div class="toggle-panel" id="cutscene-panel">
-          <p>
-            Storytelling is great, but skipping 12-minute cutscenes to get back
-            to the action should not feel like a crime.
-          </p>
-          <ul class="reasons">
-            <li>Breaks the pacing and immersion.</li>
-            <li>Disrespects player agency.</li>
-            <li>Unskippable scenes are the real boss fights.</li>
-          </ul>
-        </div>
-      </article>
+        <p class="footer-note">Reload anytime for a fresh stack of debates.</p>
+      </footer>
     </main>
 
-    <footer>
-      <p>
-        Built with playful bias by the JBT Games crew. Share your own overrated
-        trends and let's commiserate.
-      </p>
-    </footer>
+    <div class="sr-only" aria-live="polite" id="sr-status"></div>
 
     <script src="script.js"></script>
   </body>

--- a/overrated/script.js
+++ b/overrated/script.js
@@ -1,29 +1,804 @@
-const cards = document.querySelectorAll(".game-card");
+const subjects = [
+  {
+    id: "taylor-swift",
+    name: "Taylor Swift",
+    type: "Artist",
+    year: 2024,
+    origin: "Claim to fame · The Eras Tour",
+    description:
+      "Selling out stadiums worldwide and resetting every streaming record. Cultural icon or hype machine?",
+    stats: [
+      { icon: "🎟️", label: "Tour stops", value: "146" },
+      { icon: "💿", label: "Albums", value: "10" }
+    ],
+    accent:
+      "radial-gradient(circle at top, rgba(255, 180, 215, 0.4), transparent 70%)",
+    image:
+      "https://images.unsplash.com/photo-1514525253161-7a46d19cd819?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Taylor Swift performing on stage",
+    overratedScore: 88
+  },
+  {
+    id: "barbie-film",
+    name: "Barbie",
+    type: "Movie",
+    year: 2023,
+    origin: "Directed by · Greta Gerwig",
+    description:
+      "The candy-colored blockbuster that turned every theater pink. Satire genius or marketing juggernaut?",
+    stats: [
+      { icon: "🍿", label: "Box office", value: "$1.4B" },
+      { icon: "🏆", label: "Oscars", value: "8 noms" }
+    ],
+    accent:
+      "radial-gradient(circle at top left, rgba(255, 192, 203, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1570378164207-c63f4e4f5659?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Moviegoers in a cinema lit by pink light",
+    overratedScore: 82
+  },
+  {
+    id: "drake",
+    name: "Drake",
+    type: "Artist",
+    year: 2024,
+    origin: "Latest era · For All the Dogs",
+    description:
+      "Every drop dominates playlists, but fans say the formula's wearing thin. Still unstoppable or time for a reset?",
+    stats: [
+      { icon: "🎧", label: "Monthly listeners", value: "67M" },
+      { icon: "🏆", label: "No.1 singles", value: "13" }
+    ],
+    accent:
+      "radial-gradient(circle at bottom right, rgba(120, 180, 255, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Rapper performing under blue stage lights",
+    overratedScore: 79
+  },
+  {
+    id: "oppenheimer",
+    name: "Oppenheimer",
+    type: "Movie",
+    year: 2023,
+    origin: "Director · Christopher Nolan",
+    description:
+      "Three hours of prestige filmmaking that became a meme. Historic masterpiece or overblown awards bait?",
+    stats: [
+      { icon: "📽️", label: "Runtime", value: "181 min" },
+      { icon: "⭐", label: "IMDb", value: "8.3" }
+    ],
+    accent:
+      "radial-gradient(circle at center, rgba(255, 190, 120, 0.4), transparent 65%)",
+    image:
+      "https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Film reel projectors glowing in a dark room",
+    overratedScore: 74
+  },
+  {
+    id: "fortnite",
+    name: "Fortnite",
+    type: "Game",
+    year: 2024,
+    origin: "Built by · Epic Games",
+    description:
+      "Concerts, brand collabs, and battle royale chaos. Still a cultural hub or a bloated crossover platform?",
+    stats: [
+      { icon: "🕹️", label: "Players", value: "70M monthly" },
+      { icon: "🎉", label: "Collabs", value: "160+" }
+    ],
+    accent:
+      "radial-gradient(circle at top right, rgba(140, 120, 255, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1542751110-97427bbecf20?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Person playing a colorful video game on a monitor",
+    overratedScore: 77
+  },
+  {
+    id: "olivia-rodrigo",
+    name: "Olivia Rodrigo",
+    type: "Artist",
+    year: 2023,
+    origin: "Sophomore album · GUTS",
+    description:
+      "Pop-punk revival for a new generation. Breakout authenticity or derivative diary entries?",
+    stats: [
+      { icon: "🎤", label: "World tour", value: "75 dates" },
+      { icon: "💜", label: "Grammy wins", value: "3" }
+    ],
+    accent:
+      "radial-gradient(circle at bottom left, rgba(200, 140, 255, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1517582082532-16c4d649c5ed?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Singer on stage with purple lighting",
+    overratedScore: 71
+  },
+  {
+    id: "last-of-us",
+    name: "The Last of Us",
+    type: "Series",
+    year: 2023,
+    origin: "HBO adaptation · Season 1",
+    description:
+      "Game-to-TV finally done right or prestige horror coasting on nostalgia?",
+    stats: [
+      { icon: "🧟", label: "Infected count", value: "Too many" },
+      { icon: "📺", label: "Viewers", value: "30M" }
+    ],
+    accent:
+      "radial-gradient(circle at bottom, rgba(120, 170, 140, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Overgrown city street at dusk",
+    overratedScore: 73
+  },
+  {
+    id: "ariana-grande",
+    name: "Ariana Grande",
+    type: "Artist",
+    year: 2024,
+    origin: "New era · Eternal Sunshine",
+    description:
+      "Whistle tones and pop perfection or playlist wallpaper at this point?",
+    stats: [
+      { icon: "🎧", label: "Streams", value: "42B" },
+      { icon: "🏆", label: "Awards", value: "9" }
+    ],
+    accent:
+      "radial-gradient(circle at top left, rgba(255, 210, 170, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1540573133985-87b6da6d54a9?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Pop singer silhouetted under pink lights",
+    overratedScore: 69
+  },
+  {
+    id: "stranger-things",
+    name: "Stranger Things",
+    type: "Series",
+    year: 2022,
+    origin: "Season 4 · Netflix",
+    description:
+      "Still the king of synth nostalgia or stuck in the Upside Down of fan service?",
+    stats: [
+      { icon: "👾", label: "Demogorgons", value: "Many" },
+      { icon: "📈", label: "Hours viewed", value: "1.4B" }
+    ],
+    accent:
+      "radial-gradient(circle at center, rgba(255, 90, 90, 0.4), transparent 65%)",
+    image:
+      "https://images.unsplash.com/photo-1478720568477-152d9b164e26?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Retro neon lights and fog",
+    overratedScore: 70
+  },
+  {
+    id: "marvel-phase5",
+    name: "Marvel Phase Five",
+    type: "Franchise",
+    year: 2025,
+    origin: "Saga status · Multiverse",
+    description:
+      "Superhero fatigue or still unstoppable? Another crossover avalanche waits.",
+    stats: [
+      { icon: "🎬", label: "Projects", value: "12" },
+      { icon: "🌌", label: "Timelines", value: "Infinite" }
+    ],
+    accent:
+      "radial-gradient(circle at top, rgba(160, 220, 255, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Stack of colorful superhero comic books",
+    overratedScore: 86
+  },
+  {
+    id: "doja-cat",
+    name: "Doja Cat",
+    type: "Artist",
+    year: 2024,
+    origin: "Scarlet era · Planet Doja",
+    description:
+      "Genre shapeshifter or internet troll turned pop staple?",
+    stats: [
+      { icon: "📱", label: "TikTok sounds", value: "310" },
+      { icon: "🎤", label: "Headliners", value: "25" }
+    ],
+    accent:
+      "radial-gradient(circle at bottom right, rgba(255, 110, 170, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1515162305280-7d34aac4ef74?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Singer with pink lighting on stage",
+    overratedScore: 65
+  },
+  {
+    id: "billie-eilish",
+    name: "Billie Eilish",
+    type: "Artist",
+    year: 2024,
+    origin: "Hit single · What Was I Made For?",
+    description:
+      "Whisper pop innovator or mood-board mainstay?",
+    stats: [
+      { icon: "🎧", label: "Streams", value: "36B" },
+      { icon: "🏆", label: "Grammys", value: "7" }
+    ],
+    accent:
+      "radial-gradient(circle at top right, rgba(120, 255, 200, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1487412720507-e7ab37603c6f?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Musician bathed in green lights",
+    overratedScore: 64
+  },
+  {
+    id: "dune-two",
+    name: "Dune: Part Two",
+    type: "Movie",
+    year: 2024,
+    origin: "Directed by · Denis Villeneuve",
+    description:
+      "Sci-fi opera perfection or sandworm slog?",
+    stats: [
+      { icon: "🏜️", label: "Arrakis scenes", value: "Plenty" },
+      { icon: "🍿", label: "Box office", value: "$712M" }
+    ],
+    accent:
+      "radial-gradient(circle at bottom left, rgba(255, 200, 150, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1520358231651-08d28e5f16ff?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Desert landscape at sunset",
+    overratedScore: 68
+  },
+  {
+    id: "wednesday-netflix",
+    name: "Wednesday",
+    type: "Series",
+    year: 2022,
+    origin: "Netflix hit · Season 1",
+    description:
+      "Goth girl revival or TikTok-core fad?",
+    stats: [
+      { icon: "🕺", label: "Dance edits", value: "250K" },
+      { icon: "📺", label: "Hours viewed", value: "1.7B" }
+    ],
+    accent:
+      "radial-gradient(circle at top left, rgba(120, 120, 255, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1522770179533-24471fcdba45?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Gothic hallway with purple lighting",
+    overratedScore: 67
+  },
+  {
+    id: "bad-bunny",
+    name: "Bad Bunny",
+    type: "Artist",
+    year: 2024,
+    origin: "World tour · Most Wanted",
+    description:
+      "Reggaeton revolutionary or festival mainstay fatigue?",
+    stats: [
+      { icon: "🌎", label: "Tour cities", value: "45" },
+      { icon: "💿", label: "Albums", value: "5" }
+    ],
+    accent:
+      "radial-gradient(circle at center, rgba(255, 170, 110, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1470225620780-dba8ba36b745?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Singer jumping on stage with orange lights",
+    overratedScore: 72
+  },
+  {
+    id: "zelda-totk",
+    name: "Tears of the Kingdom",
+    type: "Game",
+    year: 2023,
+    origin: "Legend of Zelda · Nintendo",
+    description:
+      "Open-world mastery or crafting grind overload?",
+    stats: [
+      { icon: "🗺️", label: "Map size", value: "2x Hyrule" },
+      { icon: "🛠️", label: "Fuse combos", value: "Infinite" }
+    ],
+    accent:
+      "radial-gradient(circle at top right, rgba(110, 210, 180, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Person holding a game controller near a TV",
+    overratedScore: 60
+  },
+  {
+    id: "cybertruck",
+    name: "Cybertruck",
+    type: "Product",
+    year: 2024,
+    origin: "Tesla · Stainless steel hype",
+    description:
+      "Future-proof utility or meme-worthy wedge on wheels?",
+    stats: [
+      { icon: "⚡", label: "Range", value: "340 mi" },
+      { icon: "💰", label: "Price", value: "$61K" }
+    ],
+    accent:
+      "radial-gradient(circle at center, rgba(180, 180, 200, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1525609004556-c46c7d6cf023?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Futuristic silver vehicle in a studio",
+    overratedScore: 90
+  },
+  {
+    id: "post-malone",
+    name: "Post Malone",
+    type: "Artist",
+    year: 2024,
+    origin: "Tour · If Y'all Weren't Here",
+    description:
+      "Genre-blending superstar or playlist wallpaper?",
+    stats: [
+      { icon: "🎤", label: "Headlining years", value: "8" },
+      { icon: "💿", label: "Albums", value: "5" }
+    ],
+    accent:
+      "radial-gradient(circle at bottom, rgba(255, 200, 170, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1507874457470-272b3c8d8ee2?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Singer with microphone on a smoky stage",
+    overratedScore: 63
+  },
+  {
+    id: "erastourfilm",
+    name: "Eras Tour (Film)",
+    type: "Movie",
+    year: 2023,
+    origin: "Concert film · AMC",
+    description:
+      "Concert cinema revolution or deluxe merch drop?",
+    stats: [
+      { icon: "🎬", label: "Runtime", value: "169 min" },
+      { icon: "🍿", label: "Domestic gross", value: "$180M" }
+    ],
+    accent:
+      "radial-gradient(circle at top, rgba(255, 140, 200, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1506157786151-b8491531f063?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Crowd at a concert with colorful confetti",
+    overratedScore: 83
+  },
+  {
+    id: "grammy-awards",
+    name: "Grammy Awards",
+    type: "Event",
+    year: 2024,
+    origin: "Music industry · 66th ceremony",
+    description:
+      "Cultural barometer or industry echo chamber?",
+    stats: [
+      { icon: "🏆", label: "Categories", value: "94" },
+      { icon: "🎤", label: "Performances", value: "18" }
+    ],
+    accent:
+      "radial-gradient(circle at top right, rgba(255, 215, 130, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1511671782779-c97d3d27a1d4?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Golden microphone standing under stage lights",
+    overratedScore: 78
+  },
+  {
+    id: "coachella",
+    name: "Coachella",
+    type: "Event",
+    year: 2024,
+    origin: "Empire Polo Club · Indio",
+    description:
+      "Festival mecca or influencer backdrop?",
+    stats: [
+      { icon: "🎡", label: "Stages", value: "8" },
+      { icon: "🎟️", label: "Attendees", value: "250K" }
+    ],
+    accent:
+      "radial-gradient(circle at bottom right, rgba(255, 170, 120, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1521334884684-d80222895322?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Festival crowd at sunset with ferris wheel",
+    overratedScore: 84
+  },
+  {
+    id: "ai-generated-songs",
+    name: "AI-Generated Songs",
+    type: "Trend",
+    year: 2024,
+    origin: "Cloned vocals · Viral remixes",
+    description:
+      "Creative revolution or uncanny valley earworms?",
+    stats: [
+      { icon: "🤖", label: "Model drops", value: "420" },
+      { icon: "🎧", label: "Streams", value: "2.3B" }
+    ],
+    accent:
+      "radial-gradient(circle at top, rgba(170, 200, 255, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Producer working at a laptop with headphones",
+    overratedScore: 87
+  },
+  {
+    id: "barbenheimer",
+    name: "Barbenheimer",
+    type: "Trend",
+    year: 2023,
+    origin: "Double feature · Meme weekend",
+    description:
+      "Cinema event of the decade or marketing coincidence?",
+    stats: [
+      { icon: "🎬", label: "Tickets", value: "200M" },
+      { icon: "💬", label: "Memes", value: "Countless" }
+    ],
+    accent:
+      "radial-gradient(circle at center, rgba(255, 120, 160, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1524985069026-dd778a71c7b4?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "People in a movie theater holding popcorn",
+    overratedScore: 76
+  },
+  {
+    id: "mario-movie",
+    name: "Super Mario Bros. Movie",
+    type: "Movie",
+    year: 2023,
+    origin: "Nintendo · Illumination",
+    description:
+      "Pixel-perfect fan service or safe cash-in?",
+    stats: [
+      { icon: "🍄", label: "Box office", value: "$1.3B" },
+      { icon: "⭐", label: "Audience", value: "95%" }
+    ],
+    accent:
+      "radial-gradient(circle at bottom right, rgba(255, 210, 120, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Arcade machine glowing in the dark",
+    overratedScore: 66
+  },
+  {
+    id: "adele-vegas",
+    name: "Adele: Weekends with Adele",
+    type: "Live Show",
+    year: 2024,
+    origin: "Las Vegas Residency",
+    description:
+      "Intimate vocal clinic or spendy pilgrimage?",
+    stats: [
+      { icon: "🎙️", label: "Shows", value: "68" },
+      { icon: "💸", label: "Avg ticket", value: "$600" }
+    ],
+    accent:
+      "radial-gradient(circle at top, rgba(240, 200, 150, 0.45), transparent 60%)",
+    image:
+      "https://images.unsplash.com/photo-1529158062015-cad636e69505?auto=format&fit=crop&w=720&q=80",
+    imageAlt: "Spotlight on a singer in a theater",
+    overratedScore: 75
+  }
+];
 
-cards.forEach((card) => {
-  const toggle = card.querySelector(".toggle");
-  const panel = card.querySelector(".toggle-panel");
+const pointerState = {
+  id: null,
+  active: false,
+  startX: 0
+};
 
-  if (!toggle || !panel) return;
+let cardStackEl;
+let voteYesButton;
+let voteNoButton;
+let restartButton;
+let progressCurrent;
+let progressTotal;
+let statusRegion;
+let topList;
+let activeCard;
+let standbyCard;
 
-  const updateState = (expanded) => {
-    toggle.setAttribute("aria-expanded", expanded);
-    panel.classList.toggle("open", expanded === "true");
-  };
+let deck = [];
+let activeIndex = 0;
+let locked = false;
 
-  toggle.addEventListener("click", () => {
-    const expanded = toggle.getAttribute("aria-expanded") === "true" ? "false" : "true";
-    updateState(expanded);
-  });
+initializeWhenReady();
 
-  toggle.addEventListener("keydown", (event) => {
-    if (event.key === "Enter" || event.key === " ") {
+function initializeWhenReady() {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", setup);
+  } else {
+    setup();
+  }
+}
+
+function setup() {
+  activeCard = document.getElementById("current-card");
+  standbyCard = document.getElementById("next-card");
+  cardStackEl = document.getElementById("card-stack");
+  voteYesButton = document.getElementById("vote-yes");
+  voteNoButton = document.getElementById("vote-no");
+  restartButton = document.getElementById("restart-button");
+  progressCurrent = document.getElementById("progress-current");
+  progressTotal = document.getElementById("progress-total");
+  statusRegion = document.getElementById("sr-status");
+  topList = document.getElementById("top-list");
+
+  if (
+    !activeCard ||
+    !standbyCard ||
+    !cardStackEl ||
+    !voteYesButton ||
+    !voteNoButton ||
+    !restartButton ||
+    !progressCurrent ||
+    !progressTotal ||
+    !statusRegion ||
+    !topList
+  ) {
+    return;
+  }
+
+  voteYesButton.addEventListener("click", () => handleVote("overrated"));
+  voteNoButton.addEventListener("click", () => handleVote("chill"));
+  restartButton.addEventListener("click", () => startRound());
+
+  renderTopOverrated();
+
+  document.addEventListener("keydown", (event) => {
+    if (locked || activeIndex >= deck.length) return;
+    if (event.key === "ArrowRight") {
       event.preventDefault();
-      const expanded = toggle.getAttribute("aria-expanded") === "true" ? "false" : "true";
-      updateState(expanded);
+      handleVote("overrated");
+    }
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      handleVote("chill");
     }
   });
 
-  // Initialize collapsed state
-  updateState("false");
-});
+  cardStackEl.addEventListener("pointerdown", (event) => {
+    if (locked || activeIndex >= deck.length) return;
+    pointerState.active = true;
+    pointerState.id = event.pointerId;
+    pointerState.startX = event.clientX;
+    if (typeof activeCard.setPointerCapture === "function") {
+      activeCard.setPointerCapture(pointerState.id);
+    }
+    activeCard.style.transition = "none";
+  });
+
+  cardStackEl.addEventListener("pointermove", (event) => {
+    if (!pointerState.active || event.pointerId !== pointerState.id) return;
+    const deltaX = event.clientX - pointerState.startX;
+    const rotation = deltaX / 14;
+    activeCard.style.transform = `translateX(${deltaX}px) rotate(${rotation}deg)`;
+    const fade = Math.min(Math.abs(deltaX) / 260, 0.4);
+    activeCard.style.opacity = `${1 - fade}`;
+  });
+
+  cardStackEl.addEventListener("pointerup", (event) => {
+    if (!pointerState.active || event.pointerId !== pointerState.id) return;
+    const deltaX = event.clientX - pointerState.startX;
+    finalizePointerGesture();
+    const threshold = cardStackEl.clientWidth * 0.25;
+    if (Math.abs(deltaX) > threshold) {
+      handleVote(deltaX > 0 ? "overrated" : "chill");
+    }
+  });
+
+  cardStackEl.addEventListener("pointercancel", (event) => {
+    if (!pointerState.active || event.pointerId !== pointerState.id) return;
+    finalizePointerGesture();
+  });
+
+  startRound();
+}
+
+function finalizePointerGesture() {
+  if (!pointerState.active) return;
+  if (typeof activeCard.releasePointerCapture === "function") {
+    activeCard.releasePointerCapture(pointerState.id);
+  }
+  pointerState.active = false;
+  pointerState.id = null;
+  pointerState.startX = 0;
+  activeCard.style.transition = "";
+  activeCard.style.transform = "";
+  activeCard.style.opacity = "";
+}
+
+function startRound() {
+  deck = shuffle(subjects);
+  activeIndex = 0;
+  locked = false;
+
+  progressTotal.textContent = deck.length;
+  progressCurrent.textContent = deck.length ? 1 : 0;
+
+  restartButton.hidden = true;
+  setButtonsDisabled(deck.length === 0);
+
+  prepareCard(activeCard, "current");
+  prepareCard(standbyCard, "standby");
+
+  if (!deck.length) {
+    renderCompletion(activeCard);
+    return;
+  }
+
+  renderSubject(activeCard, deck[0]);
+  announceSubject(deck[0]);
+
+  const upcoming = deck[1];
+  if (upcoming) {
+    renderSubject(standbyCard, upcoming);
+  } else {
+    clearCard(standbyCard);
+  }
+}
+
+function handleVote(vote) {
+  if (locked || activeIndex >= deck.length) return;
+
+  locked = true;
+  setButtonsDisabled(true);
+
+  const subject = deck[activeIndex];
+  announceVote(subject, vote);
+
+  const outgoing = activeCard;
+  const incoming = standbyCard;
+  const swipeClass = vote === "overrated" ? "swipe-right" : "swipe-left";
+  outgoing.classList.add("leaving", swipeClass);
+
+  window.setTimeout(() => {
+    outgoing.classList.remove("leaving", "swipe-right", "swipe-left");
+    prepareCard(outgoing, "standby");
+
+    activeIndex += 1;
+    const hasNext = activeIndex < deck.length;
+
+    if (hasNext) {
+      prepareCard(incoming, "current");
+      renderSubject(incoming, deck[activeIndex]);
+      announceSubject(deck[activeIndex]);
+      activeCard = incoming;
+      standbyCard = outgoing;
+      progressCurrent.textContent = activeIndex + 1;
+
+      const upcoming = deck[activeIndex + 1];
+      if (upcoming) {
+        prepareCard(standbyCard, "standby");
+        renderSubject(standbyCard, upcoming);
+      } else {
+        clearCard(standbyCard);
+      }
+
+      locked = false;
+      setButtonsDisabled(false);
+    } else {
+      activeCard = incoming;
+      standbyCard = outgoing;
+      prepareCard(activeCard, "current");
+      renderCompletion(activeCard);
+      progressCurrent.textContent = deck.length;
+      restartButton.hidden = false;
+      restartButton.focus();
+      locked = false;
+    }
+  }, 300);
+}
+
+function renderSubject(card, subject) {
+  card.style.setProperty("--card-accent", subject.accent);
+  const statsMarkup = subject.stats
+    .map(
+      (stat) =>
+        `<span class="stat-pill" role="listitem"><span class="stat-icon" aria-hidden="true">${stat.icon}</span><strong>${stat.value}</strong><small>${stat.label}</small></span>`
+    )
+    .join("");
+
+  card.innerHTML = `
+    <figure class="subject-media">
+      <img src="${subject.image}" alt="${subject.imageAlt || subject.name}" loading="lazy" />
+    </figure>
+    <div class="subject-meta">
+      <span class="subject-type">${getTypeEmoji(subject.type)} ${subject.type}</span>
+      <span class="subject-year">${subject.year}</span>
+    </div>
+    <h2 class="subject-title">${subject.name}</h2>
+    <p class="subject-description">${subject.description}</p>
+    <div class="subject-stats" role="list">${statsMarkup}</div>
+    <span class="subject-origin">${subject.origin}</span>
+  `;
+}
+
+function renderCompletion(card) {
+  card.classList.add("finished");
+  card.style.removeProperty("--card-accent");
+  card.innerHTML = `
+    <div class="finished-inner">
+      <h2>That's the deck</h2>
+      <p>You've weighed in on every pick. Shuffle again to keep the takes coming.</p>
+    </div>
+  `;
+  setButtonsDisabled(true);
+  statusRegion.textContent = "Deck finished. Shuffle again for fresh subjects.";
+}
+
+function renderTopOverrated() {
+  const topFive = [...subjects]
+    .filter((item) => typeof item.overratedScore === "number")
+    .sort((a, b) => b.overratedScore - a.overratedScore)
+    .slice(0, 5);
+
+  topList.innerHTML = topFive
+    .map(
+      (subject, index) => `
+        <li class="top-item">
+          <span class="top-rank">#${index + 1}</span>
+          <figure class="top-thumb">
+            <img src="${subject.image}" alt="${subject.imageAlt || subject.name}" loading="lazy" />
+          </figure>
+          <div class="top-meta">
+            <span class="top-name">${subject.name}</span>
+            <span class="top-type">${getTypeEmoji(subject.type)} ${subject.type} • ${subject.year}</span>
+            <span class="top-score">${subject.overratedScore}% say overrated</span>
+          </div>
+        </li>
+      `
+    )
+    .join("");
+}
+
+function clearCard(card) {
+  prepareCard(card, "standby");
+  card.innerHTML = "";
+}
+
+function prepareCard(card, role) {
+  card.className = role === "current" ? "subject-card current" : "subject-card standby";
+  if (role === "current") {
+    card.removeAttribute("aria-hidden");
+  } else {
+    card.setAttribute("aria-hidden", "true");
+  }
+  card.style.removeProperty("--card-accent");
+  card.innerHTML = "";
+}
+
+function setButtonsDisabled(state) {
+  voteYesButton.disabled = state;
+  voteNoButton.disabled = state;
+}
+
+function announceSubject(subject) {
+  statusRegion.textContent = `${subject.name}. ${subject.type} • ${subject.year}.`;
+}
+
+function announceVote(subject, vote) {
+  const label = vote === "overrated" ? "Overrated" : "Not overrated";
+  statusRegion.textContent = `You voted ${label} for ${subject.name}.`;
+}
+
+function shuffle(list) {
+  const arr = [...list];
+  for (let i = arr.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function getTypeEmoji(type) {
+  const map = {
+    Artist: "🎤",
+    Album: "🎶",
+    Movie: "🎬",
+    Series: "📺",
+    "Live Show": "🎤",
+    Game: "🕹️",
+    Single: "🎵",
+    Franchise: "🦸",
+    Product: "🚗",
+    Event: "🎉",
+    Trend: "🔥"
+  };
+  return map[type] || "✨";
+}

--- a/overrated/style.css
+++ b/overrated/style.css
@@ -1,172 +1,531 @@
 :root {
-  --bg: #0f172a;
-  --card-bg: rgba(15, 23, 42, 0.85);
-  --accent: #f97316;
-  --accent-soft: rgba(249, 115, 22, 0.2);
-  --text: #f8fafc;
-  --muted: #cbd5f5;
-  --shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
-  --transition: 200ms ease-in-out;
+  --bg: #060613;
+  --bg-soft: rgba(18, 22, 45, 0.75);
+  --card: rgba(18, 22, 45, 0.9);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text: #f5f7ff;
+  --muted: #b6b9d7;
+  --accent-no: linear-gradient(135deg, #3cc9a7, #81e9d4);
+  --accent-yes: linear-gradient(135deg, #ff6b6b, #ff9a7a);
+  --shadow: 0 32px 80px rgba(6, 6, 19, 0.55);
+  --radius: 24px;
+  --transition: 240ms ease;
+  font-family: "Inter", "Segoe UI", Tahoma, sans-serif;
 }
 
-* {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
 html,
 body {
   margin: 0;
-  padding: 0;
   min-height: 100%;
-  font-family: "Poppins", "Segoe UI", Tahoma, sans-serif;
-  background: radial-gradient(circle at top, #1e293b 0, var(--bg) 40%);
+  background: radial-gradient(circle at top, #171b3b 0%, var(--bg) 70%);
   color: var(--text);
 }
 
 body {
-  display: flex;
-  flex-direction: column;
+  min-height: 100dvh;
 }
 
-header {
-  padding: 3rem 1.5rem 2rem;
+a {
+  color: inherit;
+}
+
+.app-shell {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  padding: 0;
+}
+
+.app-header {
+  width: min(100%, 420px);
+  padding: 2.2rem 1.5rem 1.2rem;
+  text-align: center;
+  display: grid;
+  gap: 1rem;
+}
+
+.brand-row {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+}
+
+.brand-title {
+  margin: 0;
+  font-size: clamp(2rem, 8vw, 2.8rem);
+  letter-spacing: -0.01em;
+}
+
+.brand-title span {
+  color: #ffaf7a;
+}
+
+.brand-progress {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.header-sub {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  max-width: 32ch;
+  justify-self: center;
+}
+
+.card-stage {
+  flex: 1;
+  width: min(100%, 460px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  padding: 0 1.5rem clamp(2.5rem, 6vh, 3.5rem);
+}
+
+.top-overrated {
+  width: min(100%, 460px);
+  padding: 0 1.5rem 2.5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.top-shell {
+  width: 100%;
+  border-radius: calc(var(--radius) * 0.75);
+  background: linear-gradient(160deg, rgba(14, 18, 40, 0.85), rgba(10, 14, 30, 0.95));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 50px rgba(6, 6, 19, 0.45);
+  padding: 1.8rem 1.4rem 1.6rem;
+  display: grid;
+  gap: 1.1rem;
   text-align: center;
 }
 
-header h1 {
+.top-title {
   margin: 0;
-  font-size: clamp(2.5rem, 7vw, 3.75rem);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+  font-size: 1.35rem;
+  letter-spacing: -0.01em;
 }
 
-header p {
-  margin: 0.5rem auto 0;
-  max-width: 540px;
+.top-sub {
+  margin: 0;
+  font-size: 0.92rem;
   color: var(--muted);
-  line-height: 1.6;
 }
 
-main {
-  flex: 1;
+.top-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
   display: grid;
-  gap: 2rem;
-  padding: 0 1.5rem 3rem;
-  max-width: 960px;
-  width: 100%;
-  margin: 0 auto;
+  gap: 0.9rem;
 }
 
-.game-card {
-  background: var(--card-bg);
-  border-radius: 22px;
-  padding: 2rem;
-  box-shadow: var(--shadow);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
-}
-
-.game-card:hover,
-.game-card:focus-within {
-  transform: translateY(-6px);
-  box-shadow: 0 26px 60px rgba(15, 23, 42, 0.6);
-  border-color: rgba(249, 115, 22, 0.4);
-}
-
-.game-card h2 {
-  margin: 0 0 0.5rem;
-  font-size: 1.75rem;
-}
-
-.game-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem 1rem;
+.top-item {
+  display: grid;
+  grid-template-columns: auto 68px 1fr;
   align-items: center;
-  margin-bottom: 1rem;
-  font-size: 0.95rem;
-  color: var(--muted);
+  gap: 0.9rem;
+  padding: 0.9rem 1rem;
+  background: rgba(9, 12, 28, 0.75);
+  border-radius: calc(var(--radius) * 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.06);
 }
 
-.meta-pill {
-  padding: 0.35rem 0.75rem;
+.top-rank {
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.top-thumb {
+  margin: 0;
+  border-radius: 16px;
+  overflow: hidden;
+  aspect-ratio: 1 / 1;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.top-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.top-meta {
+  display: grid;
+  gap: 0.25rem;
+  justify-items: start;
+  text-align: left;
+}
+
+.top-name {
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.top-type {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.top-score {
+  font-size: 0.85rem;
+  color: #ffaf7a;
+  font-weight: 600;
+}
+
+.top-note {
+  margin: 0;
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.card-stack {
+  position: relative;
+  width: min(100%, 420px);
+  min-height: clamp(360px, 62vh, 560px);
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: pan-y;
+}
+
+.subject-card {
+  position: absolute;
+  inset: 0;
+  border-radius: var(--radius);
+  padding: 1.8rem;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.08), rgba(7, 10, 26, 0.9)),
+    var(--card);
+  border: 1px solid var(--card-border);
+  box-shadow: var(--shadow);
+  display: grid;
+  grid-auto-rows: max-content;
+  align-content: center;
+  justify-items: center;
+  text-align: center;
+  gap: 1.1rem;
+  overflow: hidden;
+  transition: transform var(--transition), opacity var(--transition);
+}
+
+.subject-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--card-accent, radial-gradient(circle at top right, rgba(255, 255, 255, 0.18), transparent 65%));
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.subject-card.current {
+  z-index: 2;
+}
+
+.subject-card.standby {
+  z-index: 1;
+  transform: translateY(24px) scale(0.95);
+  opacity: 0;
+}
+
+.subject-card.leaving {
+  pointer-events: none;
+}
+
+.subject-meta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.subject-type {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.85rem;
   border-radius: 999px;
-  background: var(--accent-soft);
-  color: var(--accent);
+  background: rgba(0, 0, 0, 0.35);
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  font-size: 0.75rem;
+  font-size: 0.8rem;
 }
 
-button.toggle {
-  margin-top: 1.25rem;
-  padding: 0.75rem 1.25rem;
+.subject-year {
+  font-weight: 600;
+  padding: 0.4rem 0.8rem;
   border-radius: 999px;
-  border: none;
-  cursor: pointer;
-  background: var(--accent);
-  color: #111827;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  transition: transform var(--transition), background var(--transition), color var(--transition);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(0, 0, 0, 0.25);
 }
 
-button.toggle:hover,
-button.toggle:focus {
-  transform: translateY(-2px);
-  background: #fb923c;
-  color: #0f172a;
+.subject-title {
+  margin: 0;
+  font-size: clamp(1.75rem, 6vw, 2.4rem);
+  letter-spacing: -0.01em;
+  max-width: 24ch;
 }
 
-button.toggle[aria-expanded="true"] {
-  background: transparent;
-  color: var(--accent);
-  border: 2px solid var(--accent);
-}
-
-.toggle-panel {
-  margin-top: 1rem;
-  line-height: 1.7;
-  max-height: 0;
-  overflow: hidden;
-  transition: max-height 280ms ease;
-}
-
-.toggle-panel.open {
-  max-height: 400px;
-}
-
-.toggle-panel p {
-  margin: 0.5rem 0;
-}
-
-ul.reasons {
-  margin: 0.75rem 0 0;
-  padding-left: 1.25rem;
-}
-
-ul.reasons li {
-  margin: 0.35rem 0;
-}
-
-footer {
-  text-align: center;
-  padding: 2rem 1.5rem 3rem;
+.subject-description {
+  margin: 0;
   color: var(--muted);
-  font-size: 0.9rem;
+  line-height: 1.6;
+  max-width: 32ch;
 }
 
-@media (max-width: 640px) {
-  header {
-    padding: 2.25rem 1.25rem 1.5rem;
+.subject-stats {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.85rem;
+}
+
+.stat-pill {
+  display: grid;
+  gap: 0.2rem;
+  place-items: center;
+  padding: 0.65rem 0.95rem;
+  border-radius: 999px;
+  background: rgba(7, 10, 26, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  min-width: 120px;
+  text-align: center;
+}
+
+.stat-icon {
+  font-size: 1.1rem;
+}
+
+.stat-pill strong {
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.stat-pill small {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.subject-origin {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.75);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  max-width: 34ch;
+}
+
+.subject-media {
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  border-radius: calc(var(--radius) - 12px);
+  overflow: hidden;
+  position: relative;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.subject-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.vote-actions {
+  width: min(100%, 420px);
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.vote-button {
+  flex: 1;
+  border: 0;
+  border-radius: 999px;
+  padding: 1.1rem 1.2rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  color: #070714;
+  transition: transform var(--transition), box-shadow var(--transition), opacity var(--transition);
+}
+
+.vote-button .vote-icon {
+  font-size: 1.4rem;
+}
+
+.vote-button:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 4px;
+}
+
+.vote-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.vote-no {
+  background: var(--accent-no);
+  box-shadow: 0 18px 40px rgba(60, 201, 167, 0.4);
+}
+
+.vote-yes {
+  background: var(--accent-yes);
+  box-shadow: 0 18px 48px rgba(255, 107, 107, 0.45);
+}
+
+.vote-button:not(:disabled):active {
+  transform: scale(0.97);
+}
+
+.app-footer {
+  width: min(100%, 420px);
+  padding: 1.5rem 1.5rem calc(2.2rem + env(safe-area-inset-bottom, 0px));
+  display: grid;
+  gap: 0.9rem;
+  text-align: center;
+}
+
+.ghost-button {
+  justify-self: center;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: transparent;
+  color: var(--text);
+  border-radius: 999px;
+  padding: 0.75rem 1.4rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+
+.ghost-button:hover,
+.ghost-button:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.footer-note {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.finished-inner {
+  display: grid;
+  gap: 0.75rem;
+  text-align: center;
+}
+
+.finished-inner h2 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.finished-inner p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.subject-card.finished {
+  align-content: center;
+}
+
+.swipe-left {
+  transform: translateX(-120%) rotate(-10deg);
+  opacity: 0;
+}
+
+.swipe-right {
+  transform: translateX(120%) rotate(10deg);
+  opacity: 0;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (min-width: 720px) {
+  .app-header {
+    padding-top: 3rem;
   }
 
-  .game-card {
-    padding: 1.75rem 1.5rem;
+  .card-stage {
+    padding-left: 2.5rem;
+    padding-right: 2.5rem;
   }
 
-  button.toggle {
-    width: 100%;
+  .card-stack,
+  .vote-actions {
+    width: min(100%, 460px);
+  }
+
+  .subject-card {
+    padding: 2.2rem;
+  }
+
+  .top-overrated {
+    padding-left: 2.5rem;
+    padding-right: 2.5rem;
+  }
+
+  .top-shell {
+    padding: 2.1rem 2rem 1.8rem;
+  }
+
+  .top-item {
+    grid-template-columns: auto 78px 1fr;
+    gap: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
   }
 }


### PR DESCRIPTION
## Summary
- add a mobile-first leaderboard section that spotlights the most overrated picks right now
- expand the swipe deck with a larger roster of subjects and overrated scores to power the rankings
- style the new leaderboard to match the centered card experience and keep content aligned

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e3e5bc12d08322906a2917c44be73b