### PR TITLE
Harden TweetStream authentication gating and storage

### DIFF
--- a/tweetstream/app.js
+++ b/tweetstream/app.js
@@ -1,0 +1,585 @@
+const STORAGE_KEY = "tweetstream-data";
+const SESSION_KEY = "tweetstream-session";
+const DATA_RECORD_KEY = "snapshot";
+
+class ClientDatabase {
+  constructor(name = "tweetstream-db") {
+    this.name = name;
+    if (!("indexedDB" in window)) {
+      this.fallback = true;
+      this.storageKey = `${this.name}-fallback`;
+      return;
+    }
+    this.dbPromise = new Promise((resolve, reject) => {
+      const request = indexedDB.open(this.name, 1);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains("kv")) {
+          db.createObjectStore("kv");
+        }
+      };
+      request.onsuccess = () => {
+        const db = request.result;
+        db.onversionchange = () => db.close();
+        resolve(db);
+      };
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  async get(key) {
+    if (this.fallback) {
+      try {
+        const raw = localStorage.getItem(`${this.storageKey}:${key}`);
+        return raw ? JSON.parse(raw) : null;
+      } catch (error) {
+        console.error("Failed to read fallback storage", error);
+        return null;
+      }
+    }
+    const db = await this.dbPromise;
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction("kv", "readonly");
+      const store = tx.objectStore("kv");
+      const request = store.get(key);
+      request.onsuccess = () => resolve(request.result ?? null);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  async set(key, value) {
+    if (this.fallback) {
+      try {
+        localStorage.setItem(`${this.storageKey}:${key}`, JSON.stringify(value));
+      } catch (error) {
+        console.error("Failed to persist fallback storage", error);
+      }
+      return;
+    }
+    const db = await this.dbPromise;
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction("kv", "readwrite");
+      const store = tx.objectStore("kv");
+      const request = store.put(value, key);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  }
+}
+
+const persistence = new ClientDatabase();
+
+const elements = {
+  authCard: document.getElementById("authCard"),
+  authForm: document.getElementById("authForm"),
+  authTitle: document.getElementById("authTitle"),
+  authSubtitle: document.getElementById("authSubtitle"),
+  authSubmit: document.getElementById("authSubmit"),
+  toggleAuth: document.getElementById("toggleAuth"),
+  headerActions: document.getElementById("headerActions"),
+  loginBtn: document.getElementById("loginBtn"),
+  signupBtn: document.getElementById("signupBtn"),
+  feed: document.getElementById("feed"),
+  posts: document.getElementById("posts"),
+  postTemplate: document.getElementById("postTemplate"),
+  postInput: document.getElementById("postInput"),
+  postBtn: document.getElementById("postBtn"),
+  charCount: document.getElementById("charCount"),
+  profileName: document.getElementById("profileName"),
+  profileHandle: document.getElementById("profileHandle"),
+  profileAvatar: document.getElementById("profileAvatar"),
+  logoutBtn: document.getElementById("logoutBtn"),
+  friendsList: document.getElementById("friendsList"),
+  addFriendForm: document.getElementById("addFriendForm"),
+  friendSearch: document.getElementById("friendSearch"),
+  feedToggle: document.querySelector(".feed-toggle"),
+  pills: Array.from(document.querySelectorAll(".feed-toggle .btn.pill")),
+};
+
+const state = {
+  mode: "login",
+  data: { users: {}, posts: [] },
+  session: null,
+  activeFeed: "hot",
+  ready: false,
+};
+
+const hotness = {
+  halfLifeHours: 18,
+  likeWeight: 12,
+  friendBoost: 24,
+  freshnessBonus(hoursAgo) {
+    const decay = Math.log(2) / this.halfLifeHours;
+    return Math.exp(-decay * hoursAgo) * 100;
+  },
+  compute(post, currentUser) {
+    const now = Date.now();
+    const hoursAgo = (now - post.createdAt) / 36e5;
+    const likes = post.likes.length;
+    const hasFriendLike = currentUser
+      ? post.likes.some((u) => currentUser.friends.includes(u))
+      : false;
+    const friendBoost = hasFriendLike ? this.friendBoost : 0;
+    return (
+      this.freshnessBonus(hoursAgo) +
+      likes * this.likeWeight +
+      friendBoost +
+      (post.author === currentUser?.username ? 5 : 0)
+    );
+  },
+};
+
+async function loadData() {
+  const stored = await persistence.get(DATA_RECORD_KEY);
+  if (stored) {
+    return {
+      users: stored.users ?? {},
+      posts: stored.posts ?? [],
+    };
+  }
+
+  const legacy = localStorage.getItem(STORAGE_KEY);
+  if (legacy) {
+    try {
+      const parsed = JSON.parse(legacy);
+      const normalized = {
+        users: parsed.users ?? {},
+        posts: parsed.posts ?? [],
+      };
+      await persistence.set(DATA_RECORD_KEY, normalized);
+      localStorage.removeItem(STORAGE_KEY);
+      return normalized;
+    } catch (err) {
+      console.error("Failed migrating legacy storage", err);
+    }
+  }
+
+  const demoUsers = {
+    aurora: makeUser("aurora", "Aurora Vega", "stargazer"),
+    finn: makeUser("finn", "Finn Harper", "fieldnotes"),
+    naia: makeUser("naia", "Naia Brooks", "wavewhisper"),
+  };
+
+  demoUsers.aurora.friends.push("finn", "naia");
+  demoUsers.finn.friends.push("aurora");
+  demoUsers.naia.friends.push("aurora");
+
+  const now = Date.now();
+  const demoPosts = [
+    makePost(
+      "aurora",
+      "Watching the city lights flicker from the rooftop. Every window a story.",
+      now - 36e5
+    ),
+    makePost(
+      "finn",
+      "Someone left a typewriter on the corner table of the cafe. I left a poem behind.",
+      now - 7.2e6
+    ),
+    makePost(
+      "naia",
+      "Low tide revealed a dozen tiny glass bottles today. The ocean is secretly a librarian.",
+      now - 1.5e6
+    ),
+  ];
+
+  demoPosts[0].likes.push("finn", "naia");
+  demoPosts[1].likes.push("aurora");
+  demoPosts[2].likes.push("aurora", "finn");
+
+  const data = { users: demoUsers, posts: demoPosts };
+  await persistence.set(DATA_RECORD_KEY, data);
+  return data;
+}
+
+function loadSession() {
+  const stored = localStorage.getItem(SESSION_KEY);
+  if (!stored) return null;
+  try {
+    const parsed = JSON.parse(stored);
+    return parsed?.username ? parsed : null;
+  } catch (err) {
+    console.error("Failed to parse session", err);
+    return null;
+  }
+}
+
+async function saveData() {
+  await persistence.set(DATA_RECORD_KEY, state.data);
+}
+
+function saveSession(username) {
+  const session = username ? { username } : null;
+  state.session = session;
+  if (session) {
+    localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+  } else {
+    localStorage.removeItem(SESSION_KEY);
+  }
+}
+
+function makeUser(username, displayName, handle = username) {
+  return {
+    username,
+    displayName,
+    handle: `@${handle}`,
+    password: "password",
+    friends: [],
+  };
+}
+
+function makePost(author, content, createdAt = Date.now()) {
+  return {
+    id: crypto.randomUUID(),
+    author,
+    content,
+    createdAt,
+    likes: [],
+  };
+}
+
+async function init() {
+  elements.loginBtn?.addEventListener("click", () => switchMode("login"));
+  elements.signupBtn?.addEventListener("click", () => switchMode("signup"));
+  elements.toggleAuth?.addEventListener("click", (event) => {
+    event.preventDefault();
+    switchMode(state.mode === "login" ? "signup" : "login");
+  });
+
+  elements.authForm.addEventListener("submit", handleAuthSubmit);
+  elements.logoutBtn.addEventListener("click", () => {
+    saveSession(null);
+    state.mode = "login";
+    render();
+  });
+
+  elements.postInput.addEventListener("input", handleComposerInput);
+  elements.postBtn.addEventListener("click", handleCreatePost);
+  elements.addFriendForm.addEventListener("submit", handleAddFriend);
+
+  elements.feedToggle.addEventListener("click", (event) => {
+    const pill = event.target.closest(".btn.pill");
+    if (!pill) return;
+    const feedType = pill.dataset.feed;
+    if (!feedType || feedType === state.activeFeed) return;
+    state.activeFeed = feedType;
+    elements.pills.forEach((btn) => btn.classList.toggle("active", btn.dataset.feed === feedType));
+    renderPosts();
+  });
+
+  renderLoading();
+
+  try {
+    state.data = await loadData();
+  } catch (error) {
+    console.error("Failed to load data", error);
+    state.data = { users: {}, posts: [] };
+  }
+
+  state.session = loadSession();
+  state.ready = true;
+
+  render();
+}
+
+function switchMode(mode) {
+  state.mode = mode;
+  if (mode === "login") {
+    elements.authTitle.textContent = "Welcome back";
+    elements.authSubtitle.textContent = "Sign in to catch up with your friends.";
+    elements.authSubmit.textContent = "Log In";
+    elements.toggleAuth.textContent = "Sign up";
+  } else {
+    elements.authTitle.textContent = "Create your account";
+    elements.authSubtitle.textContent = "Join the conversation and find your crew.";
+    elements.authSubmit.textContent = "Sign Up";
+    elements.toggleAuth.textContent = "Log in";
+  }
+}
+
+async function handleAuthSubmit(event) {
+  event.preventDefault();
+  const formData = new FormData(event.target);
+  const username = formData.get("username").trim().toLowerCase();
+  const password = formData.get("password").trim();
+  if (!username || !password) return;
+
+  if (state.mode === "login") {
+    const user = state.data.users[username];
+    if (!user || user.password !== password) {
+      showToast("Invalid credentials. Try again.");
+      return;
+    }
+    saveSession(username);
+    render();
+  } else {
+    if (state.data.users[username]) {
+      showToast("That username is already taken.");
+      return;
+    }
+    const user = {
+      username,
+      displayName: username.replace(/\b\w/g, (l) => l.toUpperCase()),
+      handle: `@${username}`,
+      password,
+      friends: [],
+    };
+    state.data.users[username] = user;
+    await saveData();
+    saveSession(username);
+    showToast("Welcome aboard! Start by finding friends.");
+    render();
+  }
+}
+
+function handleComposerInput() {
+  const remaining = 280 - elements.postInput.value.length;
+  elements.charCount.textContent = remaining;
+  elements.charCount.classList.toggle("danger", remaining <= 40);
+}
+
+async function handleCreatePost() {
+  const currentUser = getCurrentUser();
+  if (!currentUser) return;
+  const content = elements.postInput.value.trim();
+  if (!content) {
+    showToast("Write something first.");
+    return;
+  }
+  const post = makePost(currentUser.username, content);
+  state.data.posts.unshift(post);
+  await saveData();
+  elements.postInput.value = "";
+  handleComposerInput();
+  renderPosts();
+}
+
+async function handleAddFriend(event) {
+  event.preventDefault();
+  const currentUser = getCurrentUser();
+  if (!currentUser) return;
+  const username = elements.friendSearch.value.trim().toLowerCase();
+  if (!username || username === currentUser.username) {
+    showToast("Enter someone else's username.");
+    return;
+  }
+  const friend = state.data.users[username];
+  if (!friend) {
+    showToast("Couldn't find that user.");
+    return;
+  }
+  if (currentUser.friends.includes(username)) {
+    showToast("You're already friends.");
+    return;
+  }
+
+  currentUser.friends.push(username);
+  friend.friends.push(currentUser.username);
+  await saveData();
+  elements.friendSearch.value = "";
+  showToast(`You're now friends with ${friend.displayName}.`);
+  renderFriends();
+  renderPosts();
+}
+
+async function handleRemoveFriend(username) {
+  const currentUser = getCurrentUser();
+  if (!currentUser) return;
+  currentUser.friends = currentUser.friends.filter((f) => f !== username);
+  const other = state.data.users[username];
+  if (other) {
+    other.friends = other.friends.filter((f) => f !== currentUser.username);
+  }
+  await saveData();
+  renderFriends();
+  renderPosts();
+}
+
+async function handleLike(postId) {
+  const currentUser = getCurrentUser();
+  if (!currentUser) return;
+  const post = state.data.posts.find((p) => p.id === postId);
+  if (!post) return;
+  const hasLiked = post.likes.includes(currentUser.username);
+  post.likes = hasLiked
+    ? post.likes.filter((u) => u !== currentUser.username)
+    : [...post.likes, currentUser.username];
+  await saveData();
+  renderPosts();
+}
+
+function getCurrentUser() {
+  if (!state.session?.username) return null;
+  return state.data.users[state.session.username] ?? null;
+}
+
+function render() {
+  if (!state.ready) {
+    renderLoading();
+    return;
+  }
+  const currentUser = getCurrentUser();
+  const isAuthenticated = Boolean(currentUser);
+
+  elements.feed.hidden = !isAuthenticated;
+  elements.authCard.hidden = isAuthenticated;
+
+  elements.headerActions.hidden = isAuthenticated;
+
+  toggleAuthFormDisabled(false);
+
+  elements.postBtn.disabled = !isAuthenticated;
+  elements.postInput.disabled = !isAuthenticated;
+  elements.friendSearch.disabled = !isAuthenticated;
+  const addFriendButton = elements.addFriendForm.querySelector("button[type='submit']");
+  if (addFriendButton) {
+    addFriendButton.disabled = !isAuthenticated;
+  }
+
+  if (!isAuthenticated) {
+    switchMode(state.mode);
+    return;
+  }
+
+  renderProfile(currentUser);
+  renderFriends();
+  renderPosts();
+}
+
+function renderProfile(user) {
+  elements.profileName.textContent = user.displayName;
+  elements.profileHandle.textContent = user.handle;
+  elements.profileAvatar.textContent = user.displayName[0]?.toUpperCase() ?? "";
+}
+
+function renderFriends() {
+  const currentUser = getCurrentUser();
+  if (!currentUser) return;
+  elements.friendsList.innerHTML = "";
+
+  if (!currentUser.friends.length) {
+    const empty = document.createElement("li");
+    empty.textContent = "No friends yet. Add someone to get started.";
+    empty.classList.add("empty-state");
+    elements.friendsList.append(empty);
+    return;
+  }
+
+  currentUser.friends.forEach((username) => {
+    const friend = state.data.users[username];
+    if (!friend) return;
+    const item = document.createElement("li");
+    const name = document.createElement("span");
+    name.textContent = friend.displayName;
+    const handle = document.createElement("small");
+    handle.textContent = friend.handle;
+    handle.style.color = "var(--text-muted)";
+    handle.style.display = "block";
+    const remove = document.createElement("button");
+    remove.className = "btn";
+    remove.textContent = "Remove";
+    remove.addEventListener("click", () => handleRemoveFriend(username));
+
+    const textWrap = document.createElement("div");
+    textWrap.append(name, handle);
+    item.append(textWrap, remove);
+    elements.friendsList.append(item);
+  });
+}
+
+function renderPosts() {
+  const currentUser = getCurrentUser();
+  if (!currentUser) return;
+  const posts = getFeedPosts(currentUser, state.activeFeed);
+  elements.posts.innerHTML = "";
+
+  if (!posts.length) {
+    const empty = document.createElement("li");
+    empty.className = "post empty-post";
+    empty.textContent = "Nothing here yet. Start a conversation!";
+    elements.posts.append(empty);
+    return;
+  }
+
+  posts.forEach((post) => {
+    const clone = elements.postTemplate.content.cloneNode(true);
+    const root = clone.querySelector(".post");
+    const author = state.data.users[post.author];
+    const likeBtn = clone.querySelector("[data-action='like']");
+
+    clone.querySelector(".post-author").textContent = author?.displayName ?? post.author;
+    clone.querySelector(".post-handle").textContent = author?.handle ?? `@${post.author}`;
+    clone.querySelector(".post-time").textContent = formatRelativeTime(post.createdAt);
+    clone.querySelector(".post-content").textContent = post.content;
+    clone.querySelector(".count").textContent = post.likes.length;
+
+    const score = hotness.compute(post, currentUser);
+    clone.querySelector(".score").textContent = `🔥 ${score.toFixed(0)} hot score`;
+
+    likeBtn.classList.toggle("primary", post.likes.includes(currentUser.username));
+    likeBtn.addEventListener("click", () => handleLike(post.id));
+
+    root.querySelector(".post-avatar").textContent = (author?.displayName ?? post.author)[0]?.toUpperCase() ?? "";
+    elements.posts.append(clone);
+  });
+}
+
+function getFeedPosts(currentUser, feed) {
+  const posts = [...state.data.posts];
+  switch (feed) {
+    case "hot":
+      return posts
+        .sort((a, b) => hotness.compute(b, currentUser) - hotness.compute(a, currentUser))
+        .slice(0, 100);
+    case "friends":
+      return posts
+        .filter((post) => post.author === currentUser.username || currentUser.friends.includes(post.author))
+        .sort((a, b) => hotness.compute(b, currentUser) - hotness.compute(a, currentUser));
+    case "fresh":
+    default:
+      return posts.sort((a, b) => b.createdAt - a.createdAt);
+  }
+}
+
+function formatRelativeTime(timestamp) {
+  const diffMs = Date.now() - timestamp;
+  const diffSeconds = Math.max(1, Math.floor(diffMs / 1000));
+  if (diffSeconds < 60) return `${diffSeconds}s ago`;
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return new Date(timestamp).toLocaleString();
+}
+
+function showToast(message) {
+  const toast = document.createElement("div");
+  toast.className = "toast";
+  toast.textContent = message;
+  document.body.appendChild(toast);
+  requestAnimationFrame(() => toast.classList.add("visible"));
+  setTimeout(() => {
+    toast.classList.remove("visible");
+    toast.addEventListener("transitionend", () => toast.remove(), { once: true });
+  }, 2600);
+}
+
+function renderLoading() {
+  elements.feed.hidden = true;
+  elements.authCard.hidden = false;
+  elements.headerActions.hidden = false;
+  elements.authTitle.textContent = "Loading TweetStream";
+  elements.authSubtitle.textContent = "Hang tight while we connect to your feed.";
+  elements.authSubmit.textContent = "Loading…";
+  toggleAuthFormDisabled(true);
+}
+
+function toggleAuthFormDisabled(disabled) {
+  Array.from(elements.authForm.elements).forEach((element) => {
+    element.disabled = disabled;
+  });
+}
+
+init();

--- a/tweetstream/index.html
+++ b/tweetstream/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>TweetStream</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div id="app">
+    <header class="app-header">
+      <div class="logo">TweetStream</div>
+      <div class="header-actions" id="headerActions">
+        <button class="btn primary" id="loginBtn">Log In</button>
+        <button class="btn" id="signupBtn">Sign Up</button>
+      </div>
+    </header>
+
+    <main class="app-main">
+      <section class="auth-card" id="authCard">
+        <h1 id="authTitle">Welcome back</h1>
+        <p id="authSubtitle">Sign in to catch up with your friends.</p>
+        <form id="authForm">
+          <div class="input-group">
+            <label for="username">Username</label>
+            <input type="text" id="username" name="username" autocomplete="username" required />
+          </div>
+          <div class="input-group">
+            <label for="password">Password</label>
+            <input type="password" id="password" name="password" autocomplete="current-password" required />
+          </div>
+          <button class="btn primary" type="submit" id="authSubmit">Log In</button>
+          <p class="auth-switch">No account yet? <a href="#" id="toggleAuth">Sign up</a></p>
+        </form>
+      </section>
+
+      <section class="feed" id="feed" hidden>
+        <aside class="sidebar">
+          <div class="profile-card" id="profileCard">
+            <div class="avatar" id="profileAvatar"></div>
+            <div class="profile-info">
+              <h2 id="profileName"></h2>
+              <p id="profileHandle"></p>
+            </div>
+            <button class="btn" id="logoutBtn">Log out</button>
+          </div>
+
+          <div class="friends-card">
+            <h3>Friends</h3>
+            <ul id="friendsList"></ul>
+            <form id="addFriendForm" class="add-friend-form">
+              <input type="text" id="friendSearch" placeholder="Add by username" required />
+              <button class="btn primary" type="submit">Add Friend</button>
+            </form>
+          </div>
+        </aside>
+
+        <section class="timeline">
+          <div class="composer">
+            <textarea id="postInput" rows="3" placeholder="What's happening?" maxlength="280" required></textarea>
+            <div class="composer-actions">
+              <span class="char-count" id="charCount">280</span>
+              <button class="btn primary" id="postBtn">Post</button>
+            </div>
+          </div>
+          <div class="feed-toggle">
+            <button class="btn pill active" data-feed="hot">Hot</button>
+            <button class="btn pill" data-feed="fresh">Fresh</button>
+            <button class="btn pill" data-feed="friends">Friends</button>
+          </div>
+          <ul class="posts" id="posts"></ul>
+        </section>
+      </section>
+    </main>
+  </div>
+
+  <template id="postTemplate">
+    <li class="post">
+      <div class="post-avatar"></div>
+      <div class="post-body">
+        <header>
+          <span class="post-author"></span>
+          <span class="post-handle"></span>
+          <span class="post-time"></span>
+        </header>
+        <p class="post-content"></p>
+        <footer>
+          <button class="btn icon" data-action="like">
+            <span class="material-symbols-rounded">favorite</span>
+            <span class="count"></span>
+          </button>
+          <span class="score"></span>
+        </footer>
+      </div>
+    </li>
+  </template>
+
+  <script src="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:wght@400" defer></script>
+  <script src="app.js" type="module"></script>
+</body>
+</html>

--- a/tweetstream/styles.css
+++ b/tweetstream/styles.css
@@ -1,0 +1,435 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --bg-elevated: rgba(15, 23, 42, 0.85);
+  --card: rgba(30, 41, 59, 0.85);
+  --card-border: rgba(148, 163, 184, 0.15);
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --accent: #38bdf8;
+  --accent-strong: #0284c7;
+  --danger: #f97316;
+  --shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top, rgba(14, 165, 233, 0.3), rgba(15, 23, 42, 0.9)),
+    linear-gradient(180deg, rgba(15, 23, 42, 1), rgba(15, 23, 42, 0.95));
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  padding: clamp(16px, 5vw, 40px);
+}
+
+#app {
+  width: min(1200px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid var(--card-border);
+  border-radius: 24px;
+  padding: 16px 24px;
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow);
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.header-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.app-main {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.auth-card {
+  grid-column: 1 / -1;
+  background: var(--card);
+  border-radius: 24px;
+  border: 1px solid var(--card-border);
+  padding: clamp(24px, 4vw, 48px);
+  display: grid;
+  gap: 24px;
+  box-shadow: var(--shadow);
+  text-align: center;
+}
+
+.auth-card form {
+  display: grid;
+  gap: 16px;
+}
+
+.input-group {
+  display: grid;
+  gap: 8px;
+  text-align: left;
+}
+
+.input-group input {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--card-border);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+}
+
+.input-group input:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.btn {
+  cursor: pointer;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 20px;
+  font-weight: 600;
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--text);
+  transition: transform 150ms ease, background 150ms ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.btn:disabled,
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  transform: none;
+}
+
+.btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: rgba(148, 163, 184, 0.35);
+}
+
+.btn.primary {
+  background: linear-gradient(120deg, var(--accent), var(--accent-strong));
+  color: white;
+}
+
+.btn.primary:hover {
+  background: linear-gradient(120deg, var(--accent-strong), var(--accent));
+}
+
+.btn.icon {
+  padding: 8px 16px;
+}
+
+.btn.pill {
+  background: transparent;
+  border: 1px solid transparent;
+}
+
+.btn.pill.active {
+  background: rgba(56, 189, 248, 0.15);
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.auth-switch a {
+  color: var(--accent);
+}
+
+.feed {
+  display: grid;
+  grid-template-columns: minmax(240px, 280px) minmax(0, 1fr);
+  gap: 24px;
+  width: 100%;
+}
+
+.sidebar {
+  display: grid;
+  gap: 24px;
+  height: fit-content;
+}
+
+.profile-card,
+.friends-card,
+.composer {
+  background: var(--card);
+  border-radius: 24px;
+  border: 1px solid var(--card-border);
+  padding: 20px;
+  box-shadow: var(--shadow);
+}
+
+.profile-card {
+  display: grid;
+  gap: 16px;
+}
+
+.profile-card .avatar {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent), #f472b6);
+  display: grid;
+  place-items: center;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.95);
+}
+
+.profile-info h2 {
+  font-size: 1.3rem;
+}
+
+.profile-info p {
+  color: var(--text-muted);
+}
+
+.friends-card h3 {
+  margin-bottom: 12px;
+}
+
+.friends-card ul {
+  list-style: none;
+  display: grid;
+  gap: 12px;
+}
+
+.friends-card li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.friends-card li span {
+  font-weight: 600;
+}
+
+.friends-card button {
+  padding: 6px 12px;
+}
+
+.add-friend-form {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.add-friend-form input {
+  flex: 1;
+  padding: 10px;
+  border-radius: 999px;
+  border: 1px solid var(--card-border);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+}
+
+.timeline {
+  display: grid;
+  gap: 20px;
+}
+
+.composer textarea {
+  width: 100%;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 16px;
+  border: 1px solid var(--card-border);
+  padding: 16px;
+  color: var(--text);
+  resize: vertical;
+}
+
+.composer textarea:focus {
+  outline: 2px solid var(--accent);
+}
+
+.composer-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 12px;
+}
+
+.char-count {
+  color: var(--text-muted);
+}
+
+.feed-toggle {
+  display: flex;
+  gap: 12px;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 999px;
+  padding: 6px;
+  border: 1px solid var(--card-border);
+}
+
+.posts {
+  list-style: none;
+  display: grid;
+  gap: 16px;
+}
+
+.post {
+  display: grid;
+  grid-template-columns: 64px 1fr;
+  gap: 16px;
+  padding: 18px;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: var(--shadow);
+}
+
+.post-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: linear-gradient(140deg, #f472b6, var(--accent));
+}
+
+.post-body header {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+
+.post-author {
+  font-weight: 700;
+}
+
+.post-handle,
+.post-time {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.post-content {
+  line-height: 1.6;
+  margin-bottom: 12px;
+}
+
+.post footer {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.post footer .count {
+  font-weight: 600;
+}
+
+.post footer .score {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 1024px) {
+  body {
+    padding: 16px;
+  }
+
+  .feed {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    order: 2;
+  }
+}
+
+@media (max-width: 600px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .auth-card {
+    padding: 24px 18px;
+  }
+
+  .feed-toggle {
+    overflow-x: auto;
+  }
+
+  .post {
+    grid-template-columns: 48px 1fr;
+  }
+
+  .post-avatar {
+    width: 48px;
+    height: 48px;
+  }
+}
+.char-count.danger {
+  color: var(--danger);
+}
+
+.empty-state {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.post.empty-post {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 40px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.toast {
+  position: fixed;
+  inset: auto 50% 32px auto;
+  transform: translateX(50%) translateY(20px);
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid var(--card-border);
+  color: var(--text);
+  padding: 12px 20px;
+  border-radius: 999px;
+  opacity: 0;
+  transition: opacity 200ms ease, transform 200ms ease;
+  box-shadow: var(--shadow);
+  z-index: 9999;
+}
+
+.toast.visible {
+  opacity: 1;
+  transform: translateX(50%) translateY(0);
+}
+
+@media (max-width: 600px) {
+  .toast {
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%) translateY(20px);
+  }
+
+  .toast.visible {
+    transform: translateX(-50%) translateY(0);
+  }
+}


### PR DESCRIPTION
## Summary
- add an IndexedDB-backed persistence layer with a localStorage fallback so data survives on GitHub Pages
- gate the feed UI until authentication completes and disable posting/friend actions while signed out
- style disabled buttons to reflect the new gating states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3f059a29883228f161106a2d0dfae