### PR TITLE
Rebuild mobile overrated swipe deck

### DIFF
--- a/overrated/data.js
+++ b/overrated/data.js
@@ -1,0 +1,490 @@
+(function () {
+  const subjects = [
+    {
+      id: "taylor-swift",
+      name: "Taylor Swift",
+      type: "Artist",
+      year: 2024,
+      origin: "Claim to fame · The Eras Tour",
+      description:
+        "Selling out stadiums worldwide and resetting every streaming record. Cultural icon or hype machine?",
+      stats: [
+        { icon: "🎟️", label: "Tour stops", value: "146" },
+        { icon: "💿", label: "Albums", value: "10" }
+      ],
+      accent:
+        "radial-gradient(circle at top, rgba(255, 180, 215, 0.4), transparent 70%)",
+      image:
+        "https://images.unsplash.com/photo-1514525253161-7a46d19cd819?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Taylor Swift performing on stage",
+      overratedScore: 88
+    },
+    {
+      id: "barbie-film",
+      name: "Barbie",
+      type: "Movie",
+      year: 2023,
+      origin: "Directed by · Greta Gerwig",
+      description:
+        "The candy-colored blockbuster that turned every theater pink. Satire genius or marketing juggernaut?",
+      stats: [
+        { icon: "🍿", label: "Box office", value: "$1.4B" },
+        { icon: "🏆", label: "Oscars", value: "8 noms" }
+      ],
+      accent:
+        "radial-gradient(circle at top left, rgba(255, 192, 203, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1570378164207-c63f4e4f5659?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Moviegoers in a cinema lit by pink light",
+      overratedScore: 82
+    },
+    {
+      id: "drake",
+      name: "Drake",
+      type: "Artist",
+      year: 2024,
+      origin: "Latest era · For All the Dogs",
+      description:
+        "Every drop dominates playlists, but fans say the formula's wearing thin. Still unstoppable or time for a reset?",
+      stats: [
+        { icon: "🎧", label: "Monthly listeners", value: "67M" },
+        { icon: "🏆", label: "No.1 singles", value: "13" }
+      ],
+      accent:
+        "radial-gradient(circle at bottom right, rgba(120, 180, 255, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1470229722913-7c0e2dbbafd3?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Rapper performing under blue stage lights",
+      overratedScore: 79
+    },
+    {
+      id: "oppenheimer",
+      name: "Oppenheimer",
+      type: "Movie",
+      year: 2023,
+      origin: "Director · Christopher Nolan",
+      description:
+        "Three hours of prestige filmmaking that became a meme. Historic masterpiece or overblown awards bait?",
+      stats: [
+        { icon: "📽️", label: "Runtime", value: "181 min" },
+        { icon: "⭐", label: "IMDb", value: "8.3" }
+      ],
+      accent:
+        "radial-gradient(circle at center, rgba(255, 190, 120, 0.4), transparent 65%)",
+      image:
+        "https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Film reel projectors glowing in a dark room",
+      overratedScore: 74
+    },
+    {
+      id: "fortnite",
+      name: "Fortnite",
+      type: "Game",
+      year: 2024,
+      origin: "Built by · Epic Games",
+      description:
+        "Concerts, brand collabs, and battle royale chaos. Still a cultural hub or a bloated crossover platform?",
+      stats: [
+        { icon: "🕹️", label: "Players", value: "70M monthly" },
+        { icon: "🎉", label: "Collabs", value: "160+" }
+      ],
+      accent:
+        "radial-gradient(circle at top right, rgba(140, 120, 255, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1542751110-97427bbecf20?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Person playing a colorful video game on a monitor",
+      overratedScore: 77
+    },
+    {
+      id: "olivia-rodrigo",
+      name: "Olivia Rodrigo",
+      type: "Artist",
+      year: 2023,
+      origin: "Sophomore album · GUTS",
+      description:
+        "Pop-punk revival for a new generation. Breakout authenticity or derivative diary entries?",
+      stats: [
+        { icon: "🎤", label: "World tour", value: "75 dates" },
+        { icon: "💜", label: "Grammy wins", value: "3" }
+      ],
+      accent:
+        "radial-gradient(circle at bottom left, rgba(200, 140, 255, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1517582082532-16c4d649c5ed?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Singer on stage with purple lighting",
+      overratedScore: 71
+    },
+    {
+      id: "last-of-us",
+      name: "The Last of Us",
+      type: "Series",
+      year: 2023,
+      origin: "HBO adaptation · Season 1",
+      description:
+        "Game-to-TV finally done right or prestige horror coasting on nostalgia?",
+      stats: [
+        { icon: "🧟", label: "Infected count", value: "Too many" },
+        { icon: "📺", label: "Viewers", value: "30M" }
+      ],
+      accent:
+        "radial-gradient(circle at bottom, rgba(120, 170, 140, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Overgrown city street at dusk",
+      overratedScore: 73
+    },
+    {
+      id: "ariana-grande",
+      name: "Ariana Grande",
+      type: "Artist",
+      year: 2024,
+      origin: "New era · Eternal Sunshine",
+      description:
+        "Whistle tones and pop perfection or playlist wallpaper at this point?",
+      stats: [
+        { icon: "🎧", label: "Streams", value: "42B" },
+        { icon: "🏆", label: "Awards", value: "9" }
+      ],
+      accent:
+        "radial-gradient(circle at top left, rgba(255, 210, 170, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1540573133985-87b6da6d54a9?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Pop singer silhouetted under pink lights",
+      overratedScore: 69
+    },
+    {
+      id: "stranger-things",
+      name: "Stranger Things",
+      type: "Series",
+      year: 2022,
+      origin: "Season 4 · Netflix",
+      description:
+        "Still the king of synth nostalgia or stuck in the Upside Down of fan service?",
+      stats: [
+        { icon: "👾", label: "Demogorgons", value: "Many" },
+        { icon: "📈", label: "Hours viewed", value: "1.4B" }
+      ],
+      accent:
+        "radial-gradient(circle at center, rgba(255, 90, 90, 0.4), transparent 65%)",
+      image:
+        "https://images.unsplash.com/photo-1478720568477-152d9b164e26?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Retro neon lights and fog",
+      overratedScore: 70
+    },
+    {
+      id: "marvel-phase5",
+      name: "Marvel Phase Five",
+      type: "Franchise",
+      year: 2025,
+      origin: "Saga status · Multiverse",
+      description:
+        "Superhero fatigue or still unstoppable? Another crossover avalanche waits.",
+      stats: [
+        { icon: "🎬", label: "Projects", value: "12" },
+        { icon: "🌌", label: "Timelines", value: "Infinite" }
+      ],
+      accent:
+        "radial-gradient(circle at top, rgba(160, 220, 255, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Stack of colorful superhero comic books",
+      overratedScore: 86
+    },
+    {
+      id: "doja-cat",
+      name: "Doja Cat",
+      type: "Artist",
+      year: 2024,
+      origin: "Scarlet era · Planet Doja",
+      description:
+        "Genre shapeshifter or internet troll turned pop staple?",
+      stats: [
+        { icon: "📱", label: "TikTok sounds", value: "310" },
+        { icon: "🎤", label: "Headliners", value: "25" }
+      ],
+      accent:
+        "radial-gradient(circle at bottom right, rgba(255, 110, 170, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1515162305280-7d34aac4ef74?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Singer with pink lighting on stage",
+      overratedScore: 65
+    },
+    {
+      id: "billie-eilish",
+      name: "Billie Eilish",
+      type: "Artist",
+      year: 2024,
+      origin: "Hit single · What Was I Made For?",
+      description:
+        "Whisper pop innovator or mood-board mainstay?",
+      stats: [
+        { icon: "🎧", label: "Streams", value: "36B" },
+        { icon: "🏆", label: "Grammys", value: "7" }
+      ],
+      accent:
+        "radial-gradient(circle at top right, rgba(120, 255, 200, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1487412720507-e7ab37603c6f?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Musician bathed in green lights",
+      overratedScore: 64
+    },
+    {
+      id: "dune-two",
+      name: "Dune: Part Two",
+      type: "Movie",
+      year: 2024,
+      origin: "Directed by · Denis Villeneuve",
+      description:
+        "Sci-fi opera perfection or sandworm slog?",
+      stats: [
+        { icon: "🏜️", label: "Arrakis scenes", value: "Plenty" },
+        { icon: "🍿", label: "Box office", value: "$712M" }
+      ],
+      accent:
+        "radial-gradient(circle at bottom left, rgba(255, 200, 150, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1520358231651-08d28e5f16ff?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Desert landscape at sunset",
+      overratedScore: 68
+    },
+    {
+      id: "wednesday-netflix",
+      name: "Wednesday",
+      type: "Series",
+      year: 2022,
+      origin: "Netflix hit · Season 1",
+      description:
+        "Goth girl revival or TikTok-core fad?",
+      stats: [
+        { icon: "🕺", label: "Dance edits", value: "250K" },
+        { icon: "📺", label: "Hours viewed", value: "1.7B" }
+      ],
+      accent:
+        "radial-gradient(circle at top left, rgba(120, 120, 255, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1522770179533-24471fcdba45?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Gothic hallway with purple lighting",
+      overratedScore: 67
+    },
+    {
+      id: "bad-bunny",
+      name: "Bad Bunny",
+      type: "Artist",
+      year: 2024,
+      origin: "World tour · Most Wanted",
+      description:
+        "Reggaeton revolutionary or festival mainstay fatigue?",
+      stats: [
+        { icon: "🌎", label: "Tour cities", value: "45" },
+        { icon: "💿", label: "Albums", value: "5" }
+      ],
+      accent:
+        "radial-gradient(circle at center, rgba(255, 170, 110, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1470225620780-dba8ba36b745?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Singer jumping on stage with orange lights",
+      overratedScore: 72
+    },
+    {
+      id: "zelda-totk",
+      name: "Tears of the Kingdom",
+      type: "Game",
+      year: 2023,
+      origin: "Legend of Zelda · Nintendo",
+      description:
+        "Open-world mastery or crafting grind overload?",
+      stats: [
+        { icon: "🗺️", label: "Map size", value: "2x Hyrule" },
+        { icon: "🛠️", label: "Fuse combos", value: "Infinite" }
+      ],
+      accent:
+        "radial-gradient(circle at top right, rgba(110, 210, 180, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Person holding a game controller near a TV",
+      overratedScore: 60
+    },
+    {
+      id: "cybertruck",
+      name: "Cybertruck",
+      type: "Product",
+      year: 2024,
+      origin: "Tesla · Stainless steel hype",
+      description:
+        "Future-proof utility or meme-worthy wedge on wheels?",
+      stats: [
+        { icon: "⚡", label: "Range", value: "340 mi" },
+        { icon: "💰", label: "Price", value: "$61K" }
+      ],
+      accent:
+        "radial-gradient(circle at center, rgba(180, 180, 200, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1525609004556-c46c7d6cf023?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Futuristic silver vehicle in a studio",
+      overratedScore: 90
+    },
+    {
+      id: "post-malone",
+      name: "Post Malone",
+      type: "Artist",
+      year: 2024,
+      origin: "Tour · If Y'all Weren't Here",
+      description:
+        "Genre-blending superstar or playlist wallpaper?",
+      stats: [
+        { icon: "🎤", label: "Headlining years", value: "8" },
+        { icon: "💿", label: "Albums", value: "5" }
+      ],
+      accent:
+        "radial-gradient(circle at bottom, rgba(255, 200, 170, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1507874457470-272b3c8d8ee2?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Singer with microphone on a smoky stage",
+      overratedScore: 63
+    },
+    {
+      id: "erastourfilm",
+      name: "Eras Tour (Film)",
+      type: "Movie",
+      year: 2023,
+      origin: "Concert film · AMC",
+      description:
+        "Concert cinema revolution or deluxe merch drop?",
+      stats: [
+        { icon: "🎬", label: "Runtime", value: "169 min" },
+        { icon: "🍿", label: "Domestic gross", value: "$180M" }
+      ],
+      accent:
+        "radial-gradient(circle at top, rgba(255, 140, 200, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1506157786151-b8491531f063?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Crowd at a concert with colorful confetti",
+      overratedScore: 83
+    },
+    {
+      id: "grammy-awards",
+      name: "Grammy Awards",
+      type: "Event",
+      year: 2024,
+      origin: "Music industry · 66th ceremony",
+      description:
+        "Cultural barometer or industry echo chamber?",
+      stats: [
+        { icon: "🏆", label: "Categories", value: "94" },
+        { icon: "🎤", label: "Performances", value: "18" }
+      ],
+      accent:
+        "radial-gradient(circle at top right, rgba(255, 215, 130, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1511671782779-c97d3d27a1d4?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Golden microphone standing under stage lights",
+      overratedScore: 78
+    },
+    {
+      id: "coachella",
+      name: "Coachella",
+      type: "Event",
+      year: 2024,
+      origin: "Empire Polo Club · Indio",
+      description:
+        "Festival mecca or influencer backdrop?",
+      stats: [
+        { icon: "🎡", label: "Stages", value: "8" },
+        { icon: "🎟️", label: "Attendees", value: "250K" }
+      ],
+      accent:
+        "radial-gradient(circle at bottom right, rgba(255, 170, 120, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1521334884684-d80222895322?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Festival crowd at sunset with ferris wheel",
+      overratedScore: 84
+    },
+    {
+      id: "ai-generated-songs",
+      name: "AI-Generated Songs",
+      type: "Trend",
+      year: 2024,
+      origin: "Cloned vocals · Viral remixes",
+      description:
+        "Creative revolution or uncanny valley earworms?",
+      stats: [
+        { icon: "🤖", label: "Model drops", value: "420" },
+        { icon: "🎧", label: "Streams", value: "2.3B" }
+      ],
+      accent:
+        "radial-gradient(circle at top, rgba(170, 200, 255, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Producer working at a laptop with headphones",
+      overratedScore: 87
+    },
+    {
+      id: "barbenheimer",
+      name: "Barbenheimer",
+      type: "Trend",
+      year: 2023,
+      origin: "Double feature · Meme weekend",
+      description:
+        "Cinema event of the decade or marketing coincidence?",
+      stats: [
+        { icon: "🎬", label: "Tickets", value: "200M" },
+        { icon: "💬", label: "Memes", value: "Countless" }
+      ],
+      accent:
+        "radial-gradient(circle at center, rgba(255, 120, 160, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1524985069026-dd778a71c7b4?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "People in a movie theater holding popcorn",
+      overratedScore: 76
+    },
+    {
+      id: "mario-movie",
+      name: "Super Mario Bros. Movie",
+      type: "Movie",
+      year: 2023,
+      origin: "Nintendo · Illumination",
+      description:
+        "Pixel-perfect fan service or safe cash-in?",
+      stats: [
+        { icon: "🍄", label: "Box office", value: "$1.3B" },
+        { icon: "⭐", label: "Audience", value: "95%" }
+      ],
+      accent:
+        "radial-gradient(circle at bottom right, rgba(255, 210, 120, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Arcade machine glowing in the dark",
+      overratedScore: 66
+    },
+    {
+      id: "adele-vegas",
+      name: "Adele: Weekends with Adele",
+      type: "Live Show",
+      year: 2024,
+      origin: "Las Vegas Residency",
+      description:
+        "Intimate vocal clinic or spendy pilgrimage?",
+      stats: [
+        { icon: "🎙️", label: "Shows", value: "68" },
+        { icon: "💸", label: "Avg ticket", value: "$600" }
+      ],
+      accent:
+        "radial-gradient(circle at top, rgba(240, 200, 150, 0.45), transparent 60%)",
+      image:
+        "https://images.unsplash.com/photo-1529158062015-cad636e69505?auto=format&fit=crop&w=720&q=80",
+      imageAlt: "Spotlight on a singer in a theater",
+      overratedScore: 75
+    }
+  ];
+
+  window.OVERRATED_SUBJECTS = Object.freeze(
+    subjects.map((subject) =>
+      Object.freeze({
+        ...subject,
+        stats: Object.freeze(
+          subject.stats.map((stat) => Object.freeze({ ...stat }))
+        )
+      })
+    )
+  );
+})();

