### PR TITLE
Add MoodMap frontend prototype

### DIFF
--- a/MoodMap/app.js
+++ b/MoodMap/app.js
@@ -1,0 +1,200 @@
+const palette = [
+  { mood: "Joy", color: "#FFD166" },
+  { mood: "Calm", color: "#5AB3E6" },
+  { mood: "Focused", color: "#06D6A0" },
+  { mood: "Tired", color: "#A8A8A8" },
+  { mood: "Sad", color: "#26547C" },
+  { mood: "Angry", color: "#EF476F" }
+];
+
+const mockMoods = [
+  { date: "2024-03-02", color: "#5AB3E6" },
+  { date: "2024-03-03", color: "#FFD166" },
+  { date: "2024-03-05", color: "#06D6A0" },
+  { date: "2024-03-08", color: "#26547C" },
+  { date: "2024-03-09", color: "#EF476F" },
+  { date: "2024-03-12", color: "#FFD166" },
+  { date: "2024-03-15", color: "#A8A8A8" },
+  { date: "2024-03-18", color: "#5AB3E6" },
+  { date: "2024-03-21", color: "#06D6A0" },
+  { date: "2024-03-24", color: "#FFD166" }
+];
+
+const gridElement = document.getElementById("moodGrid");
+const paletteElement = document.getElementById("palette");
+const legendList = document.getElementById("legendList");
+const logButton = document.getElementById("logMoodButton");
+const modal = document.getElementById("moodModal");
+const streakCount = document.getElementById("streakCount");
+const gridMonth = document.getElementById("gridMonth");
+const currentDateLabel = document.getElementById("currentDate");
+
+function formatDate(date) {
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric"
+  }).format(date);
+}
+
+function formatMonth(date) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    year: "numeric"
+  }).format(date);
+}
+
+function getISODate(date) {
+  return date.toISOString().split("T")[0];
+}
+
+function hydrateLegend() {
+  legendList.innerHTML = "";
+  palette.forEach(({ mood, color }) => {
+    const item = document.createElement("li");
+    item.className = "legend-item";
+    item.innerHTML = `
+      <span class="legend-item__swatch" style="background: ${color}"></span>
+      <span>${mood}</span>
+    `;
+    legendList.appendChild(item);
+  });
+}
+
+function hydratePalette() {
+  paletteElement.innerHTML = "";
+  palette.forEach(({ mood, color }) => {
+    const option = document.createElement("button");
+    option.type = "button";
+    option.className = "palette__option";
+    option.dataset.color = color;
+    option.dataset.mood = mood;
+    option.innerHTML = `
+      <span class="palette__swatch" style="background: ${color}"></span>
+      <span>${mood}</span>
+    `;
+    option.addEventListener("click", () => {
+      modal.close();
+      logMood(color);
+    });
+    paletteElement.appendChild(option);
+  });
+}
+
+function getMockData() {
+  return JSON.parse(localStorage.getItem("moodmap.moods")) ?? mockMoods;
+}
+
+function saveMockData(data) {
+  localStorage.setItem("moodmap.moods", JSON.stringify(data));
+}
+
+function calculateStreak(data, today) {
+  const set = new Set(data.map((item) => item.date));
+  let streak = 0;
+  const cursor = new Date(today);
+
+  while (set.has(getISODate(cursor))) {
+    streak += 1;
+    cursor.setDate(cursor.getDate() - 1);
+  }
+
+  return streak;
+}
+
+function logMood(color) {
+  const today = getISODate(new Date());
+  const data = getMockData();
+  const existing = data.find((item) => item.date === today);
+
+  if (existing) {
+    existing.color = color;
+  } else {
+    data.push({ date: today, color });
+  }
+
+  saveMockData(data);
+  renderGrid();
+}
+
+function renderGrid() {
+  const now = new Date();
+  const firstDay = new Date(now.getFullYear(), now.getMonth(), 1);
+  const startOffset = firstDay.getDay();
+  const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+  const data = getMockData();
+  const todayISO = getISODate(now);
+  const dataMap = new Map(data.map((item) => [item.date, item.color]));
+
+  gridElement.innerHTML = "";
+  gridElement.style.setProperty("--days", daysInMonth);
+
+  const totalCells = Math.ceil((startOffset + daysInMonth) / 7) * 7;
+
+  for (let cellIndex = 0; cellIndex < totalCells; cellIndex += 1) {
+    const cell = document.createElement("div");
+    cell.className = "cell";
+    cell.setAttribute("role", "gridcell");
+
+    const cellContent = document.createElement("div");
+    cellContent.className = "cell__content";
+
+    const dayNumber = cellIndex - startOffset + 1;
+
+    if (dayNumber > 0 && dayNumber <= daysInMonth) {
+      const date = new Date(now.getFullYear(), now.getMonth(), dayNumber);
+      const isoDate = getISODate(date);
+      const color = dataMap.get(isoDate);
+
+      if (color) {
+        cell.classList.add("cell--filled");
+        cell.style.background = color;
+      }
+
+      if (isoDate === todayISO) {
+        cell.classList.add("cell--today");
+      }
+
+      const label = document.createElement("span");
+      label.className = "cell__date";
+      label.textContent = dayNumber;
+
+      const moodLabel = document.createElement("span");
+      moodLabel.className = "cell__mood";
+      moodLabel.textContent = palette.find((entry) => entry.color === color)?.mood ?? "";
+
+      cellContent.append(label, moodLabel);
+      cell.appendChild(cellContent);
+      cell.dataset.date = isoDate;
+      cell.title = color ? `${moodLabel.textContent} on ${date.toDateString()}` : date.toDateString();
+    } else {
+      cell.classList.add("cell--empty");
+      cellContent.style.visibility = "hidden";
+      cell.appendChild(cellContent);
+    }
+
+    gridElement.appendChild(cell);
+  }
+
+  streakCount.textContent = `${calculateStreak(data, now)} day${calculateStreak(data, now) === 1 ? "" : "s"}`;
+  gridMonth.textContent = formatMonth(now);
+  currentDateLabel.textContent = formatDate(now);
+}
+
+logButton.addEventListener("click", () => {
+  if (typeof modal.showModal === "function") {
+    modal.showModal();
+  } else {
+    // Fallback for browsers without dialog support
+    modal.setAttribute("open", "true");
+  }
+});
+
+modal.addEventListener("cancel", (event) => {
+  event.preventDefault();
+  modal.close();
+});
+
+hydrateLegend();
+hydratePalette();
+renderGrid();

