### PR TITLE
Refactor MoodMap for Firebase login and mobile layout

### DIFF
--- a/MoodMap/app.js
+++ b/MoodMap/app.js
@@ -1,3 +1,24 @@
+import {
+  initializeApp
+} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+import {
+  getAuth,
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  updateProfile,
+  signOut
+} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+import {
+  getFirestore,
+  doc,
+  setDoc,
+  onSnapshot,
+  collection,
+  query,
+  orderBy
+} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+
 const palette = [
   { mood: "Joy", color: "#FFD166" },
   { mood: "Calm", color: "#5AB3E6" },
@@ -5,19 +26,6 @@ const palette = [
   { mood: "Tired", color: "#A8A8A8" },
   { mood: "Sad", color: "#26547C" },
   { mood: "Angry", color: "#EF476F" }
-];
-
-const mockMoods = [
-  { date: "2024-03-02", color: "#5AB3E6" },
-  { date: "2024-03-03", color: "#FFD166" },
-  { date: "2024-03-05", color: "#06D6A0" },
-  { date: "2024-03-08", color: "#26547C" },
-  { date: "2024-03-09", color: "#EF476F" },
-  { date: "2024-03-12", color: "#FFD166" },
-  { date: "2024-03-15", color: "#A8A8A8" },
-  { date: "2024-03-18", color: "#5AB3E6" },
-  { date: "2024-03-21", color: "#06D6A0" },
-  { date: "2024-03-24", color: "#FFD166" }
 ];
 
 const gridElement = document.getElementById("moodGrid");
@@ -30,11 +38,53 @@ const gridMonth = document.getElementById("gridMonth");
 const previousMonthButton = document.getElementById("previousMonth");
 const nextMonthButton = document.getElementById("nextMonth");
 const currentDateLabel = document.getElementById("currentDate");
+const appElement = document.querySelector(".app");
+const authPanel = document.getElementById("authPanel");
+const signOutButton = document.getElementById("signOutButton");
+const authTabs = document.querySelectorAll("[data-auth-tab]");
+const authForms = document.querySelectorAll("[data-auth-form]");
+const authNotice = document.getElementById("authNotice");
+const authTitle = document.getElementById("authTitle");
 
+const loginForm = document.getElementById("loginForm");
+const loginEmailInput = document.getElementById("loginEmail");
+const loginPasswordInput = document.getElementById("loginPassword");
+const loginMessage = document.getElementById("loginMessage");
+
+const registerForm = document.getElementById("registerForm");
+const registerNameInput = document.getElementById("registerName");
+const registerEmailInput = document.getElementById("registerEmail");
+const registerPasswordInput = document.getElementById("registerPassword");
+const registerConfirmInput = document.getElementById("registerConfirm");
+const registerMessage = document.getElementById("registerMessage");
+
+const firebaseConfig = window.moodMapFirebaseConfig;
+
+let firebaseReady = false;
+let appInstance;
+let auth;
+let db;
+let user = null;
+let moodEntries = [];
 let currentViewDate = (() => {
   const today = new Date();
   return new Date(today.getFullYear(), today.getMonth(), 1);
 })();
+let unsubscribeMoods = null;
+
+const status = {
+  pendingLogin: false,
+  pendingRegister: false
+};
+
+function setFormsEnabled(isEnabled) {
+  [loginForm, registerForm].forEach((form) => {
+    if (!form) return;
+    Array.from(form.elements).forEach((element) => {
+      element.disabled = !isEnabled;
+    });
+  });
+}
 
 function formatDate(date) {
   return new Intl.DateTimeFormat("en-US", {
@@ -55,13 +105,55 @@ function getISODate(date) {
   return date.toISOString().split("T")[0];
 }
 
+function setAuthMessage(target, message, tone = "info") {
+  const element = target === "login" ? loginMessage : registerMessage;
+  if (!element) return;
+  element.textContent = message;
+  element.dataset.tone = message ? tone : "";
+  if (!message) {
+    delete element.dataset.tone;
+  }
+}
+
+function setAuthNotice(message) {
+  if (!authNotice) return;
+  if (message) {
+    authNotice.removeAttribute("hidden");
+    authNotice.textContent = message;
+  } else {
+    authNotice.setAttribute("hidden", "true");
+    authNotice.textContent = "";
+  }
+}
+
+function toggleForm(mode) {
+  authTabs.forEach((tab) => {
+    const isActive = tab.dataset.authTab === mode;
+    tab.classList.toggle("auth__tab--active", isActive);
+    tab.setAttribute("aria-selected", String(isActive));
+    tab.setAttribute("tabindex", isActive ? "0" : "-1");
+  });
+
+  authForms.forEach((form) => {
+    form.toggleAttribute("hidden", form.dataset.authForm !== mode);
+  });
+
+  authTitle.textContent = mode === "login" ? "Welcome back" : "Create your MoodMap";
+
+  if (mode === "login") {
+    loginEmailInput?.focus();
+  } else {
+    registerNameInput?.focus();
+  }
+}
+
 function hydrateLegend() {
   legendList.innerHTML = "";
   palette.forEach(({ mood, color }) => {
     const item = document.createElement("li");
     item.className = "legend-item";
     item.innerHTML = `
-      <span class="legend-item__swatch" style="background: ${color}"></span>
+      <span class="legend-item__swatch" style="background:${color}"></span>
       <span>${mood}</span>
     `;
     legendList.appendChild(item);
@@ -77,31 +169,23 @@ function hydratePalette() {
     option.dataset.color = color;
     option.dataset.mood = mood;
     option.innerHTML = `
-      <span class="palette__swatch" style="background: ${color}"></span>
+      <span class="palette__swatch" style="background:${color}"></span>
       <span>${mood}</span>
     `;
     option.addEventListener("click", () => {
       modal.close();
-      logMood(color);
+      logMood(color, mood);
     });
     paletteElement.appendChild(option);
   });
 }
 
-function getMockData() {
-  return JSON.parse(localStorage.getItem("moodmap.moods")) ?? mockMoods;
-}
-
-function saveMockData(data) {
-  localStorage.setItem("moodmap.moods", JSON.stringify(data));
-}
-
 function calculateStreak(data, today) {
-  const set = new Set(data.map((item) => item.date));
+  const dates = new Set(data.map((item) => item.date));
   let streak = 0;
   const cursor = new Date(today);
 
-  while (set.has(getISODate(cursor))) {
+  while (dates.has(getISODate(cursor))) {
     streak += 1;
     cursor.setDate(cursor.getDate() - 1);
   }
@@ -109,34 +193,25 @@ function calculateStreak(data, today) {
   return streak;
 }
 
-function logMood(color) {
-  const today = getISODate(new Date());
-  const data = getMockData();
-  const existing = data.find((item) => item.date === today);
-
-  if (existing) {
-    existing.color = color;
-  } else {
-    data.push({ date: today, color });
-  }
-
-  saveMockData(data);
-  renderGrid();
-}
-
 function renderGrid() {
   const now = new Date();
-  const viewDate = new Date(currentViewDate.getFullYear(), currentViewDate.getMonth(), 1);
+  const viewDate = new Date(
+    currentViewDate.getFullYear(),
+    currentViewDate.getMonth(),
+    1
+  );
   const firstDay = new Date(viewDate);
   const startOffset = firstDay.getDay();
-  const daysInMonth = new Date(viewDate.getFullYear(), viewDate.getMonth() + 1, 0).getDate();
-  const data = getMockData();
+  const daysInMonth = new Date(
+    viewDate.getFullYear(),
+    viewDate.getMonth() + 1,
+    0
+  ).getDate();
   const todayISO = getISODate(now);
-  const dataMap = new Map(data.map((item) => [item.date, item.color]));
+  const dataMap = new Map(moodEntries.map((entry) => [entry.date, entry.color]));
+  const moodMap = new Map(moodEntries.map((entry) => [entry.date, entry.mood]));
 
   gridElement.innerHTML = "";
-  gridElement.style.setProperty("--days", daysInMonth);
-
   const totalCells = Math.ceil((startOffset + daysInMonth) / 7) * 7;
 
   for (let cellIndex = 0; cellIndex < totalCells; cellIndex += 1) {
@@ -150,13 +225,18 @@ function renderGrid() {
     const dayNumber = cellIndex - startOffset + 1;
 
     if (dayNumber > 0 && dayNumber <= daysInMonth) {
-      const date = new Date(viewDate.getFullYear(), viewDate.getMonth(), dayNumber);
+      const date = new Date(
+        viewDate.getFullYear(),
+        viewDate.getMonth(),
+        dayNumber
+      );
       const isoDate = getISODate(date);
       const color = dataMap.get(isoDate);
+      const mood = moodMap.get(isoDate);
 
       if (color) {
         cell.classList.add("cell--filled");
-        cell.style.background = color;
+        cell.style.setProperty("--cell-color", color);
       }
 
       if (isoDate === todayISO) {
@@ -169,61 +249,279 @@ function renderGrid() {
 
       const moodLabel = document.createElement("span");
       moodLabel.className = "cell__mood";
-      moodLabel.textContent = palette.find((entry) => entry.color === color)?.mood ?? "";
+      moodLabel.textContent = mood ?? "";
 
       cellContent.append(label, moodLabel);
       cell.appendChild(cellContent);
       cell.dataset.date = isoDate;
-      cell.title = color ? `${moodLabel.textContent} on ${date.toDateString()}` : date.toDateString();
+      cell.title = mood ? `${mood} on ${date.toDateString()}` : date.toDateString();
     } else {
       cell.classList.add("cell--empty");
-      cellContent.style.visibility = "hidden";
+      cellContent.setAttribute("aria-hidden", "true");
       cell.appendChild(cellContent);
     }
 
     gridElement.appendChild(cell);
   }
 
-  const streakValue = calculateStreak(data, now);
-  streakCount.textContent = `${streakValue} day${streakValue === 1 ? "" : "s"}`;
+  const streakValue = user ? calculateStreak(moodEntries, now) : 0;
+  streakCount.textContent = user
+    ? `${streakValue} day${streakValue === 1 ? "" : "s"}`
+    : "Sign in to start";
   gridMonth.textContent = formatMonth(viewDate);
   currentDateLabel.textContent = formatDate(now);
 
   const isCurrentMonth =
-    viewDate.getFullYear() === now.getFullYear() && viewDate.getMonth() === now.getMonth();
+    viewDate.getFullYear() === now.getFullYear() &&
+    viewDate.getMonth() === now.getMonth();
 
   nextMonthButton.disabled = isCurrentMonth;
 }
 
+function logMood(color, mood) {
+  if (!user || !firebaseReady) {
+    return;
+  }
+
+  const today = getISODate(new Date());
+  const moodDoc = doc(db, "users", user.uid, "moods", today);
+
+  setDoc(moodDoc, {
+    date: today,
+    color,
+    mood,
+    updatedAt: Date.now()
+  });
+}
+
 function changeMonth(offset) {
-  currentViewDate = new Date(currentViewDate.getFullYear(), currentViewDate.getMonth() + offset, 1);
+  currentViewDate = new Date(
+    currentViewDate.getFullYear(),
+    currentViewDate.getMonth() + offset,
+    1
+  );
   renderGrid();
 }
 
-logButton.addEventListener("click", () => {
-  if (typeof modal.showModal === "function") {
-    modal.showModal();
-  } else {
-    // Fallback for browsers without dialog support
-    modal.setAttribute("open", "true");
+function unsubscribeFromMoods() {
+  if (unsubscribeMoods) {
+    unsubscribeMoods();
+    unsubscribeMoods = null;
   }
-});
+}
 
-modal.addEventListener("cancel", (event) => {
-  event.preventDefault();
-  modal.close();
-});
+function subscribeToMoods(currentUser) {
+  unsubscribeFromMoods();
 
-previousMonthButton.addEventListener("click", () => {
-  changeMonth(-1);
-});
-
-nextMonthButton.addEventListener("click", () => {
-  if (!nextMonthButton.disabled) {
-    changeMonth(1);
+  if (!currentUser || !firebaseReady) {
+    moodEntries = [];
+    renderGrid();
+    return;
   }
-});
+
+  const moodsQuery = query(
+    collection(db, "users", currentUser.uid, "moods"),
+    orderBy("date", "asc")
+  );
+
+  unsubscribeMoods = onSnapshot(moodsQuery, (snapshot) => {
+    moodEntries = snapshot.docs.map((docSnapshot) => docSnapshot.data());
+    renderGrid();
+  });
+}
+
+function showAppPanel() {
+  authPanel?.setAttribute("hidden", "true");
+  appElement?.classList.remove("app--hidden");
+}
+
+function showAuthPanel() {
+  authPanel?.removeAttribute("hidden");
+  appElement?.classList.add("app--hidden");
+}
+
+function setLoadingState(form, isLoading) {
+  const button = form.querySelector("button[type='submit']");
+  if (button) {
+    button.disabled = isLoading;
+    button.dataset.loading = isLoading ? "true" : "false";
+  }
+}
+
+function initialiseFirebase() {
+  if (!firebaseConfig || !firebaseConfig.apiKey || firebaseConfig.apiKey === "YOUR_API_KEY") {
+    setAuthNotice(
+      "Add your Firebase configuration in MoodMap/firebase-config.js to enable secure sign-in."
+    );
+    setFormsEnabled(false);
+    showAuthPanel();
+    logButton.disabled = true;
+    signOutButton.hidden = true;
+    firebaseReady = false;
+    return;
+  }
+
+  setAuthNotice("");
+  setFormsEnabled(true);
+  appInstance = initializeApp(firebaseConfig);
+  auth = getAuth(appInstance);
+  db = getFirestore(appInstance);
+  firebaseReady = true;
+
+  onAuthStateChanged(auth, (firebaseUser) => {
+    user = firebaseUser;
+
+    if (user) {
+      showAppPanel();
+      logButton.disabled = false;
+      signOutButton.hidden = false;
+      signOutButton.textContent = `Sign out (${user.displayName || user.email})`;
+      subscribeToMoods(user);
+    } else {
+      showAuthPanel();
+      logButton.disabled = true;
+      signOutButton.hidden = true;
+      moodEntries = [];
+      renderGrid();
+    }
+  });
+}
+
+function initialiseAuth() {
+  toggleForm("login");
+
+  authTabs.forEach((tab) => {
+    tab.addEventListener("click", () => {
+      const mode = tab.dataset.authTab;
+      toggleForm(mode);
+    });
+  });
+
+  loginForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    if (!firebaseReady) return;
+
+    const email = loginEmailInput.value.trim();
+    const password = loginPasswordInput.value;
+
+    if (!email || !password) {
+      setAuthMessage("login", "Enter your email and password.", "error");
+      return;
+    }
+
+    setAuthMessage("login", "");
+    setLoadingState(loginForm, true);
+    status.pendingLogin = true;
+
+    signInWithEmailAndPassword(auth, email, password)
+      .then(() => {
+        loginForm.reset();
+      })
+      .catch((error) => {
+        setAuthMessage("login", error.message.replace("Firebase:", "").trim(), "error");
+      })
+      .finally(() => {
+        status.pendingLogin = false;
+        setLoadingState(loginForm, false);
+      });
+  });
+
+  registerForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    if (!firebaseReady) return;
+
+    const displayName = registerNameInput.value.trim();
+    const email = registerEmailInput.value.trim();
+    const password = registerPasswordInput.value;
+    const confirmPassword = registerConfirmInput.value;
+
+    if (!displayName) {
+      setAuthMessage("register", "Share a name to personalize your map.", "error");
+      registerNameInput.focus();
+      return;
+    }
+
+    if (!email) {
+      setAuthMessage("register", "Enter an email address.", "error");
+      registerEmailInput.focus();
+      return;
+    }
+
+    if (password.length < 6) {
+      setAuthMessage("register", "Password must be at least 6 characters.", "error");
+      registerPasswordInput.focus();
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setAuthMessage("register", "Passwords do not match.", "error");
+      registerConfirmInput.focus();
+      return;
+    }
+
+    setAuthMessage("register", "");
+    setLoadingState(registerForm, true);
+    status.pendingRegister = true;
+
+    createUserWithEmailAndPassword(auth, email, password)
+      .then(async ({ user: newUser }) => {
+        if (displayName) {
+          await updateProfile(newUser, { displayName });
+        }
+        registerForm.reset();
+        toggleForm("login");
+        setAuthMessage("login", "Account created! Sign in to start logging moods.", "success");
+      })
+      .catch((error) => {
+        setAuthMessage("register", error.message.replace("Firebase:", "").trim(), "error");
+      })
+      .finally(() => {
+        status.pendingRegister = false;
+        setLoadingState(registerForm, false);
+      });
+  });
+
+  signOutButton.addEventListener("click", () => {
+    if (!firebaseReady) return;
+    signOut(auth);
+  });
+}
+
+function bindInteractions() {
+  logButton.addEventListener("click", () => {
+    if (!user) {
+      showAuthPanel();
+      toggleForm("login");
+      loginEmailInput.focus();
+      return;
+    }
+
+    if (typeof modal.showModal === "function") {
+      modal.showModal();
+    } else {
+      modal.setAttribute("open", "true");
+    }
+  });
+
+  modal.addEventListener("cancel", (event) => {
+    event.preventDefault();
+    modal.close();
+  });
+
+  previousMonthButton.addEventListener("click", () => {
+    changeMonth(-1);
+  });
+
+  nextMonthButton.addEventListener("click", () => {
+    if (!nextMonthButton.disabled) {
+      changeMonth(1);
+    }
+  });
+}
 
 hydrateLegend();
 hydratePalette();
 renderGrid();
+initialiseAuth();
+bindInteractions();
+initialiseFirebase();

--- a/MoodMap/firebase-config.js
+++ b/MoodMap/firebase-config.js
@@ -1,0 +1,10 @@
+// Replace the placeholder values below with your Firebase project configuration.
+// You can find these settings in your Firebase console under Project Settings > General.
+window.moodMapFirebaseConfig = window.moodMapFirebaseConfig || {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID"
+};

--- a/MoodMap/index.html
+++ b/MoodMap/index.html
@@ -2,15 +2,76 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>MoodMap 🌈</title>
-  <link rel="stylesheet" href="styles.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <div class="app">
+  <div class="auth" id="authPanel" aria-labelledby="authTitle">
+    <div class="auth__card" role="dialog" aria-modal="true">
+      <header class="auth__header">
+        <p class="auth__badge">MoodMap</p>
+        <h2 class="auth__title" id="authTitle">Welcome back</h2>
+        <p class="auth__subtitle">Sign in to track how you're feeling and keep your streak alive.</p>
+      </header>
+
+      <div class="auth__tabs" role="tablist">
+        <button type="button" class="auth__tab auth__tab--active" data-auth-tab="login" role="tab" aria-selected="true">Sign in</button>
+        <button type="button" class="auth__tab" data-auth-tab="register" role="tab" aria-selected="false" tabindex="-1">Create account</button>
+      </div>
+
+      <p class="auth__notice" id="authNotice" hidden></p>
+
+      <form class="auth__form" id="loginForm" data-auth-form="login" autocomplete="on" novalidate>
+        <div class="auth__field">
+          <label class="auth__label" for="loginEmail">Email</label>
+          <input class="auth__input" id="loginEmail" type="email" name="email" autocomplete="email" inputmode="email" required />
+        </div>
+
+        <div class="auth__field">
+          <label class="auth__label" for="loginPassword">Password</label>
+          <input class="auth__input" id="loginPassword" type="password" name="password" autocomplete="current-password" minlength="6" required />
+        </div>
+
+        <button type="submit" class="button button--primary">Sign in</button>
+        <p class="auth__message" id="loginMessage" role="status" aria-live="polite"></p>
+      </form>
+
+      <form class="auth__form" id="registerForm" data-auth-form="register" autocomplete="on" hidden novalidate>
+        <div class="auth__field">
+          <label class="auth__label" for="registerName">Display name</label>
+          <input class="auth__input" id="registerName" type="text" name="name" autocomplete="name" placeholder="Skylar" required />
+        </div>
+
+        <div class="auth__field">
+          <label class="auth__label" for="registerEmail">Email</label>
+          <input class="auth__input" id="registerEmail" type="email" name="email" autocomplete="email" required />
+        </div>
+
+        <div class="auth__field">
+          <label class="auth__label" for="registerPassword">Password</label>
+          <input class="auth__input" id="registerPassword" type="password" name="password" autocomplete="new-password" minlength="6" required />
+        </div>
+
+        <div class="auth__field">
+          <label class="auth__label" for="registerConfirm">Confirm password</label>
+          <input class="auth__input" id="registerConfirm" type="password" name="confirm" autocomplete="new-password" minlength="6" required />
+        </div>
+
+        <button type="submit" class="button button--primary">Create account</button>
+        <p class="auth__message" id="registerMessage" role="status" aria-live="polite"></p>
+      </form>
+
+      <footer class="auth__footer">
+        <p>By continuing you agree to store your moods securely in our cloud database.</p>
+      </footer>
+    </div>
+  </div>
+
+  <div class="app app--hidden">
     <header class="app__header">
       <div class="app__branding">
         <h1 class="app__title">MoodMap <span aria-hidden="true">🌈</span></h1>
@@ -18,10 +79,11 @@
       </div>
       <div class="app__status">
         <div class="status-card">
-          <span class="status-card__label">Streak</span>
+          <span class="status-card__label">Current streak</span>
           <span class="status-card__value" id="streakCount">0 days</span>
         </div>
-        <button class="button button--primary" id="logMoodButton" type="button">Log Mood</button>
+        <button class="button button--primary" id="logMoodButton" type="button" disabled>Log mood</button>
+        <button class="button button--ghost" id="signOutButton" type="button" hidden>Sign out</button>
       </div>
     </header>
 
@@ -43,14 +105,14 @@
         </div>
         <div class="grid__cells" id="moodGrid" role="grid"></div>
         <div class="grid__legend">
-          <h2 class="grid__legend-title">Legend</h2>
+          <h2 class="grid__legend-title">Palette</h2>
           <ul class="legend-list" id="legendList"></ul>
         </div>
       </section>
     </main>
 
-    <nav class="app__nav" aria-label="Primary">
-      <button class="nav__item nav__item--active" type="button">My Map</button>
+    <nav class="app__nav" aria-label="Primary navigation">
+      <button class="nav__item nav__item--active" type="button">My map</button>
       <button class="nav__item" type="button">Global</button>
       <button class="nav__item" type="button">Profile</button>
     </nav>
@@ -68,6 +130,7 @@
     </form>
   </dialog>
 
-  <script src="app.js" type="module"></script>
+  <script src="firebase-config.js"></script>
+  <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/MoodMap/styles.css
+++ b/MoodMap/styles.css
@@ -1,39 +1,46 @@
 :root {
-  --color-background: #f7f8fa;
-  --color-surface: #ffffff;
-  --color-text: #1f2a37;
-  --color-muted: #6b7280;
-  --color-border: #e5e7eb;
-  --color-today: #ffed66;
-  --shadow-soft: 0 12px 24px rgba(31, 42, 55, 0.08);
+  --surface: #ffffff;
+  --background: linear-gradient(180deg, #f4f6ff 0%, #ffffff 100%);
+  --text-primary: #1f2933;
+  --text-muted: #6b7280;
+  --border: #e5e7eb;
+  --accent: #5ab3e6;
   --radius-lg: 24px;
   --radius-md: 16px;
   --radius-sm: 12px;
+  --shadow: 0 20px 45px rgba(31, 41, 55, 0.12);
   --font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 * {
   box-sizing: border-box;
-  margin: 0;
-  padding: 0;
 }
 
 body {
+  margin: 0;
   font-family: var(--font-family);
-  background: linear-gradient(180deg, #f4f9ff 0%, #ffffff 100%);
-  color: var(--color-text);
+  background: var(--background);
+  color: var(--text-primary);
   min-height: 100vh;
-  display: flex;
-  justify-content: center;
+}
+
+button,
+input {
+  font-family: inherit;
 }
 
 .app {
-  width: min(420px, 100%);
-  min-height: 100vh;
+  width: min(960px, 100%);
+  margin: 0 auto;
+  min-height: 100dvh;
+  padding: clamp(20px, 4vw, 40px) clamp(16px, 4vw, 48px) clamp(80px, 10vw, 120px);
   display: flex;
   flex-direction: column;
-  padding: 24px 20px 80px;
-  gap: 24px;
+  gap: clamp(16px, 3vw, 32px);
+}
+
+.app--hidden {
+  display: none;
 }
 
 .app__header {
@@ -49,67 +56,80 @@ body {
 }
 
 .app__title {
-  font-size: 1.8rem;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
   font-weight: 700;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
 }
 
 .app__subtitle {
-  font-size: 0.95rem;
-  color: var(--color-muted);
+  color: var(--text-muted);
+  font-size: 1rem;
 }
 
 .app__status {
   display: flex;
-  gap: 16px;
+  flex-wrap: wrap;
+  gap: 12px;
   align-items: center;
 }
 
 .status-card {
   flex: 1;
-  background: var(--color-surface);
+  min-width: 160px;
+  background: var(--surface);
   border-radius: var(--radius-md);
-  box-shadow: var(--shadow-soft);
-  padding: 14px 16px;
+  box-shadow: 0 14px 28px rgba(31, 41, 55, 0.12);
+  padding: 16px 20px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
 }
 
 .status-card__label {
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--color-muted);
+  color: var(--text-muted);
 }
 
 .status-card__value {
-  font-size: 1.2rem;
+  font-size: 1.4rem;
   font-weight: 600;
 }
 
 .button {
   border: none;
   border-radius: 999px;
-  padding: 12px 22px;
+  padding: 12px 24px;
   font-size: 0.95rem;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 150ms ease, box-shadow 150ms ease;
+  transition: transform 150ms ease, box-shadow 150ms ease, opacity 150ms ease;
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .button--primary {
-  background: linear-gradient(120deg, #ef476f 0%, #ffd166 100%);
-  color: #fff;
-  box-shadow: 0 10px 18px rgba(239, 71, 111, 0.25);
+  color: #ffffff;
+  background: linear-gradient(120deg, #ef476f 0%, #ffd166 50%, #06d6a0 100%);
+  box-shadow: 0 16px 30px rgba(239, 71, 111, 0.25);
 }
 
-.button--primary:hover,
-.button--primary:focus-visible {
+.button--ghost {
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--text-primary);
+  border: 1px solid rgba(31, 41, 55, 0.1);
+}
+
+.button:hover:not(:disabled),
+.button:focus-visible:not(:disabled) {
   transform: translateY(-1px);
-  box-shadow: 0 12px 22px rgba(239, 71, 111, 0.3);
+  box-shadow: 0 18px 32px rgba(31, 41, 55, 0.16);
 }
 
 .app__main {
@@ -117,13 +137,14 @@ body {
 }
 
 .grid {
-  background: var(--color-surface);
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(14px);
   border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-soft);
-  padding: 24px 20px 28px;
+  box-shadow: var(--shadow);
+  padding: clamp(20px, 4vw, 36px);
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: clamp(16px, 3vw, 28px);
 }
 
 .grid__header {
@@ -134,21 +155,21 @@ body {
 }
 
 .grid__header-month {
-  font-size: 1.2rem;
-  font-weight: 600;
-  text-align: center;
   flex: 1;
+  text-align: center;
+  font-size: clamp(1.1rem, 2.6vw, 1.5rem);
+  font-weight: 600;
 }
 
 .grid__nav-button {
   border: none;
-  background: #f1f5f9;
-  color: var(--color-muted);
-  width: 36px;
-  height: 36px;
+  background: #f3f4f6;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
-  font-size: 1rem;
   cursor: pointer;
+  color: var(--text-muted);
+  font-size: 1rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -158,8 +179,8 @@ body {
 .grid__nav-button:hover,
 .grid__nav-button:focus-visible {
   transform: translateY(-1px);
-  box-shadow: 0 8px 18px rgba(31, 42, 55, 0.12);
-  color: var(--color-text);
+  box-shadow: 0 12px 20px rgba(31, 41, 55, 0.14);
+  color: var(--text-primary);
 }
 
 .grid__nav-button:disabled {
@@ -171,57 +192,72 @@ body {
 
 .grid__weekdays {
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: 10px;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: clamp(6px, 1.8vw, 12px);
+  text-align: center;
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--color-muted);
-  text-align: center;
+  color: var(--text-muted);
 }
 
 .grid__cells {
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: 10px;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: clamp(6px, 1.8vw, 12px);
 }
 
 .cell {
   position: relative;
-  padding-top: 100%;
+  aspect-ratio: 1 / 1;
   border-radius: var(--radius-sm);
   background: #f1f5f9;
   overflow: hidden;
   transition: transform 150ms ease, box-shadow 150ms ease;
 }
 
+.cell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: var(--cell-color, #f1f5f9);
+  transition: opacity 200ms ease;
+}
+
 .cell__content {
   position: absolute;
-  inset: 6px;
-  border-radius: calc(var(--radius-sm) - 4px);
-  background: rgba(255, 255, 255, 0.7);
+  inset: clamp(4px, 1vw, 8px);
+  border-radius: calc(var(--radius-sm) - 6px);
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
   justify-content: space-between;
-  padding: 6px;
-  font-size: 0.75rem;
-  color: var(--color-muted);
+  align-items: flex-end;
+  padding: clamp(4px, 1.5vw, 8px);
+  background: rgba(255, 255, 255, 0.65);
+  color: var(--text-muted);
+  font-size: clamp(0.65rem, 1.8vw, 0.8rem);
 }
 
 .cell--filled .cell__content {
+  background: rgba(0, 0, 0, 0.05);
   color: #ffffff;
   font-weight: 600;
-  background: transparent;
 }
 
 .cell--today {
-  outline: 2px solid rgba(255, 209, 102, 0.9);
-  outline-offset: 2px;
+  outline: 2px solid rgba(255, 209, 102, 0.8);
+  outline-offset: 3px;
 }
 
 .cell__date {
   font-variant-numeric: tabular-nums;
+}
+
+.cell__mood {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.7em;
 }
 
 .grid__legend {
@@ -231,12 +267,14 @@ body {
 }
 
 .grid__legend-title {
-  font-size: 0.95rem;
+  font-size: 1rem;
   font-weight: 600;
 }
 
 .legend-list {
   list-style: none;
+  padding: 0;
+  margin: 0;
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
@@ -246,10 +284,10 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
-  background: #f1f5f9;
+  background: rgba(241, 245, 249, 0.9);
   border-radius: 999px;
   padding: 6px 12px;
-  font-size: 0.8rem;
+  font-size: 0.85rem;
 }
 
 .legend-item__swatch {
@@ -259,26 +297,25 @@ body {
 }
 
 .app__nav {
-  position: fixed;
-  left: 50%;
-  bottom: 20px;
-  transform: translateX(-50%);
-  width: min(380px, calc(100% - 32px));
+  position: sticky;
+  bottom: clamp(16px, 4vw, 32px);
+  align-self: center;
+  width: min(480px, calc(100% - 32px));
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 12px;
-  background: rgba(255, 255, 255, 0.9);
-  backdrop-filter: blur(14px);
+  gap: 10px;
+  background: rgba(255, 255, 255, 0.92);
   border-radius: 999px;
-  box-shadow: 0 16px 34px rgba(31, 42, 55, 0.12);
+  box-shadow: 0 18px 34px rgba(31, 41, 55, 0.18);
   padding: 12px;
+  backdrop-filter: blur(12px);
 }
 
 .nav__item {
   border: none;
   background: transparent;
   font-weight: 600;
-  color: var(--color-muted);
+  color: var(--text-muted);
   padding: 10px 0;
   border-radius: 999px;
   cursor: pointer;
@@ -294,18 +331,18 @@ body {
   border: none;
   border-radius: var(--radius-lg);
   padding: 0;
-  width: min(420px, 90vw);
-  box-shadow: var(--shadow-soft);
+  width: min(420px, 94vw);
+  box-shadow: var(--shadow);
 }
 
 .modal::backdrop {
-  background: rgba(31, 42, 55, 0.45);
+  background: rgba(17, 24, 39, 0.45);
 }
 
 .modal__content {
-  background: var(--color-surface);
+  background: var(--surface);
   border-radius: var(--radius-lg);
-  padding: 24px;
+  padding: clamp(20px, 4vw, 28px);
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -315,18 +352,19 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 12px;
 }
 
 .modal__title {
-  font-size: 1.2rem;
+  font-size: 1.1rem;
   font-weight: 600;
 }
 
 .modal__close {
   border: none;
-  background: #f1f5f9;
-  width: 32px;
-  height: 32px;
+  background: #f3f4f6;
+  width: 36px;
+  height: 36px;
   border-radius: 50%;
   font-size: 1.2rem;
   cursor: pointer;
@@ -334,15 +372,17 @@ body {
 
 .palette {
   list-style: none;
+  margin: 0;
+  padding: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 12px;
 }
 
 .palette__option {
   border: none;
   border-radius: var(--radius-md);
-  background: #f1f5f9;
+  background: rgba(241, 245, 249, 0.8);
   padding: 14px;
   display: flex;
   align-items: center;
@@ -354,26 +394,178 @@ body {
 .palette__option:hover,
 .palette__option:focus-visible {
   transform: translateY(-1px);
-  box-shadow: 0 10px 18px rgba(31, 42, 55, 0.12);
+  box-shadow: 0 12px 24px rgba(31, 41, 55, 0.16);
 }
 
 .palette__swatch {
-  width: 36px;
-  height: 36px;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
   border: 3px solid rgba(255, 255, 255, 0.8);
-  box-shadow: inset 0 0 0 1px rgba(31, 42, 55, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.1);
+}
+
+.auth {
+  position: fixed;
+  inset: 0;
+  background: rgba(244, 246, 255, 0.88);
+  backdrop-filter: blur(16px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(16px, 5vw, 40px);
+  overflow-y: auto;
+  z-index: 10;
+}
+
+.auth[hidden] {
+  display: none;
+}
+
+.auth__card {
+  width: min(420px, 100%);
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  padding: clamp(24px, 6vw, 40px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.auth__header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  text-align: center;
+}
+
+.auth__badge {
+  display: inline-flex;
+  align-self: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(6, 214, 160, 0.15);
+  color: #0b9b72;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.auth__title {
+  font-size: clamp(1.4rem, 3vw, 1.8rem);
+  font-weight: 700;
+}
+
+.auth__subtitle {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.auth__tabs {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  background: rgba(243, 244, 246, 0.8);
+  border-radius: 999px;
+  padding: 6px;
+}
+
+.auth__tab {
+  border: none;
+  background: transparent;
+  border-radius: 999px;
+  padding: 10px 14px;
+  font-weight: 600;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease, box-shadow 150ms ease;
+}
+
+.auth__tab--active {
+  background: #ffffff;
+  color: var(--text-primary);
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.12);
+}
+
+.auth__notice {
+  margin: 0;
+  background: rgba(239, 71, 111, 0.12);
+  border: 1px solid rgba(239, 71, 111, 0.4);
+  color: #b91c1c;
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+  font-size: 0.9rem;
+}
+
+.auth__form {
+  display: grid;
+  gap: 16px;
+}
+
+.auth__field {
+  display: grid;
+  gap: 8px;
+}
+
+.auth__label {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.auth__input {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: #f8fafc;
+  padding: 12px 16px;
+  font-size: 1rem;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.auth__input:focus {
+  border-color: transparent;
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(90, 179, 230, 0.25);
+}
+
+.auth__message {
+  min-height: 1.1rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.auth__message[data-tone="error"] {
+  color: #d93025;
+}
+
+.auth__message[data-tone="success"] {
+  color: #0b9b72;
+}
+
+.auth__footer {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+button[data-loading="true"]::after {
+  content: "";
+  margin-left: 8px;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  display: inline-block;
+  animation: spin 900ms linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @media (min-width: 768px) {
-  body {
-    background: radial-gradient(100% 100% at top, #f4f9ff 0%, #ffffff 50%, #f4f9ff 100%);
-  }
-
-  .app {
-    padding-bottom: 120px;
-  }
-
   .app__header {
     flex-direction: row;
     justify-content: space-between;
@@ -381,15 +573,39 @@ body {
   }
 
   .app__status {
-    flex: none;
+    flex-wrap: nowrap;
+  }
+
+  .grid {
+    padding: clamp(24px, 3vw, 40px);
+  }
+}
+
+@media (max-width: 640px) {
+  .app {
+    padding: clamp(16px, 6vw, 24px);
+    gap: 20px;
+  }
+
+  .app__status {
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .status-card {
-    min-width: 120px;
+    width: 100%;
   }
 
-  .app__nav {
-    width: min(480px, calc(100% - 64px));
-    bottom: 32px;
+  .button {
+    width: 100%;
+  }
+
+  .grid__cells,
+  .grid__weekdays {
+    gap: 6px;
+  }
+
+  .auth__card {
+    padding: clamp(20px, 8vw, 28px);
   }
 }


### PR DESCRIPTION
## Summary
- replace the mood-combo local storage auth with Firebase email/password sign-in tied to Firestore-backed mood entries
- rebuild the MoodMap auth overlay and app chrome with responsive, mobile-first layout and tabbed sign-in/up forms
- add a Firebase configuration placeholder script for supplying production credentials

## Testing
- python -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_e_68e4043c81888322936aa9b4abf1df1f