--- a/overrated/index.html
+++ b/overrated/index.html
@@ -2,113 +2,73 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="A tongue-in-cheek look at the most overrated video game trends."
+      content="Swipe through culture's biggest talking points and decide if they're overrated."
     />
-    <title>Overrated | JBT Games</title>
+    <title>Overrated? | Swipe to vote</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <header>
-      <h1>Overrated</h1>
-      <p>
-        A lovingly sarcastic tribute to the trends that dominate the gaming
-        scene. Tap on a card to discover why these fads deserve a time-out.
-      </p>
-    </header>
-
-    <main>
-      <article class="game-card">
-        <h2>Endless Battle Passes</h2>
-        <div class="game-meta">
-          <span class="meta-pill">grind fatigue</span>
-          <span>Introduced: 2017</span>
-          <span>Popularized by: Fortnite &amp; friends</span>
-        </div>
-        <p>
-          Battle passes promised rewarding progression, but the modern reality is
-          more like a part-time job.
+    <main class="layout">
+      <header class="masthead" role="banner">
+        <p class="masthead-tag">Hot takes only</p>
+        <h1 class="masthead-title">Overrated<span>?</span></h1>
+        <p class="masthead-copy">
+          One subject, one vote. Swipe through the feed and decide whether the hype is
+          deserved.
         </p>
