### PR TITLE
Add responsive shell with login for SocialSquare

### DIFF
--- a/socialsquare/app.js
+++ b/socialsquare/app.js
@@ -1,0 +1,1324 @@
+const STORAGE_KEY = 'socialsquare-posts-v1';
+const BOOKMARK_KEY = 'socialsquare-bookmarks-v1';
+const FRIENDS_KEY = 'socialsquare-friends-v1';
+const PROFILE_KEY = 'socialsquare-profile-v1';
+const AUTH_KEY = 'socialsquare-auth-v1';
+const SESSION_AUTH_KEY = 'socialsquare-session-auth-v1';
+const MAIN_USER_ID = 'alex-rivers';
+
+const postTemplate = document.getElementById('postTemplate');
+const feedEl = document.getElementById('feed');
+const postForm = document.getElementById('postForm');
+const postContent = document.getElementById('postContent');
+const mediaUpload = document.getElementById('mediaUpload');
+const tabs = document.querySelectorAll('.tab');
+const menuButtons = Array.from(document.querySelectorAll('.menu-item'));
+const mobileNavButtons = Array.from(document.querySelectorAll('.mobile-nav__item'));
+const panels = document.querySelectorAll('.panel');
+const statPosts = document.getElementById('stat-posts');
+const search = document.getElementById('search');
+const profileOverlay = document.getElementById('profileOverlay');
+const profileModalContent = document.getElementById('profileModalContent');
+
+const authScreen = document.getElementById('authScreen');
+const appShell = document.getElementById('appShell');
+const loginForm = document.getElementById('loginForm');
+const loginName = document.getElementById('loginName');
+const loginEmail = document.getElementById('loginEmail');
+const loginPassword = document.getElementById('loginPassword');
+const rememberMe = document.getElementById('rememberMe');
+const drawerBackdrop = document.getElementById('drawerBackdrop');
+const sidebar = document.getElementById('sidebar');
+const rightbar = document.getElementById('rightbar');
+const topbarName = document.getElementById('topbarName');
+const topbarAvatar = document.getElementById('topbarAvatar');
+const userMenuToggle = document.getElementById('userMenuToggle');
+const userMenu = document.getElementById('userMenu');
+const logoutButton = document.getElementById('logoutButton');
+const sidebarName = document.getElementById('sidebarName');
+const sidebarHandle = document.getElementById('sidebarHandle');
+const sidebarAvatar = document.getElementById('sidebarAvatar');
+const profileName = document.getElementById('profileName');
+const profileHandle = document.getElementById('profileHandle');
+const profileAvatar = document.getElementById('profileAvatar');
+const profileBio = document.getElementById('profileBio');
+const welcomeTitle = document.getElementById('welcomeTitle');
+
+const allSectionButtons = [...menuButtons, ...mobileNavButtons];
+const navToggleButtons = document.querySelectorAll('[data-toggle-drawer]');
+
+let activeTab = 'for-you';
+let activeSection = 'feed';
+const openComments = new Set();
+
+const profiles = {
+  'alex-rivers': {
+    id: 'alex-rivers',
+    name: 'Alex Rivers',
+    handle: '@arivers',
+    avatar: 'https://avatars.dicebear.com/api/initials/AR.svg',
+    location: 'Portland, OR',
+    tags: ['Product Design', 'Playful UX', 'Urban photography'],
+    bio: 'Product designer exploring playful experiences. Amateur photographer and tea enthusiast.',
+    stats: { posts: 0, followers: '1,204', following: '536' },
+    highlights: [
+      'Sketching a whimsical onboarding for the NebulaUI playground.',
+      'Curating photo essays from city walks on weekends.',
+    ],
+    focus: ['Motion principles', 'Creative prototyping', 'Community design jams'],
+    mutuals: ['Jamie Doe', 'Taylor Green', 'Lena Nguyen'],
+  },
+  'jamie-doe': {
+    id: 'jamie-doe',
+    name: 'Jamie Doe',
+    handle: '@jamiedoe',
+    avatar: 'https://avatars.dicebear.com/api/initials/JD.svg',
+    location: 'Seattle, WA',
+    tags: ['Design Systems', 'Speaking'],
+    bio: 'Design system lead sharing micro-interactions and inclusive tooling tips.',
+    stats: { posts: '482', followers: '18.5k', following: '1,102' },
+    highlights: [
+      'Hosting a live stream on progressive disclosure this Friday.',
+      'Building a new accessibility checklist template.',
+    ],
+    focus: ['Component governance', 'Community mentoring'],
+    mutuals: ['Alex Rivers', 'Taylor Green'],
+  },
+  'taylor-green': {
+    id: 'taylor-green',
+    name: 'Taylor Green',
+    handle: '@taylorgreen',
+    avatar: 'https://avatars.dicebear.com/api/initials/TG.svg',
+    location: 'Vancouver, BC',
+    tags: ['Product Ops', 'Launches'],
+    bio: 'Product manager translating discovery into launches. Coffee connoisseur.',
+    stats: { posts: '356', followers: '9,876', following: '803' },
+    highlights: [
+      'Shipping the beta for HorizonCollab.',
+      'Planning community office hours this weekend.',
+    ],
+    focus: ['Roadmapping', 'Feedback synthesis'],
+    mutuals: ['Alex Rivers', 'Jamie Doe'],
+  },
+  'lena-nguyen': {
+    id: 'lena-nguyen',
+    name: 'Lena Nguyen',
+    handle: '@lena.designs',
+    avatar: 'https://avatars.dicebear.com/api/initials/LN.svg',
+    location: 'Austin, TX',
+    tags: ['Visual storytelling', 'Photography'],
+    bio: 'Designing cinematic brand identities and chasing golden hour light.',
+    stats: { posts: '624', followers: '24.2k', following: '1,502' },
+    highlights: [
+      'Launching the Aurora brand kit soon.',
+      'Printing a zine of skyline sketches.',
+    ],
+    focus: ['Color grading', 'Brand systems'],
+    mutuals: ['Alex Rivers', 'Milo Hart'],
+  },
+  'marcus-clark': {
+    id: 'marcus-clark',
+    name: 'Marcus Clark',
+    handle: '@marcus.codes',
+    avatar: 'https://avatars.dicebear.com/api/initials/MC.svg',
+    location: 'Denver, CO',
+    tags: ['Web performance', 'DX'],
+    bio: 'Full-stack engineer crafting snappy experiences and docs developers love.',
+    stats: { posts: '273', followers: '6,482', following: '421' },
+    highlights: ['Documenting a DX audit checklist.', 'Sharing render performance profiles.'],
+    focus: ['Edge rendering', 'Tooling'],
+    mutuals: ['Nova Sparks', 'Alex Rivers'],
+  },
+  'sara-malik': {
+    id: 'sara-malik',
+    name: 'Sara Malik',
+    handle: '@saramalik',
+    avatar: 'https://avatars.dicebear.com/api/initials/SM.svg',
+    location: 'Chicago, IL',
+    tags: ['Community', 'Growth'],
+    bio: 'Community strategist building playful onboarding and retention rituals.',
+    stats: { posts: '198', followers: '12.1k', following: '982' },
+    highlights: ['Leading a community storytelling challenge.', 'Hosting a growth roundtable next week.'],
+    focus: ['Lifecycle journeys', 'Activation'],
+    mutuals: ['Alex Rivers', 'Chloe Winters'],
+  },
+  'nova-sparks': {
+    id: 'nova-sparks',
+    name: 'Nova Sparks',
+    handle: '@nova.codes',
+    avatar: 'https://avatars.dicebear.com/api/initials/NS.svg',
+    location: 'Remote · OrbitOps',
+    tags: ['Creative code', 'Realtime'],
+    bio: 'Creative technologist prototyping luminous dashboards and realtime toys.',
+    stats: { posts: '842', followers: '31.4k', following: '1,906' },
+    highlights: ['Pairing on WebGL accents for NebulaUI.', 'Documented a new adaptive theming recipe.'],
+    focus: ['Realtime collaboration', 'Design systems'],
+    mutuals: ['Alex Rivers', 'Marcus Clark'],
+  },
+  'milo-hart': {
+    id: 'milo-hart',
+    name: 'Milo Hart',
+    handle: '@milohart',
+    avatar: 'https://avatars.dicebear.com/api/initials/MH.svg',
+    location: 'Brooklyn, NY',
+    tags: ['Street photography', 'Analog'],
+    bio: 'Photographer documenting city pulse and blending analog textures into digital stories.',
+    stats: { posts: '1,128', followers: '45.8k', following: '2,104' },
+    highlights: ['Sequencing the Wanderlight series gallery.', 'Hosting a night photography walk.'],
+    focus: ['Long exposure', 'Editorial sequencing'],
+    mutuals: ['Alex Rivers', 'Lena Nguyen'],
+  },
+  'chloe-winters': {
+    id: 'chloe-winters',
+    name: 'Chloe Winters',
+    handle: '@chloewell',
+    avatar: 'https://avatars.dicebear.com/api/initials/CW.svg',
+    location: 'San Diego, CA',
+    tags: ['Wellness', 'Sound design'],
+    bio: 'Sound designer layering calming rituals and mindful playlists for everyday resets.',
+    stats: { posts: '564', followers: '22.6k', following: '1,305' },
+    highlights: ['Mixing a new Quiet Morning playlist.', 'Piloting skyline yoga sessions.'],
+    focus: ['Breathwork scoring', 'Sonic storytelling'],
+    mutuals: ['Alex Rivers', 'Sara Malik'],
+  },
+};
+
+const profileHandleLookup = Object.fromEntries(
+  Object.values(profiles).map((profile) => [profile.handle, profile.id])
+);
+
+const defaultFriendIds = ['jamie-doe'];
+
+const baseMainProfile = JSON.parse(JSON.stringify(profiles[MAIN_USER_ID]));
+
+const getMainProfile = () => profiles[MAIN_USER_ID] || baseMainProfile;
+
+const getMainFirstName = () => {
+  const name = getMainProfile().name || 'Alex Rivers';
+  const [first] = name.split(' ');
+  return first || name;
+};
+
+const applyStoredProfile = () => {
+  const stored = localStorage.getItem(PROFILE_KEY);
+  if (!stored) return;
+  try {
+    const parsed = JSON.parse(stored);
+    profiles[MAIN_USER_ID] = {
+      ...profiles[MAIN_USER_ID],
+      ...parsed,
+    };
+  } catch (error) {
+    console.error('Failed to parse stored profile', error);
+    localStorage.removeItem(PROFILE_KEY);
+  }
+};
+
+applyStoredProfile();
+
+const updateMainUserUI = () => {
+  const profile = getMainProfile();
+  if (topbarName) {
+    topbarName.textContent = getMainFirstName();
+  }
+  if (topbarAvatar) {
+    topbarAvatar.src = profile.avatar;
+    topbarAvatar.alt = `${profile.name} avatar`;
+  }
+  if (sidebarName) {
+    sidebarName.textContent = profile.name;
+  }
+  if (sidebarHandle) {
+    sidebarHandle.textContent = profile.handle;
+  }
+  if (sidebarAvatar) {
+    sidebarAvatar.src = profile.avatar;
+    sidebarAvatar.alt = `${profile.name} avatar`;
+  }
+  if (profileName) {
+    profileName.textContent = profile.name;
+  }
+  if (profileHandle) {
+    profileHandle.textContent = profile.handle;
+  }
+  if (profileAvatar) {
+    profileAvatar.src = profile.avatar;
+    profileAvatar.alt = `${profile.name} avatar`;
+  }
+  if (profileBio && profile.bio) {
+    profileBio.textContent = profile.bio;
+  }
+  if (welcomeTitle) {
+    welcomeTitle.textContent = `Welcome back, ${getMainFirstName()}`;
+  }
+  if (postContent) {
+    postContent.placeholder = `What's on your mind, ${getMainFirstName()}?`;
+  }
+};
+
+updateMainUserUI();
+
+const persistMainProfile = () => {
+  try {
+    const profile = getMainProfile();
+    localStorage.setItem(
+      PROFILE_KEY,
+      JSON.stringify({
+        name: profile.name,
+        handle: profile.handle,
+        avatar: profile.avatar,
+        bio: profile.bio,
+      })
+    );
+  } catch (error) {
+    console.error('Failed to persist profile', error);
+  }
+};
+
+const closeUserMenu = () => {
+  if (!userMenu) return;
+  if (!userMenu.classList.contains('hidden')) {
+    userMenu.classList.add('hidden');
+    userMenuToggle?.setAttribute('aria-expanded', 'false');
+  }
+};
+
+const openUserMenu = () => {
+  if (!userMenu) return;
+  userMenu.classList.remove('hidden');
+  userMenuToggle?.setAttribute('aria-expanded', 'true');
+};
+
+const closeDrawers = () => {
+  sidebar?.classList.remove('is-open');
+  rightbar?.classList.remove('is-open');
+  drawerBackdrop?.classList.add('hidden');
+  document.body.classList.remove('drawer-open');
+};
+
+const openDrawer = (drawer) => {
+  if (!drawer) return;
+  if (drawer === sidebar) {
+    rightbar?.classList.remove('is-open');
+  } else if (drawer === rightbar) {
+    sidebar?.classList.remove('is-open');
+  }
+  drawer.classList.add('is-open');
+  drawerBackdrop?.classList.remove('hidden');
+  document.body.classList.add('drawer-open');
+  closeUserMenu();
+};
+
+const loadFriends = () => {
+  try {
+    const stored = localStorage.getItem(FRIENDS_KEY);
+    if (!stored) return new Set(defaultFriendIds);
+    const parsed = JSON.parse(stored);
+    return new Set(parsed);
+  } catch (error) {
+    console.error('Failed to parse stored friends', error);
+    return new Set(defaultFriendIds);
+  }
+};
+
+let friends = loadFriends();
+
+const saveFriends = () => {
+  localStorage.setItem(FRIENDS_KEY, JSON.stringify([...friends]));
+};
+
+const isFriend = (profileId) => friends.has(profileId);
+
+const updateFriendButtons = (profileId) => {
+  document
+    .querySelectorAll(`[data-action="friend"][data-profile-id="${profileId}"]`)
+    .forEach((button) => {
+      if (profileId === MAIN_USER_ID) {
+        button.classList.add('hidden');
+        return;
+      }
+
+      button.classList.remove('hidden');
+      const friend = isFriend(profileId);
+      button.textContent = friend ? 'Friends' : 'Add friend';
+      button.classList.toggle('is-friend', friend);
+      button.setAttribute('aria-pressed', friend ? 'true' : 'false');
+    });
+};
+
+const updateAllFriendButtons = () => {
+  Object.keys(profiles).forEach(updateFriendButtons);
+};
+
+const mainProfileSnapshot = getMainProfile();
+
+const defaultPosts = [
+  {
+    id: crypto.randomUUID(),
+    author: 'Jamie Doe',
+    handle: '@jamiedoe',
+    avatar: 'https://avatars.dicebear.com/api/initials/JD.svg',
+    content:
+      'Exploring motion in UI design this week. Micro-interactions make such a difference! ✨',
+    timestamp: Date.now() - 1000 * 60 * 60 * 3,
+    likes: 32,
+    liked: false,
+    bookmarked: false,
+    following: true,
+    profileId: 'jamie-doe',
+    comments: [
+      {
+        id: crypto.randomUUID(),
+        author: mainProfileSnapshot.name,
+        handle: mainProfileSnapshot.handle,
+        avatar: mainProfileSnapshot.avatar,
+        content: 'Totally! The little details create big delight.',
+        timestamp: Date.now() - 1000 * 60 * 60 * 2,
+        profileId: MAIN_USER_ID,
+      },
+    ],
+  },
+  {
+    id: crypto.randomUUID(),
+    author: 'Taylor Green',
+    handle: '@taylorgreen',
+    avatar: 'https://avatars.dicebear.com/api/initials/TG.svg',
+    content:
+      'Just wrapped our product beta! Huge thanks to everyone who tested and shared feedback. 🚀',
+    timestamp: Date.now() - 1000 * 60 * 60 * 8,
+    likes: 54,
+    liked: false,
+    bookmarked: true,
+    following: false,
+    profileId: 'taylor-green',
+    comments: [],
+  },
+  {
+    id: crypto.randomUUID(),
+    author: 'Lena Nguyen',
+    handle: '@lena.designs',
+    avatar: 'https://avatars.dicebear.com/api/initials/LN.svg',
+    content:
+      'Morning walk inspo: the city skyline, soft fog, and a warm cappuccino. ☕️🌆',
+    media:
+      'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=900&q=80',
+    timestamp: Date.now() - 1000 * 60 * 60 * 24,
+    likes: 97,
+    liked: true,
+    bookmarked: false,
+    following: true,
+    profileId: 'lena-nguyen',
+    comments: [
+      {
+        id: crypto.randomUUID(),
+        author: 'Jamie Doe',
+        handle: '@jamiedoe',
+        avatar: 'https://avatars.dicebear.com/api/initials/JD.svg',
+        content: 'This photo is stunning. Captured the vibe perfectly!',
+        timestamp: Date.now() - 1000 * 60 * 60 * 20,
+        profileId: 'jamie-doe',
+      },
+    ],
+  },
+];
+
+const loadState = () => {
+  const storedPosts = localStorage.getItem(STORAGE_KEY);
+  let posts = storedPosts ? JSON.parse(storedPosts) : defaultPosts;
+
+  posts = posts.map((post) => ({
+    likes: 0,
+    liked: false,
+    bookmarked: false,
+    following: false,
+    comments: [],
+    profileId: profileHandleLookup[post.handle] || post.profileId || null,
+    botReactions: {},
+    ...post,
+  }));
+
+  const storedBookmarks = localStorage.getItem(BOOKMARK_KEY);
+  const bookmarkSet = new Set(storedBookmarks ? JSON.parse(storedBookmarks) : []);
+
+  posts = posts.map((post) => ({
+    ...post,
+    bookmarked: bookmarkSet.has(post.id) || post.bookmarked,
+    comments: (post.comments || []).map((comment) => ({
+      profileId: profileHandleLookup[comment.handle] || comment.profileId || null,
+      ...comment,
+    })),
+    botReactions: post.botReactions || {},
+  }));
+
+  return posts.sort((a, b) => b.timestamp - a.timestamp);
+};
+
+let posts = loadState();
+
+const MAX_POSTS = 60;
+const BOT_MIN_DELAY = 35000;
+const BOT_MAX_DELAY = 90000;
+const BOT_INITIAL_MIN_DELAY = 6000;
+const BOT_INITIAL_MAX_DELAY = 18000;
+const BOT_REACTION_MIN_DELAY = 6000;
+const BOT_REACTION_MAX_DELAY = 16000;
+
+const randomBetween = (min, max) =>
+  Math.floor(Math.random() * (max - min + 1)) + min;
+
+const randomChoice = (array) => array[Math.floor(Math.random() * array.length)];
+
+const saveState = () => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(posts));
+  const bookmarkedIds = posts.filter((post) => post.bookmarked).map((post) => post.id);
+  localStorage.setItem(BOOKMARK_KEY, JSON.stringify(bookmarkedIds));
+};
+
+const formatTime = (timestamp) => {
+  const diff = Date.now() - timestamp;
+  const minutes = Math.floor(diff / (1000 * 60));
+  if (minutes < 1) return 'Just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const date = new Date(timestamp);
+  return date.toLocaleDateString();
+};
+
+const refreshOpenProfile = () => {
+  if (!profileOverlay || profileOverlay.classList.contains('hidden')) {
+    return;
+  }
+  const { profileId } = profileOverlay.dataset;
+  if (!profileId) return;
+  renderProfileModal(profileId);
+};
+
+const renderPosts = () => {
+  feedEl.innerHTML = '';
+  let filtered = posts;
+  if (activeTab === 'following') {
+    filtered = posts.filter((post) => post.following);
+  } else if (activeTab === 'bookmarked') {
+    filtered = posts.filter((post) => post.bookmarked);
+  }
+
+  if (filtered.length === 0) {
+    feedEl.innerHTML = `<div class="empty">No posts here yet. Be the first to share something!</div>`;
+    const myPosts = posts.filter((post) => post.profileId === MAIN_USER_ID).length;
+    statPosts.textContent = myPosts;
+    if (profiles[MAIN_USER_ID]) {
+      profiles[MAIN_USER_ID].stats.posts = myPosts;
+    }
+    refreshOpenProfile();
+    return;
+  }
+
+  filtered.forEach((post) => {
+    const clone = postTemplate.content.firstElementChild.cloneNode(true);
+
+    const avatar = clone.querySelector('.post-avatar');
+    avatar.src = post.avatar;
+    avatar.alt = `${post.author} avatar`;
+    if (post.profileId) {
+      avatar.dataset.profileId = post.profileId;
+    }
+
+    clone.querySelector('.user-name').textContent = post.author;
+    clone.querySelector('.user-handle').textContent = post.handle;
+    clone.querySelector('.timestamp').textContent = formatTime(post.timestamp);
+    clone.dataset.id = post.id;
+    if (post.profileId) {
+      clone.dataset.profileId = post.profileId;
+      clone.querySelector('.post-user').dataset.profileId = post.profileId;
+    }
+
+    clone.querySelector('.post-content').textContent = post.content;
+
+    const mediaEl = clone.querySelector('.post-media');
+    if (post.media) {
+      mediaEl.src = post.media;
+      mediaEl.classList.remove('hidden');
+    } else {
+      mediaEl.classList.add('hidden');
+    }
+
+    const likeButton = clone.querySelector('.like-button');
+    likeButton.querySelector('span').textContent = post.likes;
+    if (post.liked) {
+      likeButton.classList.add('active');
+    }
+
+    const commentToggle = clone.querySelector('.comment-toggle');
+    commentToggle.querySelector('span').textContent = post.comments.length;
+
+    const bookmarkButton = clone.querySelector('.bookmark-button');
+    if (post.bookmarked) {
+      bookmarkButton.classList.add('active');
+    }
+
+    const commentsList = clone.querySelector('.comments-list');
+    post.comments.forEach((comment) => {
+      const commentEl = document.createElement('div');
+      commentEl.className = 'comment';
+      const profileAttr = comment.profileId ? `data-profile-id="${comment.profileId}"` : '';
+      commentEl.innerHTML = `
+        <img class="comment-avatar" src="${comment.avatar}" alt="${comment.author} avatar" ${profileAttr} />
+        <div>
+          <p class="user-name" ${profileAttr}>${comment.author} <span class="user-handle">${comment.handle}</span></p>
+          <p>${comment.content}</p>
+          <p class="timestamp">${formatTime(comment.timestamp)}</p>
+        </div>
+      `;
+      commentsList.appendChild(commentEl);
+    });
+
+    const commentSection = clone.querySelector('.comments');
+    if (openComments.has(post.id)) {
+      commentSection.classList.remove('hidden');
+    } else {
+      commentSection.classList.add('hidden');
+    }
+
+    feedEl.appendChild(clone);
+  });
+
+  const myPosts = posts.filter((post) => post.profileId === MAIN_USER_ID).length;
+  statPosts.textContent = myPosts;
+  if (profiles[MAIN_USER_ID]) {
+    profiles[MAIN_USER_ID].stats.posts = myPosts;
+  }
+
+  refreshOpenProfile();
+};
+
+const setActiveSection = (section) => {
+  if (!section) return;
+  activeSection = section;
+
+  panels.forEach((panel) => {
+    if (panel.id === section) {
+      panel.classList.remove('hidden');
+    } else {
+      panel.classList.add('hidden');
+    }
+  });
+
+  const showFeed = section === 'feed';
+  feedEl.classList.toggle('hidden', !showFeed);
+  if (showFeed) {
+    renderPosts();
+  }
+
+  allSectionButtons.forEach((button) => {
+    if (button.dataset.section === section) {
+      button.classList.add('active');
+    } else {
+      button.classList.remove('active');
+    }
+  });
+
+  closeDrawers();
+  closeUserMenu();
+};
+
+const addPostToFeed = (post) => {
+  posts = [post, ...posts];
+  if (posts.length > MAX_POSTS) {
+    posts = posts.slice(0, MAX_POSTS);
+  }
+  saveState();
+  renderPosts();
+  if (post.profileId === MAIN_USER_ID) {
+    scheduleBotReactionsForPost(post);
+  }
+};
+
+const resetComposer = () => {
+  postContent.value = '';
+  postContent.placeholder = `What's on your mind, ${getMainFirstName()}?`;
+  mediaUpload.value = '';
+  const labelSpan = mediaUpload.closest('label').querySelector('span');
+  labelSpan.textContent = '📷 Add photo';
+};
+
+const handleNewPost = async (event) => {
+  event.preventDefault();
+  const text = postContent.value.trim();
+  if (!text) return;
+
+  const file = mediaUpload.files[0];
+  let mediaUrl = null;
+
+  if (file) {
+    mediaUrl = await new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.readAsDataURL(file);
+    });
+  }
+
+  const profile = getMainProfile();
+
+  const newPost = {
+    id: crypto.randomUUID(),
+    author: profile.name,
+    handle: profile.handle,
+    avatar: profile.avatar,
+    content: text,
+    timestamp: Date.now(),
+    likes: 0,
+    liked: false,
+    bookmarked: false,
+    following: true,
+    media: mediaUrl,
+    comments: [],
+    profileId: MAIN_USER_ID,
+    botReactions: {},
+  };
+
+  addPostToFeed(newPost);
+  resetComposer();
+};
+
+const findPost = (id) => posts.find((post) => post.id === id);
+
+feedEl.addEventListener('click', (event) => {
+  const article = event.target.closest('.post');
+  if (!article) return;
+  const postId = article.dataset.id;
+  const post = findPost(postId);
+  if (!post) return;
+
+  if (event.target.closest('.like-button')) {
+    post.liked = !post.liked;
+    post.likes += post.liked ? 1 : -1;
+    saveState();
+    renderPosts();
+  }
+
+  if (event.target.closest('.bookmark-button')) {
+    post.bookmarked = !post.bookmarked;
+    saveState();
+    renderPosts();
+  }
+
+  if (event.target.closest('.comment-toggle')) {
+    if (openComments.has(post.id)) {
+      openComments.delete(post.id);
+    } else {
+      openComments.add(post.id);
+    }
+    renderPosts();
+  }
+});
+
+feedEl.addEventListener('submit', (event) => {
+  if (!event.target.matches('.comment-form')) return;
+  event.preventDefault();
+
+  const article = event.target.closest('.post');
+  const postId = article.dataset.id;
+  const post = findPost(postId);
+  if (!post) return;
+
+  const input = event.target.querySelector('input[name="comment"]');
+  const text = input.value.trim();
+  if (!text) return;
+
+  const profile = getMainProfile();
+
+  post.comments.push({
+    id: crypto.randomUUID(),
+    author: profile.name,
+    handle: profile.handle,
+    avatar: profile.avatar,
+    content: text,
+    timestamp: Date.now(),
+    profileId: MAIN_USER_ID,
+  });
+
+  input.value = '';
+  saveState();
+  renderPosts();
+});
+
+postForm.addEventListener('submit', handleNewPost);
+
+mediaUpload.addEventListener('change', () => {
+  const labelSpan = mediaUpload.closest('label').querySelector('span');
+  if (!mediaUpload.files[0]) {
+    labelSpan.textContent = '📷 Add photo';
+    return;
+  }
+  const fileName = mediaUpload.files[0].name;
+  labelSpan.textContent = `📷 ${fileName}`;
+});
+
+if (loginForm) {
+  loginForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const email = loginEmail?.value.trim();
+    const password = loginPassword?.value.trim();
+    if (!email || !password) {
+      return;
+    }
+
+    const nameValue = loginName?.value.trim();
+    const displayName = nameValue || getMainProfile().name || baseMainProfile.name;
+    const handleSeed = email.split('@')[0] || displayName.replace(/\s+/g, '');
+    const sanitizedHandle = handleSeed.toLowerCase().replace(/[^a-z0-9]+/g, '');
+    const handle = `@${sanitizedHandle || 'arivers'}`;
+    const avatarSeed = encodeURIComponent(displayName || handle.replace('@', '') || 'SocialSquare');
+    const avatarUrl = `https://avatars.dicebear.com/api/initials/${avatarSeed}.svg`;
+
+    profiles[MAIN_USER_ID] = {
+      ...profiles[MAIN_USER_ID],
+      name: displayName,
+      handle,
+      avatar: avatarUrl,
+    };
+
+    profileHandleLookup[handle] = MAIN_USER_ID;
+
+    persistMainProfile();
+
+    if (rememberMe?.checked) {
+      localStorage.setItem(AUTH_KEY, 'true');
+      sessionStorage.removeItem(SESSION_AUTH_KEY);
+    } else {
+      sessionStorage.setItem(SESSION_AUTH_KEY, 'true');
+      localStorage.removeItem(AUTH_KEY);
+    }
+
+    updateMainUserUI();
+    activeSection = 'feed';
+    setAppVisibility(true);
+    resetComposer();
+    loginForm.reset();
+  });
+}
+
+if (logoutButton) {
+  logoutButton.addEventListener('click', () => {
+    localStorage.removeItem(AUTH_KEY);
+    sessionStorage.removeItem(SESSION_AUTH_KEY);
+    localStorage.removeItem(PROFILE_KEY);
+    profiles[MAIN_USER_ID] = JSON.parse(JSON.stringify(baseMainProfile));
+    profileHandleLookup[profiles[MAIN_USER_ID].handle] = MAIN_USER_ID;
+    updateMainUserUI();
+    activeSection = 'feed';
+    closeUserMenu();
+    closeDrawers();
+    setAppVisibility(false);
+    loginForm?.reset();
+  });
+}
+
+if (search) {
+  search.addEventListener('input', (event) => {
+    const term = event.target.value.toLowerCase();
+    const articles = feedEl.querySelectorAll('.post');
+    articles.forEach((article) => {
+      const content = article.querySelector('.post-content').textContent.toLowerCase();
+      const author = article.querySelector('.user-name').textContent.toLowerCase();
+      const handle = article.querySelector('.user-handle').textContent.toLowerCase();
+      const match = content.includes(term) || author.includes(term) || handle.includes(term);
+      article.classList.toggle('hidden', term && !match);
+    });
+  });
+}
+
+allSectionButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    const { section } = button.dataset;
+    if (section) {
+      setActiveSection(section);
+    }
+  });
+});
+
+navToggleButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    const target = button.dataset.toggleDrawer;
+    const drawer = target === 'sidebar' ? sidebar : target === 'rightbar' ? rightbar : null;
+    if (!drawer) return;
+    if (drawer.classList.contains('is-open')) {
+      closeDrawers();
+    } else {
+      openDrawer(drawer);
+    }
+  });
+});
+
+drawerBackdrop?.addEventListener('click', () => {
+  closeDrawers();
+});
+
+window.addEventListener('resize', () => {
+  if (window.innerWidth > 1024) {
+    closeDrawers();
+  }
+});
+
+if (userMenuToggle) {
+  userMenuToggle.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (userMenu?.classList.contains('hidden')) {
+      openUserMenu();
+    } else {
+      closeUserMenu();
+    }
+  });
+}
+
+const setAppVisibility = (visible) => {
+  if (!authScreen || !appShell) return;
+  if (visible) {
+    closeDrawers();
+    authScreen.classList.add('hidden');
+    appShell.classList.remove('hidden');
+    document.body.classList.remove('auth-visible');
+    updateMainUserUI();
+    setActiveSection(activeSection);
+  } else {
+    authScreen.classList.remove('hidden');
+    appShell.classList.add('hidden');
+    document.body.classList.add('auth-visible');
+    closeDrawers();
+    closeUserMenu();
+  }
+};
+
+const isAuthenticated = () =>
+  localStorage.getItem(AUTH_KEY) === 'true' || sessionStorage.getItem(SESSION_AUTH_KEY) === 'true';
+
+const sharedVocabulary = {
+  emoji: ['✨', '🚀', '🎨', '🌟', '🔥', '💡', '📸', '🤖', '🌿', '🎧'],
+  mood: ['focus', 'momentum', 'curiosity', 'calm energy', 'flow state'],
+  location: [
+    'the downtown studio',
+    'a rooftop workspace',
+    'the light-filled loft',
+    'the co-working lab',
+    'the riverside park bench',
+  ],
+};
+
+const botAccounts = [
+  {
+    id: 'nova-sparks',
+    name: 'Nova Sparks',
+    handle: '@nova.codes',
+    avatar: 'https://avatars.dicebear.com/api/initials/NS.svg',
+    vocabulary: {
+      project: ['NebulaUI', 'LumenKit', 'Pulseboard', 'OrbitOps dashboard'],
+      feature: ['real-time collaboration', 'adaptive theming', 'edge caching'],
+      stack: ['TypeScript', 'Svelte', 'WebGL accents', 'serverless functions'],
+      insight: [
+        'keeping renders at 60fps',
+        'aligning gradients with accessibility',
+        'mapping journeys end-to-end',
+      ],
+    },
+    prompts: [
+      {
+        template: 'Shipped a new {project} build focused on {feature}. {emoji}',
+        likes: [38, 120],
+      },
+      {
+        template: 'Prototyping {project} with a mix of {stack} — {insight}. {emoji}',
+        likes: [24, 80],
+      },
+      {
+        template: "Sneak peek of tomorrow's {project} review from {location}. {emoji}",
+        mediaPool: [
+          'https://images.unsplash.com/photo-1555066931-4365d14bab8c?auto=format&fit=crop&w=1000&q=80',
+          'https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1000&q=80',
+          'https://images.unsplash.com/photo-1551292831-023188e78222?auto=format&fit=crop&w=1000&q=80',
+        ],
+        likes: [42, 130],
+      },
+    ],
+    commentTemplates: [
+      'Big fan of this energy, {name}! {emoji}',
+      'Love how you framed this — totally in sync with {project}. {emoji}',
+      'Bookmarking this for the {mood} playlist later. {emoji}',
+    ],
+  },
+  {
+    id: 'milo-hart',
+    name: 'Milo Hart',
+    handle: '@milohart',
+    avatar: 'https://avatars.dicebear.com/api/initials/MH.svg',
+    vocabulary: {
+      project: ['Wanderlight series', 'City Pulse photo essay', 'Analog Echo zine'],
+      feature: ['soft light', 'long exposures', 'monochrome edits'],
+      journey: ['sunrise ride', 'evening stroll', 'late-night wander'],
+    },
+    prompts: [
+      {
+        template: '{journey} through {location} today — chasing {feature}. {emoji}',
+        mediaPool: [
+          'https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?auto=format&fit=crop&w=1000&q=80',
+          'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1000&q=80',
+          'https://images.unsplash.com/photo-1472214103451-9374bd1c798e?auto=format&fit=crop&w=1000&q=80',
+        ],
+        likes: [55, 160],
+      },
+      {
+        template: 'Sequencing shots for {project}. Keeping notes on {feature}. {emoji}',
+        likes: [31, 90],
+      },
+      {
+        template: 'Printed a proof for {project} — the tones landed exactly where I hoped. {emoji}',
+        likes: [26, 75],
+      },
+    ],
+    commentTemplates: [
+      'This gives me serious inspiration for the next {project} set. {emoji}',
+      'Vibes locked in — thanks for sparking tonight’s {journey}. {emoji}',
+      'Saving this vision board energy, {name}! {emoji}',
+    ],
+  },
+  {
+    id: 'chloe-winters',
+    name: 'Chloe Winters',
+    handle: '@chloewell',
+    avatar: 'https://avatars.dicebear.com/api/initials/CW.svg',
+    vocabulary: {
+      project: ['Quiet Morning playlist', 'Breathwork loop', 'Skyline yoga flow'],
+      feature: ['slow tempo layers', 'grounding cues', 'gentle resets'],
+      ritual: ['sunrise session', 'lunch break reset', 'twilight cooldown'],
+      ingredient: ['citrus + mint water', 'lavender steam', 'eucalyptus mist'],
+    },
+    prompts: [
+      {
+        template: '{ritual} complete with {ingredient}. Drafting notes for {project}. {emoji}',
+        likes: [20, 70],
+      },
+      {
+        template: 'Layered {feature} into the next {project}. {emoji}',
+        likes: [18, 60],
+      },
+      {
+        template: 'Captured the mood board for {project}. {emoji}',
+        mediaPool: [
+          'https://images.unsplash.com/photo-1487412720507-e7ab37603c6f?auto=format&fit=crop&w=1000&q=80',
+          'https://images.unsplash.com/photo-1515871204537-9d3b18b8cdf4?auto=format&fit=crop&w=1000&q=80',
+          'https://images.unsplash.com/photo-1506126613408-eca07ce68773?auto=format&fit=crop&w=1000&q=80',
+        ],
+        likes: [34, 95],
+      },
+    ],
+    commentTemplates: [
+      'Breathing in this perspective — perfect for a {ritual} reset. {emoji}',
+      'Count me in for the next share like this, {name}. {emoji}',
+      'This is the calm spark I needed between sessions. {emoji}',
+    ],
+  },
+];
+
+const buildContent = (template, replacements) =>
+  template.replace(/\{(\w+)\}/g, (_, key) => {
+    const replacement = replacements[key];
+    if (!replacement) return '';
+    if (Array.isArray(replacement)) {
+      return randomChoice(replacement);
+    }
+    if (typeof replacement === 'function') {
+      return replacement();
+    }
+    return replacement;
+  });
+
+const generateBotPost = (bot) => {
+  const prompt = randomChoice(bot.prompts);
+  const replacements = { ...sharedVocabulary, ...bot.vocabulary };
+  let media = null;
+
+  if (prompt.mediaPool && prompt.mediaPool.length > 0) {
+    const shouldAttach = Math.random() > 0.25;
+    if (shouldAttach) {
+      media = randomChoice(prompt.mediaPool);
+    }
+  }
+
+  const content = buildContent(prompt.template, replacements);
+  const likeRange = prompt.likes || [18, 60];
+
+  return {
+    id: crypto.randomUUID(),
+    author: bot.name,
+    handle: bot.handle,
+    avatar: bot.avatar,
+    content,
+    timestamp: Date.now(),
+    likes: randomBetween(likeRange[0], likeRange[1]),
+    liked: false,
+    bookmarked: false,
+    following: true,
+    media,
+    comments: [],
+    profileId: bot.id,
+    botReactions: {},
+  };
+};
+
+const scheduleBotPost = (bot, minDelay, maxDelay) => {
+  const delay = randomBetween(minDelay, maxDelay);
+  setTimeout(() => {
+    const newPost = generateBotPost(bot);
+    addPostToFeed(newPost);
+    scheduleBotPost(bot, BOT_MIN_DELAY, BOT_MAX_DELAY);
+  }, delay);
+};
+
+const initializeBots = () => {
+  botAccounts.forEach((bot) => {
+    scheduleBotPost(bot, BOT_INITIAL_MIN_DELAY, BOT_INITIAL_MAX_DELAY);
+  });
+};
+
+const generateBotComment = (bot) => {
+  if (!bot.commentTemplates || bot.commentTemplates.length === 0) return null;
+  const replacements = {
+    ...sharedVocabulary,
+    ...bot.vocabulary,
+    name: 'Alex',
+  };
+  const template = randomChoice(bot.commentTemplates);
+  const content = buildContent(template, replacements);
+
+  return {
+    id: crypto.randomUUID(),
+    author: bot.name,
+    handle: bot.handle,
+    avatar: bot.avatar,
+    content,
+    timestamp: Date.now(),
+    profileId: bot.id,
+  };
+};
+
+const scheduleBotReactionsForPost = (post) => {
+  botAccounts.forEach((bot) => {
+    const delay = randomBetween(BOT_REACTION_MIN_DELAY, BOT_REACTION_MAX_DELAY);
+    setTimeout(() => {
+      const targetPost = findPost(post.id);
+      if (!targetPost || targetPost.profileId !== MAIN_USER_ID) {
+        return;
+      }
+
+      if (!targetPost.botReactions) {
+        targetPost.botReactions = {};
+      }
+
+      if (targetPost.botReactions[bot.id]) {
+        return;
+      }
+
+      targetPost.likes += randomBetween(1, 3);
+      const comment = generateBotComment(bot);
+      if (comment) {
+        targetPost.comments.push(comment);
+      }
+
+      targetPost.botReactions[bot.id] = true;
+      saveState();
+      renderPosts();
+    }, delay);
+  });
+};
+
+const renderProfileModal = (profileId) => {
+  const profile = profiles[profileId];
+  if (!profile || !profileModalContent) return;
+
+  const friend = isFriend(profileId);
+  const tags = (profile.tags || [])
+    .map((tag) => `<span class="profile-modal__tag">${tag}</span>`)
+    .join('');
+  const stats = profile.stats
+    ? Object.entries(profile.stats)
+        .map(
+          ([label, value]) => `
+            <div class="profile-modal__stat">
+              <span class="profile-modal__stat-value">${value}</span>
+              <span class="stat-label">${label.charAt(0).toUpperCase() + label.slice(1)}</span>
+            </div>
+          `
+        )
+        .join('')
+    : '';
+  const highlights = profile.highlights && profile.highlights.length
+    ? `
+        <section class="profile-modal__section">
+          <h3>Highlights</h3>
+          <ul class="profile-modal__list">
+            ${profile.highlights.map((item) => `<li>${item}</li>`).join('')}
+          </ul>
+        </section>
+      `
+    : '';
+  const focus = profile.focus && profile.focus.length
+    ? `
+        <section class="profile-modal__section">
+          <h3>Focus areas</h3>
+          <ul class="profile-modal__list">
+            ${profile.focus.map((item) => `<li>${item}</li>`).join('')}
+          </ul>
+        </section>
+      `
+    : '';
+  const mutuals = profile.mutuals && profile.mutuals.length
+    ? `
+        <section class="profile-modal__section">
+          <h3>Mutual friends</h3>
+          <ul class="profile-modal__list">
+            ${profile.mutuals.map((item) => `<li>${item}</li>`).join('')}
+          </ul>
+        </section>
+      `
+    : '';
+
+  const friendAction =
+    profileId === MAIN_USER_ID
+      ? '<span class="friend-badge">This is you</span>'
+      : `<button class="secondary ${friend ? 'is-friend' : ''}" data-action="friend" data-profile-id="${profileId}" aria-pressed="${friend}">${friend ? 'Friends' : 'Add friend'}</button>`;
+
+  profileModalContent.innerHTML = `
+    <div class="profile-modal__header">
+      <img src="${profile.avatar}" alt="${profile.name} avatar" />
+      <div class="profile-modal__meta">
+        <h2 id="profileModalTitle">${profile.name}</h2>
+        <p class="user-handle">${profile.handle}</p>
+        ${profile.location ? `<p class="timestamp">${profile.location}</p>` : ''}
+        ${tags ? `<div class="profile-modal__tags">${tags}</div>` : ''}
+      </div>
+    </div>
+    ${profile.bio ? `<p class="profile-modal__bio">${profile.bio}</p>` : ''}
+    <div class="profile-modal__actions">
+      ${friendAction}
+    </div>
+    ${stats ? `<div class="profile-modal__stats">${stats}</div>` : ''}
+    ${highlights}
+    ${focus}
+    ${mutuals}
+  `;
+
+  updateFriendButtons(profileId);
+
+  const friendButton = profileModalContent.querySelector('[data-action="friend"]');
+  if (friendButton) {
+    friendButton.focus({ preventScroll: true });
+  }
+};
+
+const openProfile = (profileId) => {
+  if (!profileOverlay) return;
+  profileOverlay.dataset.profileId = profileId;
+  profileOverlay.classList.remove('hidden');
+  profileOverlay.setAttribute('aria-hidden', 'false');
+  document.body.style.overflow = 'hidden';
+  renderProfileModal(profileId);
+};
+
+const closeProfile = () => {
+  if (!profileOverlay) return;
+  profileOverlay.classList.add('hidden');
+  profileOverlay.setAttribute('aria-hidden', 'true');
+  profileOverlay.dataset.profileId = '';
+  if (profileModalContent) {
+    profileModalContent.innerHTML = '';
+  }
+  document.body.style.overflow = '';
+};
+
+const tabsInit = () => {
+  tabs.forEach((tab) => {
+    tab.addEventListener('click', () => {
+      tabs.forEach((btn) => btn.classList.remove('active'));
+      tab.classList.add('active');
+      activeTab = tab.dataset.tab;
+      renderPosts();
+    });
+  });
+};
+
+tabsInit();
+const initialAuth = isAuthenticated();
+setAppVisibility(initialAuth);
+initializeBots();
+
+posts
+  .filter((post) => post.profileId === MAIN_USER_ID)
+  .forEach((post) => {
+    scheduleBotReactionsForPost(post);
+  });
+
+updateAllFriendButtons();
+
+document.addEventListener('click', (event) => {
+  if (
+    userMenu &&
+    !userMenu.classList.contains('hidden') &&
+    !event.target.closest('.user-menu') &&
+    !event.target.closest('#userMenuToggle')
+  ) {
+    closeUserMenu();
+  }
+
+  const friendButton = event.target.closest('[data-action="friend"]');
+  if (friendButton) {
+    const { profileId } = friendButton.dataset;
+    if (profileId && profileId !== MAIN_USER_ID) {
+      if (isFriend(profileId)) {
+        friends.delete(profileId);
+      } else {
+        friends.add(profileId);
+      }
+      saveFriends();
+      updateFriendButtons(profileId);
+      refreshOpenProfile();
+    }
+    event.stopPropagation();
+    return;
+  }
+
+  const profileTrigger = event.target.closest('[data-profile-id]');
+  if (profileTrigger) {
+    const { profileId } = profileTrigger.dataset;
+    if (profileId) {
+      openProfile(profileId);
+    }
+  }
+});
+
+if (profileOverlay) {
+  profileOverlay.addEventListener('click', (event) => {
+    if (event.target.matches('[data-close-profile]')) {
+      closeProfile();
+    }
+  });
+}
+
+document.addEventListener('keydown', (event) => {
+  if (event.key !== 'Escape') return;
+
+  if (profileOverlay && !profileOverlay.classList.contains('hidden')) {
+    closeProfile();
+    return;
+  }
+
+  if (sidebar?.classList.contains('is-open') || rightbar?.classList.contains('is-open')) {
+    closeDrawers();
+  }
+
+  if (userMenu && !userMenu.classList.contains('hidden')) {
+    closeUserMenu();
+  }
+});

