### PR TITLE
Enable editing logged moods from the grid

### DIFF
--- a/MoodMap/index.html
+++ b/MoodMap/index.html
@@ -139,7 +139,11 @@
         <button type="submit" class="modal__close" aria-label="Close">×</button>
       </header>
       <div class="modal__body">
+        <p class="modal__subtitle" id="modalSubtitle">Tap a mood to log it.</p>
         <ul class="palette" id="palette"></ul>
+        <div class="modal__actions">
+          <button type="button" class="button button--ghost modal__clear" id="clearMoodButton" disabled>Clear mood for this day</button>
+        </div>
       </div>
     </form>
   </dialog>

--- a/MoodMap/styles.css
+++ b/MoodMap/styles.css
@@ -234,6 +234,21 @@ body {
   color: var(--color-muted);
 }
 
+.cell--interactive {
+  cursor: pointer;
+}
+
+.cell--interactive:hover,
+.cell--interactive:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(31, 42, 55, 0.18);
+}
+
+.cell--interactive:focus-visible {
+  outline: 2px solid rgba(6, 214, 160, 0.55);
+  outline-offset: 3px;
+}
+
 .cell--filled .cell__content {
   color: #ffffff;
   font-weight: 600;
@@ -419,6 +434,23 @@ body {
   box-shadow: inset 0 0 0 1px rgba(31, 42, 55, 0.06);
 }
 
+.timeline__item--interactive {
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+
+.timeline__item--interactive:hover,
+.timeline__item--interactive:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(31, 42, 55, 0.18);
+  background: rgba(241, 245, 249, 0.95);
+}
+
+.timeline__item--interactive:focus-visible {
+  outline: 2px solid rgba(90, 179, 230, 0.6);
+  outline-offset: 2px;
+}
+
 .timeline__swatch {
   width: 42px;
   height: 42px;
@@ -494,6 +526,22 @@ body {
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.7);
   box-shadow: inset 0 0 0 1px rgba(31, 42, 55, 0.04);
+}
+
+.history-calendar__cell--interactive {
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.history-calendar__cell--interactive:hover,
+.history-calendar__cell--interactive:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(31, 42, 55, 0.18);
+}
+
+.history-calendar__cell--interactive:focus-visible {
+  outline: 2px solid rgba(6, 214, 160, 0.55);
+  outline-offset: 3px;
 }
 
 .history-calendar__cell--padding {
@@ -592,6 +640,27 @@ body {
   font-weight: 600;
 }
 
+.modal__subtitle {
+  font-size: 0.92rem;
+  color: var(--color-muted);
+  line-height: 1.4;
+}
+
+.modal__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.modal__clear {
+  font-size: 0.85rem;
+  padding: 10px 18px;
+}
+
+.modal__clear:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .modal__close {
   border: none;
   background: #f1f5f9;
@@ -625,6 +694,16 @@ body {
 .palette__option:focus-visible {
   transform: translateY(-1px);
   box-shadow: 0 10px 18px rgba(31, 42, 55, 0.12);
+}
+
+.palette__option--active {
+  background: linear-gradient(140deg, rgba(6, 214, 160, 0.18), rgba(90, 179, 230, 0.16));
+  box-shadow: 0 12px 24px rgba(6, 214, 160, 0.18);
+  transform: translateY(-1px);
+}
+
+.palette__option--active .palette__swatch {
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.95), 0 0 0 4px rgba(6, 214, 160, 0.45);
 }
 
 .palette__swatch {


### PR DESCRIPTION
## Summary
- allow calendar cells, timeline entries, and history tiles to open the mood modal for the selected day so moods can be edited retroactively
- update the modal to show contextual messaging, highlight the current selection, and provide a clear-mood action
- add styles for interactive states across the grid, history, and palette so editing affordances feel consistent

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e4161270b0832296d0891da3ff3a05