### PR TITLE
Add per-user mood combo login to MoodMap

### DIFF
--- a/MoodMap/app.js
+++ b/MoodMap/app.js
@@ -7,7 +7,7 @@ const palette = [
   { mood: "Angry", color: "#EF476F" }
 ];
 
-const mockMoods = [
+const starterMoods = [
   { date: "2024-03-02", color: "#5AB3E6" },
   { date: "2024-03-03", color: "#FFD166" },
   { date: "2024-03-05", color: "#06D6A0" },
@@ -20,6 +20,13 @@ const mockMoods = [
   { date: "2024-03-24", color: "#FFD166" }
 ];
 
+const STORAGE_PREFIX = "moodmap.";
+const USERS_KEY = `${STORAGE_PREFIX}users`;
+const CURRENT_USER_KEY = `${STORAGE_PREFIX}currentUser`;
+
+let currentUser = null;
+let authMode = "signIn";
+
 const gridElement = document.getElementById("moodGrid");
 const paletteElement = document.getElementById("palette");
 const legendList = document.getElementById("legendList");
@@ -30,6 +37,37 @@ const gridMonth = document.getElementById("gridMonth");
 const previousMonthButton = document.getElementById("previousMonth");
 const nextMonthButton = document.getElementById("nextMonth");
 const currentDateLabel = document.getElementById("currentDate");
+const appElement = document.querySelector(".app");
+const authPanel = document.getElementById("authPanel");
+const signOutButton = document.getElementById("signOutButton");
+
+const signInForm = document.getElementById("signInForm");
+const createForm = document.getElementById("createForm");
+const switchToCreate = document.getElementById("switchToCreate");
+const switchToSignIn = document.getElementById("switchToSignIn");
+const signInUsernameInput = document.getElementById("signInUsername");
+const createUsernameInput = document.getElementById("createUsername");
+const authSubtitle = document.getElementById("authSubtitle");
+
+const comboElements = {
+  signIn: document.getElementById("signInCombo"),
+  create: document.getElementById("createCombo")
+};
+
+const padElements = {
+  signIn: document.getElementById("signInPad"),
+  create: document.getElementById("createPad")
+};
+
+const messageElements = {
+  signIn: document.getElementById("signInMessage"),
+  create: document.getElementById("createMessage")
+};
+
+const comboState = {
+  signIn: [],
+  create: []
+};
 
 let currentViewDate = (() => {
   const today = new Date();
@@ -55,45 +93,191 @@ function getISODate(date) {
   return date.toISOString().split("T")[0];
 }
 
-function hydrateLegend() {
-  legendList.innerHTML = "";
-  palette.forEach(({ mood, color }) => {
-    const item = document.createElement("li");
-    item.className = "legend-item";
-    item.innerHTML = `
-      <span class="legend-item__swatch" style="background: ${color}"></span>
-      <span>${mood}</span>
-    `;
-    legendList.appendChild(item);
-  });
+function getMoodColorByName(name) {
+  return palette.find((entry) => entry.mood === name)?.color ?? "#f1f5f9";
 }
 
-function hydratePalette() {
-  paletteElement.innerHTML = "";
-  palette.forEach(({ mood, color }) => {
-    const option = document.createElement("button");
-    option.type = "button";
-    option.className = "palette__option";
-    option.dataset.color = color;
-    option.dataset.mood = mood;
-    option.innerHTML = `
-      <span class="palette__swatch" style="background: ${color}"></span>
-      <span>${mood}</span>
-    `;
-    option.addEventListener("click", () => {
-      modal.close();
-      logMood(color);
+function updateComboUI(key) {
+  const element = comboElements[key];
+  if (!element) return;
+
+  element.innerHTML = "";
+
+  for (let index = 0; index < 3; index += 1) {
+    const mood = comboState[key][index];
+    const slot = document.createElement("button");
+    slot.type = "button";
+    slot.className = "auth__combo-slot";
+
+    if (mood) {
+      const color = getMoodColorByName(mood);
+      slot.classList.add("auth__combo-slot--filled");
+      slot.innerHTML = `
+        <span class="auth__combo-swatch" style="background: ${color}"></span>
+        <span>${mood}</span>
+      `;
+    } else {
+      slot.innerHTML = `<span class="auth__combo-placeholder">Mood ${index + 1}</span>`;
+    }
+
+    slot.addEventListener("click", () => {
+      if (!mood) return;
+      comboState[key].splice(index, 1);
+      updateComboUI(key);
     });
-    paletteElement.appendChild(option);
+
+    element.appendChild(slot);
+  }
+}
+
+function handleMoodSelection(key, mood) {
+  const state = comboState[key];
+  if (!state) return;
+  if (state.length >= 3) {
+    setAuthMessage(key, "Combo full. Tap a mood bubble to remove one.", "info");
+    return;
+  }
+
+  state.push(mood);
+  setAuthMessage(key, "");
+  updateComboUI(key);
+}
+
+function populateMoodPad(key) {
+  const pad = padElements[key];
+  if (!pad) return;
+
+  pad.innerHTML = "";
+
+  palette.forEach(({ mood, color }) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "auth__pad-option";
+    button.innerHTML = `
+      <span class="auth__pad-swatch" style="background: ${color}"></span>
+      <span>${mood}</span>
+    `;
+
+    button.addEventListener("click", () => {
+      handleMoodSelection(key, mood);
+    });
+
+    pad.appendChild(button);
   });
 }
 
-function getMockData() {
-  return JSON.parse(localStorage.getItem("moodmap.moods")) ?? mockMoods;
+function resetCombo(key) {
+  comboState[key] = [];
+  updateComboUI(key);
+  setAuthMessage(key, "");
 }
 
-function saveMockData(data) {
-  localStorage.setItem("moodmap.moods", JSON.stringify(data));
+function setAuthMessage(target, message, tone = "info") {
+  const element = messageElements[target];
+  if (!element) return;
+
+  element.textContent = message;
+  if (message) {
+    element.dataset.tone = tone;
+  } else {
+    delete element.dataset.tone;
+  }
+}
+
+function loadUsers() {
+  try {
+    return JSON.parse(localStorage.getItem(USERS_KEY)) ?? {};
+  } catch (error) {
+    console.warn("Unable to parse stored users", error);
+    return {};
+  }
+}
+
+function saveUsers(users) {
+  localStorage.setItem(USERS_KEY, JSON.stringify(users));
+}
+
+function moodSequenceKey(sequence) {
+  return sequence.join("|");
+}
+
+function ensureUserData(username) {
+  const key = `${STORAGE_PREFIX}moods.${username}`;
+  if (!localStorage.getItem(key)) {
+    localStorage.setItem(key, JSON.stringify(starterMoods));
+  }
+}
+
+function getUserMoods(targetUser = currentUser) {
+  if (!targetUser) {
+    return [];
+  }
+
+  const key = `${STORAGE_PREFIX}moods.${targetUser}`;
+  const stored = localStorage.getItem(key);
+
+  if (!stored) {
+    return [];
+  }
+
+  try {
+    return JSON.parse(stored);
+  } catch (error) {
+    console.warn("Unable to parse mood data", error);
+    return [];
+  }
+}
+
+function saveUserMoods(data, targetUser = currentUser) {
+  if (!targetUser) return;
+  const key = `${STORAGE_PREFIX}moods.${targetUser}`;
+  localStorage.setItem(key, JSON.stringify(data));
+}
+
+function toggleAuthMode(mode) {
+  authMode = mode;
+
+  if (mode === "signIn") {
+    signInForm.classList.remove("auth__form--hidden");
+    createForm.classList.add("auth__form--hidden");
+    authSubtitle.textContent = "Pick the three-mood combo you chose when you signed up.";
+  } else {
+    createForm.classList.remove("auth__form--hidden");
+    signInForm.classList.add("auth__form--hidden");
+    authSubtitle.textContent = "Invent a username and lock it with a trio of moods.";
+  }
+
+  authPanel?.setAttribute("data-mode", mode);
+}
+
+function showAuthPanel() {
+  authPanel?.removeAttribute("hidden");
+  appElement?.classList.add("app--hidden");
+}
+
+function showAppPanel() {
+  authPanel?.setAttribute("hidden", "true");
+  appElement?.classList.remove("app--hidden");
+}
+
+function setCurrentUser(username) {
+  currentUser = username;
+
+  if (username) {
+    localStorage.setItem(CURRENT_USER_KEY, username);
+    ensureUserData(username);
+    showAppPanel();
+    logButton.disabled = false;
+    signOutButton.hidden = false;
+    signOutButton.textContent = `Sign out (${username})`;
+  } else {
+    localStorage.removeItem(CURRENT_USER_KEY);
+    showAuthPanel();
+    logButton.disabled = true;
+    signOutButton.hidden = true;
+  }
+
+  renderGrid();
 }
 
 function calculateStreak(data, today) {
@@ -110,8 +294,12 @@ function calculateStreak(data, today) {
 }
 
 function logMood(color) {
+  if (!currentUser) {
+    return;
+  }
+
   const today = getISODate(new Date());
-  const data = getMockData();
+  const data = getUserMoods();
   const existing = data.find((item) => item.date === today);
 
   if (existing) {
@@ -120,7 +308,7 @@ function logMood(color) {
     data.push({ date: today, color });
   }
 
-  saveMockData(data);
+  saveUserMoods(data);
   renderGrid();
 }
 
@@ -130,7 +318,7 @@ function renderGrid() {
   const firstDay = new Date(viewDate);
   const startOffset = firstDay.getDay();
   const daysInMonth = new Date(viewDate.getFullYear(), viewDate.getMonth() + 1, 0).getDate();
-  const data = getMockData();
+  const data = getUserMoods();
   const todayISO = getISODate(now);
   const dataMap = new Map(data.map((item) => [item.date, item.color]));
 
@@ -184,8 +372,10 @@ function renderGrid() {
     gridElement.appendChild(cell);
   }
 
-  const streakValue = calculateStreak(data, now);
-  streakCount.textContent = `${streakValue} day${streakValue === 1 ? "" : "s"}`;
+  const streakValue = currentUser ? calculateStreak(data, now) : 0;
+  streakCount.textContent = currentUser
+    ? `${streakValue} day${streakValue === 1 ? "" : "s"}`
+    : "Sign in to start";
   gridMonth.textContent = formatMonth(viewDate);
   currentDateLabel.textContent = formatDate(now);
 
@@ -200,11 +390,165 @@ function changeMonth(offset) {
   renderGrid();
 }
 
+function hydrateLegend() {
+  legendList.innerHTML = "";
+  palette.forEach(({ mood, color }) => {
+    const item = document.createElement("li");
+    item.className = "legend-item";
+    item.innerHTML = `
+      <span class="legend-item__swatch" style=\"background: ${color}\"></span>
+      <span>${mood}</span>
+    `;
+    legendList.appendChild(item);
+  });
+}
+
+function hydratePalette() {
+  paletteElement.innerHTML = "";
+  palette.forEach(({ mood, color }) => {
+    const option = document.createElement("button");
+    option.type = "button";
+    option.className = "palette__option";
+    option.dataset.color = color;
+    option.dataset.mood = mood;
+    option.innerHTML = `
+      <span class="palette__swatch" style=\"background: ${color}\"></span>
+      <span>${mood}</span>
+    `;
+    option.addEventListener("click", () => {
+      modal.close();
+      logMood(color);
+    });
+    paletteElement.appendChild(option);
+  });
+}
+
+function initialiseAuth() {
+  Object.keys(comboElements).forEach((key) => {
+    updateComboUI(key);
+    populateMoodPad(key);
+  });
+
+  document.querySelectorAll("[data-reset-combo]").forEach((button) => {
+    button.addEventListener("click", () => {
+      const key = button.getAttribute("data-reset-combo");
+      resetCombo(key);
+    });
+  });
+
+  switchToCreate?.addEventListener("click", () => {
+    toggleAuthMode("create");
+    resetCombo("create");
+    setAuthMessage("signIn", "");
+    createUsernameInput.focus();
+  });
+
+  switchToSignIn?.addEventListener("click", () => {
+    toggleAuthMode("signIn");
+    resetCombo("signIn");
+    setAuthMessage("create", "");
+    signInUsernameInput.focus();
+  });
+
+  signOutButton.addEventListener("click", () => {
+    setCurrentUser(null);
+    toggleAuthMode("signIn");
+    resetCombo("signIn");
+    signInForm.reset();
+    signInUsernameInput.focus();
+  });
+
+  signInForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+
+    const username = signInUsernameInput.value.trim();
+
+    if (!username) {
+      setAuthMessage("signIn", "Enter your username to continue.", "error");
+      return;
+    }
+
+    if (comboState.signIn.length !== 3) {
+      setAuthMessage("signIn", "Select your three moods in order.", "error");
+      return;
+    }
+
+    const users = loadUsers();
+    const secret = moodSequenceKey(comboState.signIn);
+
+    if (!users[username]) {
+      setAuthMessage("signIn", "We don't know that username yet. Try creating it.", "error");
+      return;
+    }
+
+    if (users[username] !== secret) {
+      setAuthMessage("signIn", "That mood combo doesn't match. Try again.", "error");
+      return;
+    }
+
+    setAuthMessage("signIn", "");
+    signInForm.reset();
+    resetCombo("signIn");
+    setCurrentUser(username);
+  });
+
+  createForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+
+    const username = createUsernameInput.value.trim();
+
+    if (!username) {
+      setAuthMessage("create", "Pick a username to get started.", "error");
+      return;
+    }
+
+    if (comboState.create.length !== 3) {
+      setAuthMessage("create", "Choose three moods to lock in your account.", "error");
+      return;
+    }
+
+    const users = loadUsers();
+
+    if (users[username]) {
+      setAuthMessage("create", "That username is already taken. Try another.", "error");
+      return;
+    }
+
+    users[username] = moodSequenceKey(comboState.create);
+    saveUsers(users);
+    ensureUserData(username);
+
+    setAuthMessage("create", "Account created! Signing you in...", "success");
+    createForm.reset();
+    resetCombo("create");
+    setCurrentUser(username);
+  });
+
+  toggleAuthMode("signIn");
+
+  const storedUser = localStorage.getItem(CURRENT_USER_KEY);
+  const knownUsers = loadUsers();
+
+  if (storedUser && knownUsers[storedUser]) {
+    setCurrentUser(storedUser);
+  } else {
+    setCurrentUser(null);
+    signOutButton.hidden = true;
+  }
+}
+
 logButton.addEventListener("click", () => {
+  if (!currentUser) {
+    showAuthPanel();
+    toggleAuthMode("signIn");
+    resetCombo("signIn");
+    signInUsernameInput.focus();
+    return;
+  }
+
   if (typeof modal.showModal === "function") {
     modal.showModal();
   } else {
-    // Fallback for browsers without dialog support
     modal.setAttribute("open", "true");
   }
 });
@@ -227,3 +571,5 @@ nextMonthButton.addEventListener("click", () => {
 hydrateLegend();
 hydratePalette();
 renderGrid();
+initialiseAuth();
+

--- a/MoodMap/index.html
+++ b/MoodMap/index.html
@@ -10,7 +10,56 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
 </head>
 <body>
-  <div class="app">
+  <div class="auth" id="authPanel" aria-labelledby="authTitle">
+    <div class="auth__card" role="dialog" aria-modal="true">
+      <div class="auth__header">
+        <h2 class="auth__title" id="authTitle">Unlock your MoodMap</h2>
+        <p class="auth__subtitle" id="authSubtitle">Pick the three-mood combo you chose when you signed up.</p>
+      </div>
+
+      <form class="auth__form" id="signInForm" autocomplete="off">
+        <label class="auth__label" for="signInUsername">Username</label>
+        <input class="auth__input" id="signInUsername" name="username" type="text" required autocomplete="username" placeholder="alex" />
+
+        <div class="auth__combo" id="signInCombo" aria-live="polite"></div>
+        <div class="auth__pad" id="signInPad" aria-label="Mood keypad"></div>
+
+        <div class="auth__controls">
+          <button type="button" class="auth__reset" data-reset-combo="signIn">Clear combo</button>
+        </div>
+
+        <p class="auth__message" id="signInMessage" role="status" aria-live="polite"></p>
+
+        <div class="auth__actions">
+          <button type="submit" class="button button--primary">Sign in</button>
+          <button type="button" class="button button--ghost" id="switchToCreate">Create account</button>
+        </div>
+      </form>
+
+      <form class="auth__form auth__form--hidden" id="createForm" autocomplete="off">
+        <label class="auth__label" for="createUsername">Choose a username</label>
+        <input class="auth__input" id="createUsername" name="new-username" type="text" required autocomplete="off" placeholder="moonbeam" />
+
+        <p class="auth__hint">Tap three moods in order to set your secret pass-sequence.</p>
+
+        <div class="auth__combo" id="createCombo" aria-live="polite"></div>
+        <div class="auth__pad" id="createPad" aria-label="Mood keypad"></div>
+
+        <div class="auth__controls">
+          <button type="button" class="auth__reset" data-reset-combo="create">Clear combo</button>
+        </div>
+
+        <p class="auth__message" id="createMessage" role="status" aria-live="polite"></p>
+
+        <div class="auth__actions">
+          <button type="submit" class="button button--primary">Create account</button>
+          <button type="button" class="button button--ghost" id="switchToSignIn">Back to sign in</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div class="app app--hidden">
     <header class="app__header">
       <div class="app__branding">
         <h1 class="app__title">MoodMap <span aria-hidden="true">🌈</span></h1>
@@ -22,6 +71,7 @@
           <span class="status-card__value" id="streakCount">0 days</span>
         </div>
         <button class="button button--primary" id="logMoodButton" type="button">Log Mood</button>
+        <button class="button button--ghost" id="signOutButton" type="button">Sign out</button>
       </div>
     </header>
 

--- a/MoodMap/styles.css
+++ b/MoodMap/styles.css
@@ -36,6 +36,10 @@ body {
   gap: 24px;
 }
 
+.app--hidden {
+  display: none;
+}
+
 .app__header {
   display: flex;
   flex-direction: column;
@@ -65,6 +69,7 @@ body {
   display: flex;
   gap: 16px;
   align-items: center;
+  flex-wrap: wrap;
 }
 
 .status-card {
@@ -110,6 +115,19 @@ body {
 .button--primary:focus-visible {
   transform: translateY(-1px);
   box-shadow: 0 12px 22px rgba(239, 71, 111, 0.3);
+}
+
+.button--ghost {
+  background: rgba(255, 255, 255, 0.65);
+  color: var(--color-text);
+  border: 1px solid rgba(31, 42, 55, 0.12);
+  box-shadow: none;
+}
+
+.button--ghost:hover,
+.button--ghost:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(31, 42, 55, 0.12);
 }
 
 .app__main {
@@ -363,6 +381,244 @@ body {
   border-radius: 50%;
   border: 3px solid rgba(255, 255, 255, 0.8);
   box-shadow: inset 0 0 0 1px rgba(31, 42, 55, 0.08);
+}
+
+.auth {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(247, 248, 250, 0.85);
+  backdrop-filter: blur(14px);
+  z-index: 10;
+  overflow-y: auto;
+}
+
+.auth[hidden] {
+  display: none;
+}
+
+.auth__card {
+  width: min(420px, 100%);
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  padding: 32px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.auth__header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  text-align: center;
+}
+
+.auth__title {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.auth__subtitle {
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.auth__form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.auth__form--hidden {
+  display: none;
+}
+
+.auth__label {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.auth__input {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: #f8fafc;
+  padding: 12px 16px;
+  font-size: 1rem;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.auth__input:focus {
+  border-color: transparent;
+  outline: 2px solid #5ab3e6;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(90, 179, 230, 0.18);
+}
+
+.auth__hint {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.auth__combo {
+  display: flex;
+  gap: 12px;
+}
+
+.auth__combo-slot {
+  flex: 1;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  background: #f8fafc;
+  color: var(--color-muted);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 6px;
+  gap: 6px;
+  cursor: pointer;
+  transition: border-color 150ms ease, transform 150ms ease, box-shadow 150ms ease;
+  min-height: 72px;
+  text-align: center;
+}
+
+.auth__combo-slot:hover,
+.auth__combo-slot:focus-visible {
+  border-color: var(--color-text);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(31, 42, 55, 0.1);
+}
+
+.auth__combo-slot--filled {
+  border-style: solid;
+  border-color: transparent;
+  background: linear-gradient(135deg, rgba(239, 71, 111, 0.12), rgba(90, 179, 230, 0.12));
+  color: var(--color-text);
+}
+
+.auth__combo-swatch {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  box-shadow: 0 6px 12px rgba(31, 42, 55, 0.18);
+}
+
+.auth__combo-placeholder {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.auth__pad {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.auth__pad-option {
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-soft);
+  padding: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.auth__pad-option:hover,
+.auth__pad-option:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(31, 42, 55, 0.16);
+}
+
+.auth__pad-swatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+}
+
+.auth__controls {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.auth__reset {
+  border: none;
+  background: none;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+}
+
+.auth__reset:hover,
+.auth__reset:focus-visible {
+  color: var(--color-text);
+}
+
+.auth__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.auth__message {
+  min-height: 1.1rem;
+  font-size: 0.85rem;
+}
+
+.auth__message[data-tone="error"] {
+  color: #ef476f;
+}
+
+.auth__message[data-tone="success"] {
+  color: #06d6a0;
+}
+
+.auth__card form:last-of-type .auth__actions {
+  justify-content: space-between;
+}
+
+.auth__card form .button--primary,
+.auth__card form .button--ghost {
+  flex: 1;
+  min-width: 140px;
+}
+
+@media (max-width: 480px) {
+  .auth {
+    padding: 16px;
+  }
+
+  .auth__card {
+    padding: 24px 20px;
+  }
+
+  .auth__combo {
+    flex-direction: column;
+  }
+
+  .auth__actions {
+    flex-direction: column;
+  }
+
+  .auth__card form .button--primary,
+  .auth__card form .button--ghost {
+    min-width: unset;
+    width: 100%;
+  }
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- add a mood-combo based authentication overlay for creating and signing into accounts
- persist user credentials and mood entries per user in localStorage with sign-out support
- refresh MoodMap UI styling to accommodate the new auth flow

## Testing
- manual: python -m http.server 8000 & opened http://127.0.0.1:8000/MoodMap/


------
https://chatgpt.com/codex/tasks/task_e_68e4043c81888322936aa9b4abf1df1f