-        <button class="toggle" aria-expanded="false" type="button">
-          Why it's overrated
-        </button>
-        <div class="toggle-panel" id="battle-pass-panel">
-          <p>
-            The pressure to log in daily can turn a hobby into a chore.
-            Meanwhile, the rewards often feel like virtual clutter.
-          </p>
-          <ul class="reasons">
-            <li>Artificial fear-of-missing-out tactics.</li>
-            <li>Confusing currencies and tier unlocks.</li>
-            <li>Cosmetics that rarely feel worth the grind.</li>
-          </ul>
-        </div>
-      </article>
-
-      <article class="game-card">
-        <h2>Ultra-Realistic Mud Physics</h2>
-        <div class="game-meta">
-          <span class="meta-pill">tech flex</span>
-          <span>Introduced: 2015</span>
-          <span>Popularized by: Racing sims</span>
-        </div>
-        <p>
-          Yes, the mud looks fantastic. No, it does not make the gameplay more
-          exciting.
+        <p class="masthead-progress" aria-live="polite">
+          <span id="progress-current">0</span>
+          <span class="progress-divider">of</span>
+          <span id="progress-total">0</span>
         </p>
-        <button class="toggle" aria-expanded="false" type="button">
-          Why it's overrated
-        </button>
-        <div class="toggle-panel" id="mud-physics-panel">
-          <p>
-            When studios brag about dirt realism more than track design, maybe
-            priorities need a patch.
-          </p>
-          <ul class="reasons">
-            <li>The novelty wears off after the first splash.</li>
-            <li>Often masks lackluster vehicle handling.</li>
-            <li>Consumes dev time better spent on smarter AI.</li>
-          </ul>
-        </div>
-      </article>
+      </header>
 