--- a/socialsquare/index.html
+++ b/socialsquare/index.html
@@ -1,0 +1,294 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SocialSquare</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+</head>
+<body>
+  <div class="auth-screen" id="authScreen" aria-labelledby="authTitle">
+    <div class="auth-card">
+      <div class="auth-brand">SocialSquare</div>
+      <h1 id="authTitle">Sign in to keep exploring</h1>
+      <p class="auth-subtitle">Join the conversation from anywhere.</p>
+      <form class="auth-form" id="loginForm">
+        <label class="auth-field">
+          <span>Full name</span>
+          <input type="text" id="loginName" placeholder="Alex Rivers" autocomplete="name" />
+        </label>
+        <label class="auth-field">
+          <span>Email</span>
+          <input type="email" id="loginEmail" placeholder="alex@socialsquare.com" autocomplete="email" required />
+        </label>
+        <label class="auth-field">
+          <span>Password</span>
+          <input type="password" id="loginPassword" placeholder="••••••••" autocomplete="current-password" required />
+        </label>
+        <label class="auth-remember">
+          <input type="checkbox" id="rememberMe" />
+          <span>Keep me signed in</span>
+        </label>
+        <button type="submit" class="primary auth-submit">Sign in</button>
+      </form>
+    </div>
+  </div>
+
+  <div class="app-shell hidden" id="appShell">
+    <header class="topbar">
+      <div class="topbar-left">
+        <button class="icon-button topbar-toggle" data-toggle-drawer="sidebar" aria-label="Toggle navigation">
+          ☰
+        </button>
+        <span class="brand">SocialSquare</span>
+      </div>
+      <div class="topbar-actions">
+        <button class="icon-button topbar-toggle" data-toggle-drawer="rightbar" aria-label="Open explore panel">
+          🔍
+        </button>
+        <button class="avatar-button" id="userMenuToggle" aria-haspopup="true" aria-expanded="false">
+          <img src="https://avatars.dicebear.com/api/initials/AR.svg" alt="" id="topbarAvatar" />
+          <span id="topbarName">Alex</span>
+        </button>
+        <div class="user-menu hidden" id="userMenu" role="menu">
+          <button class="ghost" id="logoutButton" role="menuitem">Log out</button>
+        </div>
+      </div>
+    </header>
+
+    <div class="app-grid">
+      <aside class="sidebar" id="sidebar">
+        <div class="sidebar__scroll">
+          <nav class="menu" aria-label="Primary navigation">
+            <button class="menu-item active" data-section="feed">
+              <span class="menu-icon" aria-hidden="true">🏠</span>
+              <span>Home</span>
+            </button>
+            <button class="menu-item" data-section="messages">
+              <span class="menu-icon" aria-hidden="true">💬</span>
+              <span>Messages</span>
+            </button>
+            <button class="menu-item" data-section="trending">
+              <span class="menu-icon" aria-hidden="true">📈</span>
+              <span>Trending</span>
+            </button>
+            <button class="menu-item" data-section="profile">
+              <span class="menu-icon" aria-hidden="true">👤</span>
+              <span>Profile</span>
+            </button>
+          </nav>
+          <div class="user-card">
+            <img src="https://avatars.dicebear.com/api/initials/AR.svg" alt="Profile avatar" id="sidebarAvatar" />
+            <div>
+              <p class="user-name" id="sidebarName">Alex Rivers</p>
+              <p class="user-handle" id="sidebarHandle">@arivers</p>
+            </div>
+          </div>
+        </div>
+      </aside>
+
+      <main class="main">
+        <header class="main-header">
+          <h1 id="welcomeTitle">Welcome back, Alex</h1>
+          <p>Share a moment, react to friends, and see what's trending.</p>
+        </header>
+
+        <section class="composer" aria-label="Create a post">
+          <form id="postForm">
+            <textarea id="postContent" placeholder="What's on your mind today?" rows="3" required></textarea>
+            <div class="composer-actions">
+              <label class="upload">
+                <input type="file" id="mediaUpload" accept="image/*" />
+                <span>📷 Add photo</span>
+              </label>
+              <button type="submit" class="primary">Share</button>
+            </div>
+          </form>
+        </section>
+
+        <section class="tabs" role="tablist" aria-label="Feed filters">
+          <button class="tab active" data-tab="for-you">For you</button>
+          <button class="tab" data-tab="following">Following</button>
+          <button class="tab" data-tab="bookmarked">Bookmarked</button>
+        </section>
+
+        <section id="feed" class="feed" aria-live="polite"></section>
+
+        <section id="messages" class="panel hidden" aria-live="polite">
+          <h2>Messages</h2>
+          <div class="message-card">
+            <div class="message-card__header">
+              <img src="https://avatars.dicebear.com/api/initials/JD.svg" alt="Avatar" />
+              <div>
+                <p class="user-name">Jamie Doe</p>
+                <p class="timestamp">2h ago</p>
+              </div>
+            </div>
+            <p>Hey Alex! Loved your last post about the design sprint. Let's catch up this week?</p>
+            <div class="message-card__actions">
+              <button class="secondary">Reply</button>
+              <button class="ghost">Mark as read</button>
+            </div>
+          </div>
+          <div class="message-empty">No new messages right now. Send a hello to your friends!</div>
+        </section>
+
+        <section id="trending" class="panel hidden" aria-live="polite">
+          <h2>Trending Topics</h2>
+          <ul class="trending-list">
+            <li>
+              <span>#DesignSystems</span>
+              <span class="trend-count">12k posts</span>
+            </li>
+            <li>
+              <span>#CoffeeChat</span>
+              <span class="trend-count">8.9k posts</span>
+            </li>
+            <li>
+              <span>#ProductLaunch</span>
+              <span class="trend-count">5.3k posts</span>
+            </li>
+            <li>
+              <span>#CityWalks</span>
+              <span class="trend-count">2.1k posts</span>
+            </li>
+          </ul>
+        </section>
+
+        <section id="profile" class="panel hidden" aria-live="polite">
+          <h2>Your Profile</h2>
+          <div class="profile-card">
+            <img src="https://avatars.dicebear.com/api/initials/AR.svg" alt="Profile avatar" id="profileAvatar" />
+            <div>
+              <p class="user-name" id="profileName">Alex Rivers</p>
+              <p class="user-handle" id="profileHandle">@arivers</p>
+              <p class="bio" id="profileBio">Product designer exploring playful experiences. Amateur photographer and tea enthusiast.</p>
+            </div>
+          </div>
+          <div class="profile-stats">
+            <div>
+              <span class="stat-value" id="stat-posts">0</span>
+              <span class="stat-label">Posts</span>
+            </div>
+            <div>
+              <span class="stat-value">1,204</span>
+              <span class="stat-label">Followers</span>
+            </div>
+            <div>
+              <span class="stat-value">536</span>
+              <span class="stat-label">Following</span>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <aside class="rightbar" id="rightbar">
+        <div class="widget search-widget">
+          <input type="search" id="search" placeholder="Search SocialSquare" />
+        </div>
+
+        <div class="widget suggestions">
+          <h3>Who to follow</h3>
+          <div class="suggestion" data-profile-id="lena-nguyen">
+            <img src="https://avatars.dicebear.com/api/initials/LN.svg" alt="Lena" />
+            <div>
+              <p class="user-name">Lena Nguyen</p>
+              <p class="user-handle">@lena.designs</p>
+            </div>
+            <button class="secondary" data-action="friend" data-profile-id="lena-nguyen">Add friend</button>
+          </div>
+          <div class="suggestion" data-profile-id="marcus-clark">
+            <img src="https://avatars.dicebear.com/api/initials/MC.svg" alt="Marcus" />
+            <div>
+              <p class="user-name">Marcus Clark</p>
+              <p class="user-handle">@marcus.codes</p>
+            </div>
+            <button class="secondary" data-action="friend" data-profile-id="marcus-clark">Add friend</button>
+          </div>
+          <div class="suggestion" data-profile-id="sara-malik">
+            <img src="https://avatars.dicebear.com/api/initials/SM.svg" alt="Sara" />
+            <div>
+              <p class="user-name">Sara Malik</p>
+              <p class="user-handle">@saramalik</p>
+            </div>
+            <button class="secondary" data-action="friend" data-profile-id="sara-malik">Add friend</button>
+          </div>
+        </div>
+
+        <div class="widget activity">
+          <h3>Latest Activity</h3>
+          <ul>
+            <li><strong>Jamie</strong> liked your post “Morning light ✨”</li>
+            <li><strong>Taylor</strong> started following you</li>
+            <li><strong>Avery</strong> added a new collection “Urban exploration”</li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+
+    <nav class="mobile-nav" aria-label="Primary navigation">
+      <button class="mobile-nav__item active" data-section="feed">
+        <span aria-hidden="true">🏠</span>
+        <span>Home</span>
+      </button>
+      <button class="mobile-nav__item" data-section="messages">
+        <span aria-hidden="true">💬</span>
+        <span>Messages</span>
+      </button>
+      <button class="mobile-nav__item" data-section="trending">
+        <span aria-hidden="true">📈</span>
+        <span>Trending</span>
+      </button>
+      <button class="mobile-nav__item" data-section="profile">
+        <span aria-hidden="true">👤</span>
+        <span>Profile</span>
+      </button>
+    </nav>
+
+    <div class="drawer-backdrop hidden" id="drawerBackdrop" aria-hidden="true"></div>
+  </div>
+
+  <template id="postTemplate">
+    <article class="post" aria-live="polite">
+      <header class="post-header">
+        <img class="post-avatar" alt="" />
+        <div>
+          <div class="post-user">
+            <span class="user-name"></span>
+            <span class="user-handle"></span>
+          </div>
+          <time class="timestamp"></time>
+        </div>
+        <button class="ghost post-menu" aria-label="More options">⋯</button>
+      </header>
+      <p class="post-content"></p>
+      <img class="post-media hidden" alt="Attached media" />
+      <footer class="post-footer">
+        <button class="ghost like-button">❤️ <span>0</span></button>
+        <button class="ghost comment-toggle">💬 <span>0</span></button>
+        <button class="ghost bookmark-button">🔖</button>
+      </footer>
+      <section class="comments hidden" aria-label="Comments">
+        <div class="comments-list"></div>
+        <form class="comment-form">
+          <input type="text" name="comment" placeholder="Add a comment" required />
+          <button type="submit" class="secondary">Post</button>
+        </form>
+      </section>
+    </article>
+  </template>
+
+  <div class="profile-overlay hidden" id="profileOverlay" aria-hidden="true">
+    <div class="profile-overlay__backdrop" data-close-profile></div>
+    <div class="profile-modal" role="dialog" aria-modal="true" aria-labelledby="profileModalTitle">
+      <button class="ghost profile-modal__close" data-close-profile aria-label="Close profile">✕</button>
+      <div id="profileModalContent"></div>
+    </div>
+  </div>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/socialsquare/styles.css
+++ b/socialsquare/styles.css
@@ -1,0 +1,968 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f6f7fb;
+  --surface: #ffffff;
+  --surface-dark: #101823;
+  --primary: #5b5bd6;
+  --primary-dark: #818cf8;
+  --text: #1c1f26;
+  --muted: #5b6070;
+  --border: #dbe0ea;
+  --radius: 18px;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: linear-gradient(160deg, rgba(91, 91, 214, 0.1), transparent 55%), var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+body.drawer-open {
+  overflow: hidden;
+}
+
+body.auth-visible {
+  overflow: hidden;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+button {
+  font: inherit;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.auth-screen {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(12, 19, 32, 0.68);
+  backdrop-filter: blur(18px);
+  z-index: 200;
+}
+
+.auth-card {
+  background: var(--surface);
+  border-radius: 28px;
+  padding: 48px 42px;
+  width: min(420px, 100%);
+  box-shadow: 0 28px 80px rgba(15, 23, 42, 0.16);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.auth-brand {
+  font-weight: 700;
+  font-size: 1.75rem;
+  color: var(--primary);
+}
+
+.auth-subtitle {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.auth-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.auth-field input {
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  padding: 12px 16px;
+  font: inherit;
+}
+
+.auth-field input:focus {
+  outline: 2px solid rgba(91, 91, 214, 0.3);
+  outline-offset: 2px;
+}
+
+.auth-remember {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.auth-submit {
+  width: 100%;
+}
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  width: min(1180px, 100%);
+  margin: 0 auto;
+  padding: 24px 24px 100px;
+  gap: 24px;
+  min-height: 100vh;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 16px 22px;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+  position: sticky;
+  top: 16px;
+  z-index: 50;
+}
+
+.topbar-left {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  position: relative;
+}
+
+.icon-button {
+  border: none;
+  background: rgba(91, 91, 214, 0.12);
+  color: var(--primary);
+  border-radius: 50%;
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.icon-button:hover {
+  background: rgba(91, 91, 214, 0.2);
+  transform: translateY(-1px);
+}
+
+.avatar-button {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 999px;
+  transition: background 0.2s ease;
+}
+
+.avatar-button:hover {
+  background: rgba(91, 91, 214, 0.12);
+}
+
+.avatar-button img {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+}
+
+.user-menu {
+  position: absolute;
+  top: calc(100% + 12px);
+  right: 0;
+  background: var(--surface);
+  border-radius: 18px;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.14);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 160px;
+  z-index: 60;
+}
+
+.user-menu .ghost {
+  justify-content: flex-start;
+}
+
+.app-grid {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr) 300px;
+  gap: 24px;
+  flex: 1;
+  align-items: start;
+}
+
+.sidebar,
+.rightbar,
+.main {
+  background: var(--surface);
+  border-radius: var(--radius);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  padding: 24px;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  min-height: 0;
+}
+
+.sidebar__scroll {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-height: calc(100vh - 200px);
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.sidebar__scroll::-webkit-scrollbar {
+  width: 6px;
+}
+
+.sidebar__scroll::-webkit-scrollbar-thumb {
+  background: rgba(91, 91, 214, 0.25);
+  border-radius: 999px;
+}
+
+.menu {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.menu-item {
+  border: none;
+  background: transparent;
+  text-align: left;
+  padding: 12px 16px;
+  border-radius: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.menu-item .menu-icon {
+  font-size: 1.1rem;
+}
+
+.menu-item:hover,
+.menu-item.active {
+  background: rgba(91, 91, 214, 0.12);
+  color: var(--primary);
+}
+
+.user-card {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(91, 91, 214, 0.08);
+}
+
+.user-card img,
+.post-avatar,
+.profile-card img,
+.suggestion img {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+}
+
+.user-name {
+  font-weight: 600;
+}
+
+.user-handle,
+.timestamp,
+.stat-label {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  min-height: 0;
+}
+
+.main-header h1 {
+  font-size: 2rem;
+  margin-bottom: 8px;
+}
+
+.composer {
+  background: rgba(91, 91, 214, 0.08);
+  border-radius: 16px;
+  padding: 18px;
+}
+
+#postContent {
+  width: 100%;
+  border: none;
+  padding: 8px;
+  border-radius: 12px;
+  resize: vertical;
+  font-family: inherit;
+  font-size: 1rem;
+  min-height: 72px;
+}
+
+#postContent:focus {
+  outline: 2px solid rgba(91, 91, 214, 0.35);
+}
+
+.upload input[type="file"] {
+  display: none;
+}
+
+.composer-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 12px;
+  gap: 16px;
+}
+
+.primary,
+.secondary,
+.ghost {
+  border-radius: 999px;
+  padding: 10px 18px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.primary {
+  background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+  color: white;
+  box-shadow: 0 10px 20px rgba(91, 91, 214, 0.25);
+}
+
+.primary:hover {
+  transform: translateY(-1px);
+}
+
+.secondary {
+  background: rgba(91, 91, 214, 0.15);
+  color: var(--primary);
+}
+
+.secondary.is-friend {
+  background: rgba(16, 196, 119, 0.18);
+  color: #047857;
+}
+
+.ghost {
+  background: transparent;
+  color: var(--muted);
+}
+
+.tabs {
+  display: flex;
+  gap: 12px;
+}
+
+.tab {
+  border: none;
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: rgba(91, 91, 214, 0.08);
+  color: var(--muted);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.tab.active {
+  background: var(--primary);
+  color: white;
+}
+
+.feed {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.empty {
+  padding: 40px;
+  border-radius: 18px;
+  text-align: center;
+  color: var(--muted);
+  background: rgba(91, 91, 214, 0.08);
+}
+
+.post {
+  padding: 20px;
+  border-radius: 18px;
+  background: linear-gradient(120deg, rgba(91, 91, 214, 0.1), transparent 50%), var(--surface);
+  border: 1px solid rgba(91, 91, 214, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.post-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.post-user {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.post-user:hover .user-name {
+  color: var(--primary);
+}
+
+.post-avatar {
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.post-avatar:hover {
+  transform: translateY(-1px) scale(1.02);
+}
+
+.post-media {
+  width: 100%;
+  border-radius: 16px;
+  object-fit: cover;
+  max-height: 280px;
+}
+
+.post-footer {
+  display: flex;
+  gap: 16px;
+}
+
+.like-button.active {
+  color: #ef4444;
+}
+
+.bookmark-button.active {
+  color: #f59e0b;
+}
+
+.comments {
+  border-top: 1px solid rgba(91, 91, 214, 0.15);
+  padding-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.comment {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.comment .comment-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.comment .user-name {
+  display: inline-flex;
+  gap: 4px;
+  cursor: pointer;
+}
+
+.comment .user-name:hover {
+  color: var(--primary);
+}
+
+.comment-form {
+  display: flex;
+  gap: 8px;
+}
+
+.comment-form input {
+  flex: 1;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  padding: 8px 14px;
+  font: inherit;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.message-card {
+  padding: 18px;
+  border-radius: 16px;
+  border: 1px solid rgba(91, 91, 214, 0.12);
+  background: rgba(91, 91, 214, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.message-card__header {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.message-card__actions {
+  display: flex;
+  gap: 12px;
+}
+
+.message-empty {
+  color: var(--muted);
+}
+
+.trending-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.trending-list li {
+  display: flex;
+  justify-content: space-between;
+}
+
+.trend-count {
+  color: var(--muted);
+}
+
+.rightbar {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.widget {
+  background: rgba(91, 91, 214, 0.06);
+  padding: 18px;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.search-widget input {
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  padding: 10px 16px;
+  font: inherit;
+}
+
+.suggestions {
+  gap: 16px;
+}
+
+.suggestion {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.activity ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  color: var(--muted);
+}
+
+.profile-card {
+  display: flex;
+  gap: 18px;
+  align-items: center;
+}
+
+.profile-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.stat-value {
+  font-weight: 700;
+  font-size: 1.25rem;
+}
+
+.drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(6px);
+  z-index: 30;
+}
+
+.mobile-nav {
+  display: none;
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 12px 18px calc(env(safe-area-inset-bottom) + 16px);
+  background: var(--surface);
+  border-radius: 24px 24px 0 0;
+  box-shadow: 0 -12px 40px rgba(15, 23, 42, 0.18);
+  justify-content: space-between;
+  z-index: 35;
+  gap: 8px;
+}
+
+.mobile-nav__item {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-weight: 600;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 6px;
+}
+
+.mobile-nav__item.active {
+  background: rgba(91, 91, 214, 0.15);
+  color: var(--primary);
+}
+
+.profile-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.profile-overlay__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.profile-modal {
+  position: relative;
+  background: var(--surface);
+  padding: 32px;
+  border-radius: 24px;
+  width: min(640px, 92%);
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.35);
+}
+
+.profile-modal__close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+}
+
+.profile-modal__header {
+  display: flex;
+  gap: 18px;
+}
+
+.profile-modal__header img {
+  width: 82px;
+  height: 82px;
+  border-radius: 24px;
+}
+
+.profile-modal__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.profile-modal__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.profile-modal__tag {
+  background: rgba(91, 91, 214, 0.12);
+  color: var(--primary);
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+
+.profile-modal__bio {
+  margin: 16px 0;
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+.profile-modal__actions {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.profile-modal__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.profile-modal__stat {
+  display: flex;
+  flex-direction: column;
+  background: rgba(91, 91, 214, 0.08);
+  padding: 12px;
+  border-radius: 16px;
+  gap: 4px;
+}
+
+.profile-modal__stat-value {
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.profile-modal__section {
+  margin-top: 16px;
+}
+
+.profile-modal__section h3 {
+  font-size: 1rem;
+  margin-bottom: 8px;
+}
+
+.profile-modal__list {
+  list-style: disc;
+  margin-left: 20px;
+  color: var(--muted);
+  display: grid;
+  gap: 6px;
+}
+
+.friend-badge {
+  background: rgba(91, 91, 214, 0.12);
+  color: var(--primary);
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+@media (max-width: 1200px) {
+  .app-grid {
+    grid-template-columns: 220px minmax(0, 1fr);
+  }
+
+  .rightbar {
+    grid-column: span 2;
+  }
+}
+
+@media (max-width: 1024px) {
+  .app-shell {
+    padding: 20px 20px 120px;
+  }
+
+  .app-grid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 20px;
+  }
+
+  .sidebar,
+  .rightbar {
+    position: fixed;
+    top: 88px;
+    width: min(320px, calc(100% - 32px));
+    max-height: calc(100vh - 104px);
+    overflow-y: auto;
+    transform: translateX(-110%);
+    opacity: 0;
+    pointer-events: none;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+    z-index: 40;
+  }
+
+  .rightbar {
+    right: 16px;
+    left: auto;
+    transform: translateX(110%);
+  }
+
+  .sidebar {
+    left: 16px;
+  }
+
+  .sidebar.is-open,
+  .rightbar.is-open {
+    transform: translateX(0);
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .sidebar__scroll {
+    max-height: calc(100vh - 160px);
+  }
+
+  .drawer-backdrop {
+    backdrop-filter: blur(8px);
+  }
+}
+
+@media (max-width: 880px) {
+  .main-header h1 {
+    font-size: 1.8rem;
+  }
+
+  .composer {
+    padding: 16px;
+  }
+
+  .post {
+    padding: 18px;
+  }
+}
+
+@media (max-width: 768px) {
+  .app-shell {
+    padding-bottom: calc(140px + env(safe-area-inset-bottom));
+  }
+
+  .topbar {
+    top: 12px;
+  }
+
+  .mobile-nav {
+    display: flex;
+  }
+
+  .tabs {
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .tabs::-webkit-scrollbar {
+    display: none;
+  }
+
+  .post-footer {
+    flex-wrap: wrap;
+  }
+
+  .comment-form {
+    flex-direction: column;
+  }
+
+  .comment-form input,
+  .comment-form button {
+    width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-shell {
+    padding: 16px 16px calc(130px + env(safe-area-inset-bottom));
+  }
+
+  .sidebar,
+  .rightbar,
+  .main {
+    padding: 18px;
+  }
+
+  .main-header h1 {
+    font-size: 1.6rem;
+  }
+
+  .profile-card {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+}
+
+@media (max-width: 520px) {
+  .auth-card {
+    padding: 36px 28px;
+  }
+
+  .post {
+    padding: 16px;
+  }
+
+  .profile-modal {
+    padding: 24px;
+  }
+
+  .profile-modal__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a login overlay, compact top navigation, and mobile controls to the SocialSquare layout
- overhaul styling with responsive grid, drawers, and mobile navigation to deliver a full-width experience
- wire authentication persistence, adaptive profile data, and drawer/menu toggles in the feed logic

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e3ea0b6c908322a2356678f1adc1b0