--- a/MoodMap/index.html
+++ b/MoodMap/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MoodMap 🌈</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+</head>
+<body>
+  <div class="app">
+    <header class="app__header">
+      <div class="app__branding">
+        <h1 class="app__title">MoodMap <span aria-hidden="true">🌈</span></h1>
+        <p class="app__subtitle" id="currentDate">Tuesday, March 12</p>
+      </div>
+      <div class="app__status">
+        <div class="status-card">
+          <span class="status-card__label">Streak</span>
+          <span class="status-card__value" id="streakCount">0 days</span>
+        </div>
+        <button class="button button--primary" id="logMoodButton" type="button">Log Mood</button>
+      </div>
+    </header>
+
+    <main class="app__main" aria-live="polite">
+      <section class="grid" aria-label="Mood grid for current month">
+        <div class="grid__header" id="gridMonth">March 2024</div>
+        <div class="grid__weekdays">
+          <span>Sun</span>
+          <span>Mon</span>
+          <span>Tue</span>
+          <span>Wed</span>
+          <span>Thu</span>
+          <span>Fri</span>
+          <span>Sat</span>
+        </div>
+        <div class="grid__cells" id="moodGrid" role="grid"></div>
+        <div class="grid__legend">
+          <h2 class="grid__legend-title">Legend</h2>
+          <ul class="legend-list" id="legendList"></ul>
+        </div>
+      </section>
+    </main>
+
+    <nav class="app__nav" aria-label="Primary">
+      <button class="nav__item nav__item--active" type="button">My Map</button>
+      <button class="nav__item" type="button">Global</button>
+      <button class="nav__item" type="button">Profile</button>
+    </nav>
+  </div>
+
+  <dialog class="modal" id="moodModal" aria-labelledby="modalTitle">
+    <form method="dialog" class="modal__content">
+      <header class="modal__header">
+        <h2 class="modal__title" id="modalTitle">How are you feeling today?</h2>
+        <button type="submit" class="modal__close" aria-label="Close">×</button>
+      </header>
+      <div class="modal__body">
+        <ul class="palette" id="palette"></ul>
+      </div>
+    </form>
+  </dialog>
+
+  <script src="app.js" type="module"></script>
+</body>
+</html>