-      <article class="game-card">
-        <h2>Non-Stop Cinematic Cutscenes</h2>
-        <div class="game-meta">
-          <span class="meta-pill">passive play</span>
-          <span>Introduced: 2001</span>
-          <span>Popularized by: Prestige action titles</span>
+      <section class="swipe-zone" aria-label="Swipe through culture picks">
+        <div class="card-wrapper" id="card-wrapper">
+          <article class="card current" id="card-current"></article>
+          <article class="card standby" id="card-standby" aria-hidden="true"></article>
         </div>
-        <p>
-          Games that forget to let you actually play them? A bold creative
-          choice, sure.
-        </p>
-        <button class="toggle" aria-expanded="false" type="button">
-          Why it's overrated
-        </button>
-        <div class="toggle-panel" id="cutscene-panel">
-          <p>
-            Storytelling is great, but skipping 12-minute cutscenes to get back
-            to the action should not feel like a crime.
+        <div class="actions" role="group" aria-label="Cast your vote">
+          <button class="action action-no" id="action-no" type="button">
+            <span aria-hidden="true">👎</span>
+            <span class="action-label">Not overrated</span>
+          </button>
+          <button class="action action-yes" id="action-yes" type="button">
+            <span aria-hidden="true">🔥</span>
+            <span class="action-label">Overrated</span>
+          </button>
+        </div>
+      </section>
+
+      <section class="leaderboard" aria-label="Most overrated right now">
+        <div class="leaderboard-shell">
+          <h2 class="leaderboard-title">Most overrated right now</h2>
+          <p class="leaderboard-copy">
+            Scores update from the same deck you're swiping.
           </p>
-          <ul class="reasons">
-            <li>Breaks the pacing and immersion.</li>
-            <li>Disrespects player agency.</li>
-            <li>Unskippable scenes are the real boss fights.</li>
-          </ul>
+          <ol class="leaderboard-list" id="leaderboard-list"></ol>
+          <p class="leaderboard-note">See one you disagree with? Keep swiping.</p>
         </div>
-      </article>
+      </section>
+
+      <footer class="footer">
+        <button class="restart" id="restart" type="button" hidden>Shuffle a fresh stack</button>
+        <p class="footer-copy">Tip: You can use the arrow keys or swipe to vote.</p>
+      </footer>
     </main>
 
-    <footer>
-      <p>
-        Built with playful bias by the JBT Games crew. Share your own overrated
-        trends and let's commiserate.
-      </p>
-    </footer>
+    <div class="sr-only" id="aria-status" aria-live="polite"></div>
 
+    <script src="data.js"></script>
     <script src="script.js"></script>
   </body>
 </html>

