### PR TITLE
Add month navigation controls to MoodMap

### DIFF
--- a/MoodMap/app.js
+++ b/MoodMap/app.js
@@ -27,7 +27,14 @@ const logButton = document.getElementById("logMoodButton");
 const modal = document.getElementById("moodModal");
 const streakCount = document.getElementById("streakCount");
 const gridMonth = document.getElementById("gridMonth");
+const previousMonthButton = document.getElementById("previousMonth");
+const nextMonthButton = document.getElementById("nextMonth");
 const currentDateLabel = document.getElementById("currentDate");
+
+let currentViewDate = (() => {
+  const today = new Date();
+  return new Date(today.getFullYear(), today.getMonth(), 1);
+})();
 
 function formatDate(date) {
   return new Intl.DateTimeFormat("en-US", {
@@ -119,9 +126,10 @@ function logMood(color) {
 
 function renderGrid() {
   const now = new Date();
-  const firstDay = new Date(now.getFullYear(), now.getMonth(), 1);
+  const viewDate = new Date(currentViewDate.getFullYear(), currentViewDate.getMonth(), 1);
+  const firstDay = new Date(viewDate);
   const startOffset = firstDay.getDay();
-  const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+  const daysInMonth = new Date(viewDate.getFullYear(), viewDate.getMonth() + 1, 0).getDate();
   const data = getMockData();
   const todayISO = getISODate(now);
   const dataMap = new Map(data.map((item) => [item.date, item.color]));
@@ -142,7 +150,7 @@ function renderGrid() {
     const dayNumber = cellIndex - startOffset + 1;
 
     if (dayNumber > 0 && dayNumber <= daysInMonth) {
-      const date = new Date(now.getFullYear(), now.getMonth(), dayNumber);
+      const date = new Date(viewDate.getFullYear(), viewDate.getMonth(), dayNumber);
       const isoDate = getISODate(date);
       const color = dataMap.get(isoDate);
 
@@ -176,9 +184,20 @@ function renderGrid() {
     gridElement.appendChild(cell);
   }
 
-  streakCount.textContent = `${calculateStreak(data, now)} day${calculateStreak(data, now) === 1 ? "" : "s"}`;
-  gridMonth.textContent = formatMonth(now);
+  const streakValue = calculateStreak(data, now);
+  streakCount.textContent = `${streakValue} day${streakValue === 1 ? "" : "s"}`;
+  gridMonth.textContent = formatMonth(viewDate);
   currentDateLabel.textContent = formatDate(now);
+
+  const isCurrentMonth =
+    viewDate.getFullYear() === now.getFullYear() && viewDate.getMonth() === now.getMonth();
+
+  nextMonthButton.disabled = isCurrentMonth;
+}
+
+function changeMonth(offset) {
+  currentViewDate = new Date(currentViewDate.getFullYear(), currentViewDate.getMonth() + offset, 1);
+  renderGrid();
 }
 
 logButton.addEventListener("click", () => {
@@ -193,6 +212,16 @@ logButton.addEventListener("click", () => {
 modal.addEventListener("cancel", (event) => {
   event.preventDefault();
   modal.close();
+});
+
+previousMonthButton.addEventListener("click", () => {
+  changeMonth(-1);
+});
+
+nextMonthButton.addEventListener("click", () => {
+  if (!nextMonthButton.disabled) {
+    changeMonth(1);
+  }
 });
 
 hydrateLegend();

--- a/MoodMap/index.html
+++ b/MoodMap/index.html
@@ -27,7 +27,11 @@
 
     <main class="app__main" aria-live="polite">
       <section class="grid" aria-label="Mood grid for current month">
-        <div class="grid__header" id="gridMonth">March 2024</div>
+        <div class="grid__header">
+          <button class="grid__nav-button" id="previousMonth" type="button" aria-label="View previous month">◀</button>
+          <div class="grid__header-month" id="gridMonth">March 2024</div>
+          <button class="grid__nav-button" id="nextMonth" type="button" aria-label="View next month">▶</button>
+        </div>
         <div class="grid__weekdays">
           <span>Sun</span>
           <span>Mon</span>

--- a/MoodMap/styles.css
+++ b/MoodMap/styles.css
@@ -127,9 +127,46 @@ body {
 }
 
 .grid__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.grid__header-month {
   font-size: 1.2rem;
   font-weight: 600;
   text-align: center;
+  flex: 1;
+}
+
+.grid__nav-button {
+  border: none;
+  background: #f1f5f9;
+  color: var(--color-muted);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  font-size: 1rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 150ms ease, box-shadow 150ms ease, color 150ms ease;
+}
+
+.grid__nav-button:hover,
+.grid__nav-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(31, 42, 55, 0.12);
+  color: var(--color-text);
+}
+
+.grid__nav-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
 }
 
 .grid__weekdays {


### PR DESCRIPTION
## Summary
- add previous/next month controls to the MoodMap calendar header
- persist the viewed month in state and disable navigating beyond the current month
- refresh styling to accommodate the new navigation buttons

## Testing
- Manual QA on http://127.0.0.1:8000/MoodMap/


------
https://chatgpt.com/codex/tasks/task_e_68e3fe7dbf788322bcf2f3ad0d2c68b3