--- a/MoodMap/styles.css
+++ b/MoodMap/styles.css
@@ -1,0 +1,358 @@
+:root {
+  --color-background: #f7f8fa;
+  --color-surface: #ffffff;
+  --color-text: #1f2a37;
+  --color-muted: #6b7280;
+  --color-border: #e5e7eb;
+  --color-today: #ffed66;
+  --shadow-soft: 0 12px 24px rgba(31, 42, 55, 0.08);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-family);
+  background: linear-gradient(180deg, #f4f9ff 0%, #ffffff 100%);
+  color: var(--color-text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+}
+
+.app {
+  width: min(420px, 100%);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding: 24px 20px 80px;
+  gap: 24px;
+}
+
+.app__header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.app__branding {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.app__title {
+  font-size: 1.8rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.app__subtitle {
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.app__status {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.status-card {
+  flex: 1;
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-soft);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.status-card__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.status-card__value {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.button {
+  border: none;
+  border-radius: 999px;
+  padding: 12px 22px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.button--primary {
+  background: linear-gradient(120deg, #ef476f 0%, #ffd166 100%);
+  color: #fff;
+  box-shadow: 0 10px 18px rgba(239, 71, 111, 0.25);
+}
+
+.button--primary:hover,
+.button--primary:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(239, 71, 111, 0.3);
+}
+
+.app__main {
+  flex: 1;
+}
+
+.grid {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  padding: 24px 20px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.grid__header {
+  font-size: 1.2rem;
+  font-weight: 600;
+  text-align: center;
+}
+
+.grid__weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 10px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+  text-align: center;
+}
+
+.grid__cells {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 10px;
+}
+
+.cell {
+  position: relative;
+  padding-top: 100%;
+  border-radius: var(--radius-sm);
+  background: #f1f5f9;
+  overflow: hidden;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.cell__content {
+  position: absolute;
+  inset: 6px;
+  border-radius: calc(var(--radius-sm) - 4px);
+  background: rgba(255, 255, 255, 0.7);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding: 6px;
+  font-size: 0.75rem;
+  color: var(--color-muted);
+}
+
+.cell--filled .cell__content {
+  color: #ffffff;
+  font-weight: 600;
+  background: transparent;
+}
+
+.cell--today {
+  outline: 2px solid rgba(255, 209, 102, 0.9);
+  outline-offset: 2px;
+}
+
+.cell__date {
+  font-variant-numeric: tabular-nums;
+}
+
+.grid__legend {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.grid__legend-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.legend-list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: #f1f5f9;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 0.8rem;
+}
+
+.legend-item__swatch {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+}
+
+.app__nav {
+  position: fixed;
+  left: 50%;
+  bottom: 20px;
+  transform: translateX(-50%);
+  width: min(380px, calc(100% - 32px));
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(14px);
+  border-radius: 999px;
+  box-shadow: 0 16px 34px rgba(31, 42, 55, 0.12);
+  padding: 12px;
+}
+
+.nav__item {
+  border: none;
+  background: transparent;
+  font-weight: 600;
+  color: var(--color-muted);
+  padding: 10px 0;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.nav__item--active {
+  background: linear-gradient(120deg, #06d6a0 0%, #5ab3e6 100%);
+  color: #ffffff;
+}
+
+.modal {
+  border: none;
+  border-radius: var(--radius-lg);
+  padding: 0;
+  width: min(420px, 90vw);
+  box-shadow: var(--shadow-soft);
+}
+
+.modal::backdrop {
+  background: rgba(31, 42, 55, 0.45);
+}
+
+.modal__content {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.modal__title {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.modal__close {
+  border: none;
+  background: #f1f5f9;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.palette {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+}
+
+.palette__option {
+  border: none;
+  border-radius: var(--radius-md);
+  background: #f1f5f9;
+  padding: 14px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.palette__option:hover,
+.palette__option:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(31, 42, 55, 0.12);
+}
+
+.palette__swatch {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 255, 255, 0.8);
+  box-shadow: inset 0 0 0 1px rgba(31, 42, 55, 0.08);
+}
+
+@media (min-width: 768px) {
+  body {
+    background: radial-gradient(100% 100% at top, #f4f9ff 0%, #ffffff 50%, #f4f9ff 100%);
+  }
+
+  .app {
+    padding-bottom: 120px;
+  }
+
+  .app__header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .app__status {
+    flex: none;
+  }
+
+  .status-card {
+    min-width: 120px;
+  }
+
+  .app__nav {
+    width: min(480px, calc(100% - 64px));
+    bottom: 32px;
+  }
+}


### PR DESCRIPTION
## Summary
- add new MoodMap folder containing mobile-first UI prototype for daily mood tracking
- implement interactive mood grid with mock data, streak calculation, and color legend
- include modal-based mood logging palette tied to local storage for persistent demo experience

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3fa7c15448322bbf90ca9d9a75bbd