--- a/overrated/script.js
+++ b/overrated/script.js
@@ -1,29 +1,375 @@
-const cards = document.querySelectorAll(".game-card");
+(() => {
+  const subjects = Array.isArray(window.OVERRATED_SUBJECTS)
+    ? window.OVERRATED_SUBJECTS
+    : [];
 
-cards.forEach((card) => {
-  const toggle = card.querySelector(".toggle");
-  const panel = card.querySelector(".toggle-panel");
-
-  if (!toggle || !panel) return;
-
-  const updateState = (expanded) => {
-    toggle.setAttribute("aria-expanded", expanded);
-    panel.classList.toggle("open", expanded === "true");
+  const pointer = {
+    active: false,
+    id: null,
+    startX: 0,
+    captureTarget: null
   };
 
-  toggle.addEventListener("click", () => {
-    const expanded = toggle.getAttribute("aria-expanded") === "true" ? "false" : "true";
-    updateState(expanded);
-  });
+  const state = {
+    deck: [],
+    index: 0,
+    locked: false
+  };
 
-  toggle.addEventListener("keydown", (event) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      const expanded = toggle.getAttribute("aria-expanded") === "true" ? "false" : "true";
-      updateState(expanded);
+  const dom = {};
+  let activeCard;
+  let standbyCard;
+
+  document.addEventListener("DOMContentLoaded", init);
+
+  function init() {
+    dom.wrapper = document.getElementById("card-wrapper");
+    dom.voteYes = document.getElementById("action-yes");
+    dom.voteNo = document.getElementById("action-no");
+    dom.restart = document.getElementById("restart");
+    dom.progressCurrent = document.getElementById("progress-current");
+    dom.progressTotal = document.getElementById("progress-total");
+    dom.status = document.getElementById("aria-status");
+    dom.leaderboard = document.getElementById("leaderboard-list");
+    activeCard = document.getElementById("card-current");
+    standbyCard = document.getElementById("card-standby");
+
+    if (
+      !dom.wrapper ||
+      !dom.voteYes ||
+      !dom.voteNo ||
+      !dom.restart ||
+      !dom.progressCurrent ||
+      !dom.progressTotal ||
+      !dom.status ||
+      !dom.leaderboard ||
+      !activeCard ||
+      !standbyCard
+    ) {
+      return;
     }
-  });
 
-  // Initialize collapsed state
-  updateState("false");
-});
+    dom.voteYes.addEventListener("click", () => handleVote("overrated"));
+    dom.voteNo.addEventListener("click", () => handleVote("chill"));
+    dom.restart.addEventListener("click", resetDeck);
+
+    document.addEventListener("keydown", (event) => {
+      if (state.locked || state.index >= state.deck.length) return;
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        handleVote("overrated");
+      }
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        handleVote("chill");
+      }
+    });
+
+    dom.wrapper.addEventListener("pointerdown", onPointerDown);
+    dom.wrapper.addEventListener("pointermove", onPointerMove);
+    dom.wrapper.addEventListener("pointerup", onPointerUp);
+    dom.wrapper.addEventListener("pointercancel", finalizePointerGesture);
+
+    renderLeaderboard();
+    resetDeck();
+  }
+
+  function onPointerDown(event) {
+    if (state.locked || state.index >= state.deck.length) return;
+    pointer.active = true;
+    pointer.id = event.pointerId;
+    pointer.startX = event.clientX;
+    if (typeof dom.wrapper.setPointerCapture === "function") {
+      dom.wrapper.setPointerCapture(pointer.id);
+      pointer.captureTarget = dom.wrapper;
+    }
+    if (activeCard) {
+      activeCard.style.transition = "none";
+    }
+  }
+
+  function onPointerMove(event) {
+    if (!pointer.active || event.pointerId !== pointer.id) return;
+    if (!activeCard) return;
+
+    const deltaX = event.clientX - pointer.startX;
+    const rotation = deltaX / 14;
+    const fade = Math.min(Math.abs(deltaX) / 260, 0.45);
+
+    activeCard.style.transform = `translate3d(${deltaX}px, 0, 0) rotate(${rotation}deg)`;
+    activeCard.style.opacity = `${1 - fade}`;
+  }
+
+  function onPointerUp(event) {
+    if (!pointer.active || event.pointerId !== pointer.id) return;
+    const deltaX = event.clientX - pointer.startX;
+    finalizePointerGesture();
+
+    const threshold = dom.wrapper.clientWidth * 0.25;
+    if (Math.abs(deltaX) > threshold) {
+      handleVote(deltaX > 0 ? "overrated" : "chill");
+    }
+  }
+
+  function finalizePointerGesture() {
+    if (!pointer.active) return;
+    if (
+      pointer.captureTarget &&
+      typeof pointer.captureTarget.releasePointerCapture === "function"
+    ) {
+      pointer.captureTarget.releasePointerCapture(pointer.id);
+    }
+    pointer.active = false;
+    pointer.id = null;
+    pointer.startX = 0;
+    pointer.captureTarget = null;
+    if (activeCard) {
+      activeCard.style.transition = "";
+      activeCard.style.transform = "";
+      activeCard.style.opacity = "";
+    }
+  }
+
+  function resetDeck() {
+    state.deck = shuffle(subjects);
+    state.index = 0;
+    state.locked = false;
+
+    updateProgress(state.deck.length ? 1 : 0, state.deck.length);
+    dom.restart.hidden = true;
+    setButtonsDisabled(!state.deck.length);
+
+    prepareCard(activeCard, "current");
+    prepareCard(standbyCard, "standby");
+
+    if (!state.deck.length) {
+      renderEmpty(activeCard);
+      return;
+    }
+
+    renderSubject(activeCard, state.deck[0]);
+    announceSubject(state.deck[0]);
+
+    const upcoming = state.deck[1];
+    if (upcoming) {
+      renderSubject(standbyCard, upcoming);
+    } else {
+      clearCard(standbyCard);
+    }
+  }
+
+  function handleVote(choice) {
+    if (state.locked || state.index >= state.deck.length) return;
+
+    state.locked = true;
+    setButtonsDisabled(true);
+
+    const subject = state.deck[state.index];
+    announceVote(subject, choice);
+
+    const outgoing = activeCard;
+    const incoming = standbyCard;
+    const direction = choice === "overrated" ? "right" : "left";
+
+    if (outgoing) {
+      outgoing.classList.add("leaving", `swipe-${direction}`);
+    }
+
+    window.setTimeout(() => {
+      if (outgoing) {
+        outgoing.classList.remove("leaving", "swipe-right", "swipe-left");
+        prepareCard(outgoing, "standby");
+      }
+
+      state.index += 1;
+      const hasNext = state.index < state.deck.length;
+
+      if (hasNext) {
+        if (incoming) {
+          prepareCard(incoming, "current");
+          renderSubject(incoming, state.deck[state.index]);
+          announceSubject(state.deck[state.index]);
+        }
+
+        activeCard = incoming;
+        standbyCard = outgoing;
+
+        updateProgress(state.index + 1, state.deck.length);
+
+        const upcoming = state.deck[state.index + 1];
+        if (upcoming && standbyCard) {
+          renderSubject(standbyCard, upcoming);
+        } else if (standbyCard) {
+          clearCard(standbyCard);
+        }
+
+        state.locked = false;
+        setButtonsDisabled(false);
+      } else {
+        activeCard = incoming;
+        standbyCard = outgoing;
+        if (activeCard) {
+          prepareCard(activeCard, "current");
+          renderFinished(activeCard);
+        }
+        updateProgress(state.deck.length, state.deck.length);
+        dom.restart.hidden = false;
+        dom.restart.focus();
+        state.locked = false;
+      }
+    }, 280);
+  }
+
+  function renderSubject(card, subject) {
+    if (!card) return;
+    card.style.setProperty("--card-accent", subject.accent || "transparent");
+
+    const statsMarkup = Array.isArray(subject.stats)
+      ? subject.stats
+          .map(
+            (stat) => `
+              <li class="stat-chip" role="listitem">
+                <span class="stat-icon" aria-hidden="true">${stat.icon}</span>
+                <span class="stat-value">${stat.value}</span>
+                <span class="stat-label">${stat.label}</span>
+              </li>
+            `
+          )
+          .join("")
+      : "";
+
+    card.innerHTML = `
+      <figure class="subject-photo">
+        <img src="${subject.image}" alt="${subject.imageAlt || subject.name}" loading="lazy" />
+      </figure>
+      <div class="subject-details">
+        <div class="subject-header">
+          <span class="subject-type">${getTypeEmoji(subject.type)} ${subject.type}</span>
+          <span class="subject-year">${subject.year}</span>
+        </div>
+        <h2 class="subject-title">${subject.name}</h2>
+        <p class="subject-origin">${subject.origin}</p>
+        <p class="subject-description">${subject.description}</p>
+        <ul class="subject-stats" role="list">${statsMarkup}</ul>
+      </div>
+    `;
+  }
+
+  function renderFinished(card) {
+    card.classList.add("finished");
+    card.style.removeProperty("--card-accent");
+    card.innerHTML = `
+      <div class="finished-inner">
+        <h2>That's a wrap</h2>
+        <p>You have voted on every pick. Shuffle again for a fresh round of debates.</p>
+      </div>
+    `;
+    setButtonsDisabled(true);
+    dom.status.textContent = "Deck finished. Shuffle again for fresh topics.";
+  }
+
+  function renderEmpty(card) {
+    card.classList.add("finished");
+    card.style.removeProperty("--card-accent");
+    card.innerHTML = `
+      <div class="finished-inner">
+        <h2>No topics yet</h2>
+        <p>Come back soon for more culture debates to swipe on.</p>
+      </div>
+    `;
+    setButtonsDisabled(true);
+    dom.status.textContent = "No topics available right now.";
+  }
+
+  function renderLeaderboard() {
+    if (!dom.leaderboard) return;
+    const topFive = [...subjects]
+      .filter((item) => typeof item.overratedScore === "number")
+      .sort((a, b) => b.overratedScore - a.overratedScore)
+      .slice(0, 5);
+
+    dom.leaderboard.innerHTML = topFive
+      .map(
+        (subject, index) => `
+          <li class="leaderboard-item">
+            <span class="leaderboard-rank">#${index + 1}</span>
+            <figure class="leaderboard-photo">
+              <img src="${subject.image}" alt="${subject.imageAlt || subject.name}" loading="lazy" />
+            </figure>
+            <div class="leaderboard-details">
+              <span class="leaderboard-name">${subject.name}</span>
+              <span class="leaderboard-meta">${getTypeEmoji(subject.type)} ${subject.type} • ${subject.year}</span>
+            </div>
+            <span class="leaderboard-score">${subject.overratedScore}% say overrated</span>
+          </li>
+        `
+      )
+      .join("");
+  }
+
+  function clearCard(card) {
+    if (!card) return;
+    prepareCard(card, "standby");
+    card.innerHTML = "";
+  }
+
+  function prepareCard(card, role) {
+    if (!card) return;
+    card.className = role === "current" ? "card current" : "card standby";
+    card.style.removeProperty("--card-accent");
+    card.style.opacity = "";
+    card.style.transform = "";
+    if (role === "current") {
+      card.removeAttribute("aria-hidden");
+    } else {
+      card.setAttribute("aria-hidden", "true");
+    }
+  }
+
+  function setButtonsDisabled(state) {
+    dom.voteYes.disabled = state;
+    dom.voteNo.disabled = state;
+    dom.voteYes.setAttribute("aria-disabled", state ? "true" : "false");
+    dom.voteNo.setAttribute("aria-disabled", state ? "true" : "false");
+  }
+
+  function announceSubject(subject) {
+    dom.status.textContent = `${subject.name}. ${subject.type} • ${subject.year}.`;
+  }
+
+  function announceVote(subject, vote) {
+    const label = vote === "overrated" ? "Overrated" : "Not overrated";
+    dom.status.textContent = `You voted ${label} for ${subject.name}.`;
+  }
+
+  function updateProgress(current, total) {
+    dom.progressCurrent.textContent = `${Math.min(current, total)}`;
+    dom.progressTotal.textContent = `${total}`;
+  }
+
+  function shuffle(list) {
+    const arr = [...list];
+    for (let i = arr.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
+  function getTypeEmoji(type) {
+    const map = {
+      Artist: "🎤",
+      Album: "🎶",
+      Movie: "🎬",
+      Series: "📺",
+      "Live Show": "🎤",
+      Game: "🕹️",
+      Single: "🎵",
+      Franchise: "🦸",
+      Product: "🚗",
+      Event: "🎉",
+      Trend: "🔥"
+    };
+    return map[type] || "✨";
+  }
+})();

--- a/overrated/style.css
+++ b/overrated/style.css
@@ -1,172 +1,480 @@
 :root {
-  --bg: #0f172a;
-  --card-bg: rgba(15, 23, 42, 0.85);
-  --accent: #f97316;
-  --accent-soft: rgba(249, 115, 22, 0.2);
-  --text: #f8fafc;
-  --muted: #cbd5f5;
-  --shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
-  --transition: 200ms ease-in-out;
+  --bg: #050718;
+  --bg-gradient: radial-gradient(circle at top, #1a1f41 0%, #050718 65%);
+  --panel: rgba(17, 20, 44, 0.88);
+  --panel-border: rgba(255, 255, 255, 0.08);
+  --card-bg: rgba(13, 16, 36, 0.92);
+  --card-border: rgba(255, 255, 255, 0.06);
+  --text: #f5f7ff;
+  --muted: #b3b6d6;
+  --shadow: 0 32px 90px rgba(5, 7, 22, 0.55);
+  --radius-lg: 28px;
+  --radius-md: 18px;
+  --transition: 260ms ease;
+  --accent-no: linear-gradient(135deg, #3fd3a5, #7cf8d2);
+  --accent-yes: linear-gradient(135deg, #ff6a88, #ff8e53);
+  font-family: "Inter", "Segoe UI", Tahoma, sans-serif;
+  color: var(--text);
 }
 
-* {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
 html,
 body {
   margin: 0;
-  padding: 0;
   min-height: 100%;
-  font-family: "Poppins", "Segoe UI", Tahoma, sans-serif;
-  background: radial-gradient(circle at top, #1e293b 0, var(--bg) 40%);
-  color: var(--text);
 }
 
 body {
+  min-height: 100dvh;
+  background: var(--bg-gradient);
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: var(--text);
 }
 
-header {
-  padding: 3rem 1.5rem 2rem;
+a {
+  color: inherit;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+button {
+  font-family: inherit;
+  cursor: pointer;
+  border: none;
+  background: none;
+  color: inherit;
+}
+
+button:disabled {
+  cursor: not-allowed;
+}
+
+button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.85);
+  outline-offset: 3px;
+}
+
+.layout {
+  width: min(100%, 460px);
+  min-height: 100dvh;
+  padding: clamp(2rem, 4vh, 3rem) 1.5rem 2.5rem;
+  display: grid;
+  gap: clamp(2rem, 4vh, 3rem);
+  place-items: center;
+}
+
+.masthead {
   text-align: center;
+  display: grid;
+  gap: 0.9rem;
 }
 
-header h1 {
-  margin: 0;
-  font-size: clamp(2.5rem, 7vw, 3.75rem);
-  letter-spacing: 0.06em;
+.masthead-tag {
   text-transform: uppercase;
+  letter-spacing: 0.28em;
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.55);
+  margin: 0;
 }
 
-header p {
-  margin: 0.5rem auto 0;
-  max-width: 540px;
+.masthead-title {
+  margin: 0;
+  font-size: clamp(2.4rem, 10vw, 3rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.masthead-title span {
+  color: #ffaf7a;
+}
+
+.masthead-copy {
+  margin: 0;
+  font-size: 0.98rem;
+  line-height: 1.65;
   color: var(--muted);
+}
+
+.masthead-progress {
+  margin: 0;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.7);
+  display: inline-flex;
+  gap: 0.4rem;
+  justify-content: center;
+}
+
+.progress-divider {
+  opacity: 0.6;
+}
+
+.swipe-zone {
+  width: 100%;
+  display: grid;
+  gap: 1.8rem;
+  justify-items: center;
+}
+
+.card-wrapper {
+  width: 100%;
+  aspect-ratio: 11 / 16;
+  max-height: 620px;
+  position: relative;
+}
+
+.card {
+  position: absolute;
+  inset: 0;
+  background: var(--card-bg);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--card-border);
+  overflow: hidden;
+  box-shadow: var(--shadow);
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  transition: transform var(--transition), opacity 220ms ease;
+  pointer-events: auto;
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--card-accent, transparent);
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.card.standby {
+  opacity: 0;
+  transform: translateY(18px) scale(0.94);
+  pointer-events: none;
+}
+
+.card.leaving {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.card.leaving.swipe-right {
+  transform: translate3d(420px, -60px, 0) rotate(18deg);
+}
+
+.card.leaving.swipe-left {
+  transform: translate3d(-420px, -60px, 0) rotate(-18deg);
+}
+
+.card.finished {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2.5rem 2rem;
+}
+
+.finished-inner {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.finished-inner h2 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.finished-inner p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.subject-photo {
+  margin: 0;
+  display: block;
+  overflow: hidden;
+  aspect-ratio: 11 / 9;
+}
+
+.subject-photo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.subject-details {
+  padding: 1.8rem 1.6rem 1.9rem;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.subject-header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.subject-title {
+  margin: 0;
+  font-size: 1.8rem;
+  letter-spacing: -0.01em;
+}
+
+.subject-origin,
+.subject-description {
+  margin: 0;
   line-height: 1.6;
 }
 
-main {
-  flex: 1;
-  display: grid;
-  gap: 2rem;
-  padding: 0 1.5rem 3rem;
-  max-width: 960px;
-  width: 100%;
-  margin: 0 auto;
+.subject-origin {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.75);
 }
 
-.game-card {
-  background: var(--card-bg);
-  border-radius: 22px;
-  padding: 2rem;
-  box-shadow: var(--shadow);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
-}
-
-.game-card:hover,
-.game-card:focus-within {
-  transform: translateY(-6px);
-  box-shadow: 0 26px 60px rgba(15, 23, 42, 0.6);
-  border-color: rgba(249, 115, 22, 0.4);
-}
-
-.game-card h2 {
-  margin: 0 0 0.5rem;
-  font-size: 1.75rem;
-}
-
-.game-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem 1rem;
-  align-items: center;
-  margin-bottom: 1rem;
-  font-size: 0.95rem;
+.subject-description {
   color: var(--muted);
 }
 
-.meta-pill {
-  padding: 0.35rem 0.75rem;
+.subject-stats {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.stat-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 0.75rem;
   border-radius: 999px;
-  background: var(--accent-soft);
-  color: var(--accent);
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.82rem;
+}
+
+.stat-icon {
+  font-size: 1rem;
+}
+
+.stat-value {
+  font-weight: 700;
+}
+
+.stat-label {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.actions {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.1rem;
+}
+
+.action {
+  border-radius: var(--radius-md);
+  padding: 1rem 1.2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  display: grid;
+  place-items: center;
+  gap: 0.45rem;
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.action span[aria-hidden] {
+  font-size: 1.6rem;
+}
+
+.action-no {
+  background: var(--accent-no);
+  color: #05392d;
+}
+
+.action-yes {
+  background: var(--accent-yes);
+  color: #3a0a00;
+}
+
+.action:active {
+  transform: scale(0.96);
+}
+
+.action:disabled {
+  opacity: 0.4;
+  transform: none;
+}
+
+.leaderboard {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.leaderboard-shell {
+  width: 100%;
+  background: var(--panel);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--panel-border);
+  box-shadow: 0 24px 70px rgba(4, 6, 20, 0.45);
+  padding: 1.8rem 1.4rem 1.6rem;
+  display: grid;
+  gap: 1rem;
+  text-align: center;
+}
+
+.leaderboard-title {
+  margin: 0;
+  font-size: 1.4rem;
+  letter-spacing: -0.01em;
+}
+
+.leaderboard-copy,
+.leaderboard-note {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--muted);
+}
+
+.leaderboard-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.leaderboard-item {
+  display: grid;
+  grid-template-columns: auto 70px 1fr;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.95rem 1rem;
+  border-radius: var(--radius-md);
+  background: rgba(6, 9, 26, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.leaderboard-rank {
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.leaderboard-photo {
+  margin: 0;
+  aspect-ratio: 1 / 1;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.leaderboard-photo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.leaderboard-details {
+  display: grid;
+  gap: 0.25rem;
+  justify-items: start;
+  text-align: left;
+}
+
+.leaderboard-name {
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.leaderboard-meta {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.leaderboard-score {
+  justify-self: end;
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: #ffb37a;
+}
+
+.footer {
+  width: 100%;
+  text-align: center;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.restart {
+  justify-self: center;
+  padding: 0.75rem 1.3rem;
+  border-radius: 999px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  color: rgba(255, 255, 255, 0.85);
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  font-size: 0.75rem;
 }
 
-button.toggle {
-  margin-top: 1.25rem;
-  padding: 0.75rem 1.25rem;
-  border-radius: 999px;
-  border: none;
-  cursor: pointer;
-  background: var(--accent);
-  color: #111827;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  transition: transform var(--transition), background var(--transition), color var(--transition);
+.footer-copy {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.55);
 }
 
-button.toggle:hover,
-button.toggle:focus {
-  transform: translateY(-2px);
-  background: #fb923c;
-  color: #0f172a;
-}
-
-button.toggle[aria-expanded="true"] {
-  background: transparent;
-  color: var(--accent);
-  border: 2px solid var(--accent);
-}
-
-.toggle-panel {
-  margin-top: 1rem;
-  line-height: 1.7;
-  max-height: 0;
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
   overflow: hidden;
-  transition: max-height 280ms ease;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
-.toggle-panel.open {
-  max-height: 400px;
-}
-
-.toggle-panel p {
-  margin: 0.5rem 0;
-}
-
-ul.reasons {
-  margin: 0.75rem 0 0;
-  padding-left: 1.25rem;
-}
-
-ul.reasons li {
-  margin: 0.35rem 0;
-}
-
-footer {
-  text-align: center;
-  padding: 2rem 1.5rem 3rem;
-  color: var(--muted);
-  font-size: 0.9rem;
-}
-
-@media (max-width: 640px) {
-  header {
-    padding: 2.25rem 1.25rem 1.5rem;
+@media (min-width: 520px) {
+  .layout {
+    width: min(100%, 520px);
+    padding-top: 3.2rem;
   }
 
-  .game-card {
-    padding: 1.75rem 1.5rem;
+  .card-wrapper {
+    aspect-ratio: 10 / 15;
   }
+}
 
-  button.toggle {
-    width: 100%;
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
   }
 }


### PR DESCRIPTION
## Summary
- rebuild the Overrated? page with a centered mobile-first layout, single-card swipe zone, and inline progress display
- rewrite the swipe controller to manage deck shuffling, pointer gestures, accessibility updates, and leaderboard rendering after DOM readiness
- refresh the styling and leaderboard presentation while freezing the shared dataset export for reuse without merge conflicts

## Testing
- python3 -m http.server 4173 --bind 0.0.0.0 & curl -I http://127.0.0.1:4173/overrated/index.html


------
https://chatgpt.com/codex/tasks/task_e_68e3e5bc12d08322906a2917c44be73b