### PR TITLE
Add AI Judge lightweight court MVP

### DIFF
--- a/jury/aijudge/README.md
+++ b/jury/aijudge/README.md
@@ -1,0 +1,14 @@
+# AI Judge — Moral Court MVP
+
+This lightweight build runs inside the `jury` collection. It exposes a Tailwind-powered front-end, JSON data store, and Node-based API routes ready for Vercel Functions.
+
+## Structure
+
+- `public/` – static pages for the feed, case detail, and judge bios.
+- `api/` – serverless endpoints for uploads, voting, comments, sentiment summarization, and mock AI trials.
+- `data/` – flat JSON storage for cases and judges.
+- `vercel.json` – hourly cron configuration for running AI trials.
+
+## Local Notes
+
+These functions assume a Vercel-like environment with automatic JSON parsing. When adapting to Express, wrap the handlers with `app.use(express.json())` before mounting.

--- a/jury/aijudge/api/_storage.js
+++ b/jury/aijudge/api/_storage.js
@@ -1,0 +1,20 @@
+const path = require('path');
+const fs = require('fs/promises');
+
+const DATA_ROOT = path.join(__dirname, '..', 'data');
+
+async function readJson(filename) {
+  const file = path.join(DATA_ROOT, filename);
+  const content = await fs.readFile(file, 'utf8');
+  return JSON.parse(content);
+}
+
+async function writeJson(filename, data) {
+  const file = path.join(DATA_ROOT, filename);
+  await fs.writeFile(file, JSON.stringify(data, null, 2));
+}
+
+module.exports = {
+  readJson,
+  writeJson
+};

--- a/jury/aijudge/api/comment.js
+++ b/jury/aijudge/api/comment.js
@@ -1,0 +1,42 @@
+const { readJson, writeJson } = require('./_storage');
+
+function summarizeSentiment(comments) {
+  if (!comments.length) return 'No comments yet.';
+  const average = comments.reduce((acc, c) => acc + (c.sentiment || 0), 0) / comments.length;
+  if (average > 0.35) return 'Crowd leans supportive with mostly positive takes.';
+  if (average < -0.35) return 'Crowd is largely critical of the actor.';
+  return 'Opinions are mixed with no clear majority.';
+}
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { id, user, text, sentiment = 0 } = req.body || {};
+  if (!id || !user || !text) {
+    res.status(400).json({ error: 'Missing id, user, or text' });
+    return;
+  }
+
+  const cases = await readJson('cases.json');
+  const index = cases.findIndex((item) => item.id === id);
+  if (index === -1) {
+    res.status(404).json({ error: 'Case not found' });
+    return;
+  }
+
+  const comment = {
+    user: user.trim().slice(0, 40) || 'anon',
+    text: text.trim(),
+    sentiment: Number.isFinite(Number(sentiment)) ? Number(sentiment) : 0
+  };
+
+  cases[index].comments = cases[index].comments || [];
+  cases[index].comments.push(comment);
+  cases[index].ai_summary = summarizeSentiment(cases[index].comments);
+
+  await writeJson('cases.json', cases);
+  res.status(200).json({ ok: true, comment });
+};

--- a/jury/aijudge/api/runTrial.js
+++ b/jury/aijudge/api/runTrial.js
@@ -1,0 +1,71 @@
+const { readJson, writeJson } = require('./_storage');
+
+function generateArgument(role, story) {
+  const intro = story.split('.').slice(0, 2).join('.').trim();
+  if (role === 'prosecution') {
+    return `The prosecution argues that the actor's choices created tangible harm. ${intro} This decision reflects avoidable disrespect for others' boundaries and a lack of communication.`;
+  }
+  return `The defense stresses the context and intent behind the decision. ${intro} Given the pressures described, the actor acted out of necessity and attempted to limit negative impact.`;
+}
+
+function summarizeComments(comments = []) {
+  if (!comments.length) {
+    return ['• No public comments yet.', '• Jury sentiment pending.'];
+  }
+  const avg = comments.reduce((acc, c) => acc + (c.sentiment || 0), 0) / comments.length;
+  const tone = avg > 0.25 ? 'supportive' : avg < -0.25 ? 'critical' : 'mixed';
+  const reasons = comments.slice(-3).map((c) => `• ${c.text.slice(0, 90)}`);
+  return [`• Crowd tone: ${tone}.`, ...reasons];
+}
+
+function judgeVerdict(story, prosecution, defense, commentsSummary) {
+  const severity = prosecution.length - defense.length;
+  const publicTone = commentsSummary.find((line) => line.includes('Crowd tone')) || '';
+  const judgeScore = severity > 0 ? 70 : 30;
+  const publicScore = publicTone.includes('supportive') ? 25 : publicTone.includes('critical') ? 70 : 50;
+  const juryScore = publicScore;
+
+  const finalScore = Math.round(0.5 * judgeScore + 0.3 * publicScore + 0.2 * juryScore);
+  let decision;
+  if (finalScore <= 25) decision = 'Morally Justified';
+  else if (finalScore <= 50) decision = 'Mostly Justified';
+  else if (finalScore <= 75) decision = 'Morally Wrong';
+  else decision = 'Severe Violation';
+
+  return {
+    decision,
+    reasoning: `Considering the arguments and crowd reaction (${publicTone || 'no sentiment yet'}), the judge leans toward ${decision.toLowerCase()}.`,
+    confidence: 65,
+    judge: 'Judge Iron',
+    finalScore
+  };
+}
+
+module.exports = async (req, res) => {
+  const cases = await readJson('cases.json');
+  const pending = cases.filter((item) => item.status !== 'judged').slice(0, 3);
+
+  pending.forEach((caseItem) => {
+    const prosecution = generateArgument('prosecution', caseItem.story);
+    const defense = generateArgument('defense', caseItem.story);
+    const summary = summarizeComments(caseItem.comments);
+    const verdict = judgeVerdict(caseItem.story, prosecution, defense, summary);
+
+    caseItem.prosecution = prosecution;
+    caseItem.defense = defense;
+    caseItem.ai_summary = summary.join('\n');
+    caseItem.verdict = {
+      decision: verdict.decision,
+      reasoning: verdict.reasoning,
+      confidence: verdict.confidence,
+      judge: verdict.judge
+    };
+    caseItem.status = 'judged';
+    caseItem.finalScore = verdict.finalScore;
+  });
+
+  const updatedCases = cases.map((item) => pending.find((p) => p.id === item.id) || item);
+  await writeJson('cases.json', updatedCases);
+
+  res.status(200).json({ ok: true, processed: pending.map((item) => item.id) });
+};

--- a/jury/aijudge/api/summary.js
+++ b/jury/aijudge/api/summary.js
@@ -1,0 +1,31 @@
+const { readJson, writeJson } = require('./_storage');
+
+function summarizeCase(caseItem) {
+  const comments = caseItem.comments || [];
+  if (!comments.length) {
+    caseItem.ai_summary = 'No public sentiment recorded yet.';
+    return caseItem;
+  }
+
+  const average = comments.reduce((acc, c) => acc + (c.sentiment || 0), 0) / comments.length;
+  const topReasons = comments
+    .slice(-5)
+    .map((c) => `• ${c.text.slice(0, 80)}`)
+    .join('\n');
+
+  caseItem.ai_summary = `${average > 0 ? 'Mostly supportive crowd.' : average < 0 ? 'Crowd leans critical.' : 'Sentiment is evenly split.'}\n${topReasons}`;
+  caseItem.publicSentiment = average;
+  return caseItem;
+}
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const cases = await readJson('cases.json');
+  const updated = cases.map(summarizeCase);
+  await writeJson('cases.json', updated);
+  res.status(200).json({ ok: true, casesUpdated: updated.length });
+};

--- a/jury/aijudge/api/upload.js
+++ b/jury/aijudge/api/upload.js
@@ -1,0 +1,33 @@
+const { readJson, writeJson } = require('./_storage');
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { title, story } = req.body || {};
+  if (!title || !story) {
+    res.status(400).json({ error: 'Missing title or story' });
+    return;
+  }
+
+  const cases = await readJson('cases.json');
+  const id = `case_${Date.now()}`;
+  const newCase = {
+    id,
+    title: title.trim().slice(0, 120),
+    story: story.trim(),
+    votes: 0,
+    comments: [],
+    ai_summary: '',
+    status: 'pending',
+    prosecution: '',
+    defense: '',
+    verdict: null
+  };
+
+  cases.unshift(newCase);
+  await writeJson('cases.json', cases);
+  res.status(201).json({ ok: true, case: newCase });
+};

--- a/jury/aijudge/api/vote.js
+++ b/jury/aijudge/api/vote.js
@@ -1,0 +1,25 @@
+const { readJson, writeJson } = require('./_storage');
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { id, delta } = req.body || {};
+  if (!id || !delta) {
+    res.status(400).json({ error: 'Missing id or delta' });
+    return;
+  }
+
+  const cases = await readJson('cases.json');
+  const item = cases.find((entry) => entry.id === id);
+  if (!item) {
+    res.status(404).json({ error: 'Case not found' });
+    return;
+  }
+
+  item.votes = Math.max(0, (item.votes || 0) + Number(delta));
+  await writeJson('cases.json', cases);
+  res.status(200).json({ ok: true, votes: item.votes });
+};

--- a/jury/aijudge/data/cases.json
+++ b/jury/aijudge/data/cases.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "case_001",
+    "title": "Borrowed laptop for remote class",
+    "story": "I borrowed my roommate's laptop while he was out because my own died before an online exam. I returned it the same day, but he was upset that I didn't ask first.",
+    "votes": 12,
+    "comments": [
+      { "user": "anon1", "text": "You should have left a note.", "sentiment": -0.1 },
+      { "user": "anon2", "text": "Saving your grade seems fair.", "sentiment": 0.6 }
+    ],
+    "ai_summary": "Split: some say borrowing without asking was wrong, others prioritize the exam emergency.",
+    "status": "pending",
+    "prosecution": "",
+    "defense": "",
+    "verdict": null
+  }
+]

--- a/jury/aijudge/data/judges.json
+++ b/jury/aijudge/data/judges.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "iron",
+    "name": "Judge Iron",
+    "bio": "Former prosecutor AI obsessed with order and consequence.",
+    "philosophy": "Rule of law above emotion.",
+    "style": "Short, decisive, formal.",
+    "stats": {
+      "cases": 42,
+      "agreeRate": 0.64
+    }
+  },
+  {
+    "id": "mercy",
+    "name": "Judge Mercy",
+    "bio": "Empathetic and human-centered; always sees intent before act.",
+    "philosophy": "Compassion over rigidity.",
+    "style": "Warm and reflective.",
+    "stats": {
+      "cases": 38,
+      "agreeRate": 0.78
+    }
+  }
+]

--- a/jury/aijudge/package.json
+++ b/jury/aijudge/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ai-judge",
+  "version": "0.1.0",
+  "description": "AI-powered moral court MVP",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/jury/aijudge/public/case.html
+++ b/jury/aijudge/public/case.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Case Detail • AI Judge</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/inter@5.0.16/variable.css">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <main class="max-w-3xl mx-auto px-4 py-10 space-y-8">
+    <a href="index.html" class="inline-flex items-center gap-2 text-sm text-slate-300 hover:text-indigo-200">← Back to docket</a>
+    <article class="card space-y-6" id="case-card">
+      <header class="space-y-2">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <h1 class="text-2xl font-semibold" id="case-title"></h1>
+          <span class="badge"><span>🗳️</span><span id="case-votes"></span></span>
+        </div>
+        <p id="case-story" class="text-slate-300 leading-relaxed"></p>
+        <div class="text-xs uppercase tracking-wide text-slate-500" id="case-status"></div>
+      </header>
+      <section class="space-y-4" id="verdict-section" hidden>
+        <h2 class="text-lg font-semibold">Latest Verdict</h2>
+        <div class="grid gap-4 md:grid-cols-3 text-sm text-slate-200">
+          <div class="bg-slate-900/50 rounded-xl p-4">
+            <h3 class="font-semibold text-slate-100 mb-1">Verdict</h3>
+            <p id="verdict-decision" class="text-indigo-300"></p>
+          </div>
+          <div class="bg-slate-900/50 rounded-xl p-4 md:col-span-2">
+            <h3 class="font-semibold text-slate-100 mb-1">Judge Reasoning</h3>
+            <p id="verdict-reasoning" class="text-slate-300"></p>
+            <p class="text-xs text-slate-500 mt-2" id="verdict-meta"></p>
+          </div>
+        </div>
+        <section class="space-y-3">
+          <h3 class="font-semibold text-slate-100">AI Arguments</h3>
+          <details class="bg-slate-900/40 rounded-xl p-4" id="prosecution">
+            <summary class="cursor-pointer text-sm font-semibold text-rose-300">Prosecution Case</summary>
+            <p class="mt-2 text-sm text-slate-300"></p>
+          </details>
+          <details class="bg-slate-900/40 rounded-xl p-4" id="defense">
+            <summary class="cursor-pointer text-sm font-semibold text-emerald-300">Defense Case</summary>
+            <p class="mt-2 text-sm text-slate-300"></p>
+          </details>
+        </section>
+      </section>
+    </article>
+
+    <section class="card space-y-4">
+      <header class="flex items-center justify-between">
+        <h2 class="text-xl font-semibold">Community Reactions</h2>
+        <span id="sentiment-score" class="text-sm text-slate-400"></span>
+      </header>
+      <ul id="comment-list" class="space-y-3"></ul>
+      <form id="comment-form" class="space-y-3">
+        <div class="grid gap-3 md:grid-cols-2">
+          <input type="text" name="user" placeholder="Username" required class="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 focus:border-indigo-400">
+          <select name="sentiment" class="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 focus:border-indigo-400">
+            <option value="0.6">Supportive</option>
+            <option value="0.2">Mixed</option>
+            <option value="-0.4">Critical</option>
+          </select>
+        </div>
+        <textarea name="text" rows="3" placeholder="Share your view" required class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 focus:border-indigo-400"></textarea>
+        <button type="submit" class="button-primary w-full">Add Comment</button>
+      </form>
+    </section>
+  </main>
+
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    const caseId = params.get('id');
+    if (!caseId) {
+      window.location.replace('index.html');
+    }
+
+    async function loadCase() {
+      const response = await fetch('../data/cases.json?_=' + Date.now());
+      const cases = await response.json();
+      const item = cases.find((entry) => entry.id === caseId);
+      if (!item) {
+        document.getElementById('case-card').innerHTML = '<p class="text-slate-300">Case not found.</p>';
+        return;
+      }
+      document.getElementById('case-title').textContent = item.title;
+      document.getElementById('case-story').textContent = item.story;
+      document.getElementById('case-votes').textContent = item.votes;
+      document.getElementById('case-status').textContent = item.status === 'judged' ? 'VERDICT PUBLISHED' : 'AWAITING TRIAL';
+
+      if (item.verdict) {
+        document.getElementById('verdict-section').hidden = false;
+        document.getElementById('verdict-decision').textContent = item.verdict.decision;
+        document.getElementById('verdict-reasoning').textContent = item.verdict.reasoning;
+        const judgeName = item.verdict.judge || 'Unknown Judge';
+        document.getElementById('verdict-meta').textContent = `${judgeName} • Confidence ${item.verdict.confidence ?? '—'}%`;
+        document.querySelector('#prosecution p').textContent = item.prosecution || 'Awaiting trial.';
+        document.querySelector('#defense p').textContent = item.defense || 'Awaiting trial.';
+      }
+
+      const comments = item.comments || [];
+      const list = document.getElementById('comment-list');
+      list.innerHTML = '';
+      comments.forEach((comment) => {
+        const li = document.createElement('li');
+        li.className = 'bg-slate-900/40 rounded-xl p-3 text-sm flex flex-col gap-1';
+        li.innerHTML = `<div class="flex items-center justify-between text-slate-400"><span>${comment.user}</span><span>${formatSentiment(comment.sentiment)}</span></div><p class="text-slate-200">${comment.text}</p>`;
+        list.appendChild(li);
+      });
+      const average = comments.reduce((acc, c) => acc + (c.sentiment || 0), 0) / Math.max(1, comments.length);
+      document.getElementById('sentiment-score').textContent = `Crowd Sentiment: ${(average * 100).toFixed(0)} / 100`;
+    }
+
+    function formatSentiment(score = 0) {
+      if (score > 0.25) return 'Supportive';
+      if (score < -0.25) return 'Critical';
+      return 'Mixed';
+    }
+
+    document.getElementById('comment-form').addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const formData = new FormData(event.target);
+      const payload = Object.fromEntries(formData.entries());
+      payload.sentiment = Number(payload.sentiment);
+      payload.id = caseId;
+      try {
+        await fetch('/api/comment', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        event.target.reset();
+        loadCase();
+      } catch (error) {
+        console.error('Comment failed', error);
+      }
+    });
+
+    loadCase();
+  </script>
+</body>
+</html>

--- a/jury/aijudge/public/index.html
+++ b/jury/aijudge/public/index.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Judge • Moral Court</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/inter@5.0.16/variable.css">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <main class="max-w-5xl mx-auto px-4 py-10 space-y-12">
+    <header class="text-center space-y-4">
+      <span class="badge">Hourly AI Trials</span>
+      <h1 class="text-4xl font-semibold tracking-tight">AI Judge — Moral Court</h1>
+      <p class="text-slate-300 max-w-2xl mx-auto">
+        Upload dilemmas, debate with the crowd, then let our AI tribunal deliver a nightly verdict.
+      </p>
+      <div class="flex flex-wrap justify-center gap-3 text-sm text-slate-400">
+        <span>🚀 Upload cases</span>
+        <span>💬 Sentiment-weighted comments</span>
+        <span>⚖️ AI prosecution, defense &amp; judge</span>
+      </div>
+    </header>
+
+    <section class="grid gap-6 md:grid-cols-[2fr,1fr]">
+      <article class="card space-y-6">
+        <div class="flex items-center justify-between">
+          <h2 class="text-xl font-semibold">Live Docket</h2>
+          <a href="judges.html" class="text-sm text-indigo-300 hover:text-indigo-200">Meet the Judges →</a>
+        </div>
+        <div id="case-feed" class="space-y-4"></div>
+      </article>
+
+      <aside class="card space-y-4">
+        <h2 class="text-xl font-semibold">Submit a Case</h2>
+        <form id="upload-form" class="space-y-3">
+          <div>
+            <label class="block text-sm text-slate-300 mb-1">Title</label>
+            <input type="text" name="title" required class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 focus:border-indigo-400" placeholder="Caught lying to a friend" />
+          </div>
+          <div>
+            <label class="block text-sm text-slate-300 mb-1">Story</label>
+            <textarea name="story" rows="5" required class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 focus:border-indigo-400" placeholder="Explain what happened"></textarea>
+          </div>
+          <button type="submit" class="button-primary w-full">Send to the Jury</button>
+          <p class="text-xs text-slate-400">
+            Uploads run through a quick moderation check before joining the docket.
+          </p>
+        </form>
+      </aside>
+    </section>
+
+    <section class="card space-y-4">
+      <h2 class="text-xl font-semibold">How the Court Works</h2>
+      <div class="grid md:grid-cols-3 gap-4 text-sm text-slate-300">
+        <div>
+          <h3 class="font-semibold text-slate-100 mb-2">Daytime Debate</h3>
+          <p>People vote and leave comments. A sentiment bot keeps score and builds the crowd summary.</p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-slate-100 mb-2">Hourly Session</h3>
+          <p>Top cases face prosecution, defense, and a neutral judge prompt. Verdicts land automatically.</p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-slate-100 mb-2">Transparency</h3>
+          <p>Every verdict includes public mood, AI arguments, and judge confidence.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <template id="case-template">
+    <article class="rounded-2xl border border-slate-800 bg-slate-900/60 p-5 space-y-4">
+      <header class="space-y-1">
+        <div class="flex items-center justify-between gap-4">
+          <h3 class="text-lg font-semibold"></h3>
+          <span class="badge"><span class="emoji">🗳️</span><span class="votes"></span></span>
+        </div>
+        <p class="text-sm text-slate-300 story"></p>
+      </header>
+      <div class="space-y-2 text-sm text-slate-400">
+        <div class="progress-bar"><div class="sentiment" style="width:50%"></div></div>
+        <p><strong class="text-slate-200">Public Mood:</strong> <span class="summary"></span></p>
+        <p class="status text-xs uppercase tracking-wide text-slate-500"></p>
+      </div>
+      <footer class="flex items-center justify-between text-sm">
+        <div class="flex gap-2">
+          <button class="px-3 py-1 rounded-full bg-slate-800 hover:bg-slate-700 vote-up">👍</button>
+          <button class="px-3 py-1 rounded-full bg-slate-800 hover:bg-slate-700 vote-down">👎</button>
+        </div>
+        <a class="text-indigo-300 hover:text-indigo-200 text-sm" href="#">View Case →</a>
+      </footer>
+    </article>
+  </template>
+
+  <script>
+    const feed = document.getElementById('case-feed');
+    const template = document.getElementById('case-template');
+    const uploadForm = document.getElementById('upload-form');
+
+    async function fetchCases() {
+      const response = await fetch('../data/cases.json');
+      const cases = await response.json();
+      renderCases(cases);
+    }
+
+    function renderCases(cases) {
+      feed.innerHTML = '';
+      cases.forEach((item) => {
+        const node = template.content.cloneNode(true);
+        node.querySelector('h3').textContent = item.title;
+        node.querySelector('.story').textContent = item.story;
+        node.querySelector('.votes').textContent = item.votes;
+        node.querySelector('.summary').textContent = item.ai_summary || 'Awaiting community input.';
+        node.querySelector('.status').textContent = item.status === 'judged' ? 'VERDICT PUBLISHED' : 'AWAITING TRIAL';
+        const sentiment = Math.max(0, Math.min(100, Math.round(((item.comments || []).reduce((acc, c) => acc + (c.sentiment || 0), 0) / Math.max(1, (item.comments || []).length) + 1) * 50)));
+        node.querySelector('.sentiment').style.width = sentiment + '%';
+        node.querySelector('a').href = `case.html?id=${encodeURIComponent(item.id)}`;
+        node.querySelector('.vote-up').addEventListener('click', () => vote(item.id, 1));
+        node.querySelector('.vote-down').addEventListener('click', () => vote(item.id, -1));
+        feed.appendChild(node);
+      });
+    }
+
+    async function vote(id, delta) {
+      try {
+        await fetch('/api/vote', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id, delta })
+        });
+        fetchCases();
+      } catch (error) {
+        console.error('Vote failed', error);
+      }
+    }
+
+    uploadForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const formData = new FormData(uploadForm);
+      const payload = Object.fromEntries(formData.entries());
+      try {
+        await fetch('/api/upload', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        uploadForm.reset();
+        fetchCases();
+      } catch (error) {
+        console.error('Upload failed', error);
+      }
+    });
+
+    fetchCases();
+  </script>
+</body>
+</html>

--- a/jury/aijudge/public/judges.html
+++ b/jury/aijudge/public/judges.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Meet the Judges • AI Judge</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/inter@5.0.16/variable.css">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <main class="max-w-4xl mx-auto px-4 py-10 space-y-8">
+    <header class="text-center space-y-3">
+      <a href="index.html" class="inline-flex items-center gap-2 text-sm text-slate-300 hover:text-indigo-200">← Back to docket</a>
+      <h1 class="text-3xl font-semibold tracking-tight">Meet the Bench</h1>
+      <p class="text-slate-300 max-w-2xl mx-auto">
+        Each AI judge brings a distinct philosophy. We rotate them through hourly court sessions to balance compassion and order.
+      </p>
+    </header>
+
+    <section id="judge-grid" class="grid gap-6 md:grid-cols-2"></section>
+  </main>
+
+  <template id="judge-card">
+    <article class="card space-y-3">
+      <header>
+        <h2 class="text-xl font-semibold"></h2>
+        <p class="text-sm text-slate-400 philosophy"></p>
+      </header>
+      <p class="text-slate-300 bio"></p>
+      <div class="text-xs text-slate-500 uppercase tracking-wide">Style</div>
+      <p class="text-sm text-indigo-300 style"></p>
+      <div class="flex items-center justify-between text-sm text-slate-400">
+        <span class="cases"></span>
+        <span class="agree"></span>
+      </div>
+    </article>
+  </template>
+
+  <script>
+    async function loadJudges() {
+      const response = await fetch('../data/judges.json');
+      const judges = await response.json();
+      const grid = document.getElementById('judge-grid');
+      const template = document.getElementById('judge-card');
+      judges.forEach((judge) => {
+        const node = template.content.cloneNode(true);
+        node.querySelector('h2').textContent = judge.name;
+        node.querySelector('.philosophy').textContent = judge.philosophy;
+        node.querySelector('.bio').textContent = judge.bio;
+        node.querySelector('.style').textContent = judge.style;
+        if (judge.stats) {
+          node.querySelector('.cases').textContent = `${judge.stats.cases} cases heard`;
+          node.querySelector('.agree').textContent = `${Math.round(judge.stats.agreeRate * 100)}% public agreement`;
+        }
+        grid.appendChild(node);
+      });
+    }
+    loadJudges();
+  </script>
+</body>
+</html>

--- a/jury/aijudge/public/style.css
+++ b/jury/aijudge/public/style.css
@@ -1,0 +1,71 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(79, 70, 229, 0.08), transparent 60%), #0f172a;
+  color: #e2e8f0;
+}
+
+a {
+  color: #a855f7;
+}
+
+a:hover {
+  color: #d946ef;
+}
+
+.card {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.3);
+  backdrop-filter: blur(16px);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  border-radius: 9999px;
+  padding: 0.25rem 0.75rem;
+  background: rgba(59, 130, 246, 0.15);
+  color: #93c5fd;
+}
+
+.button-primary {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #6366f1, #a855f7);
+  color: white;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px rgba(99, 102, 241, 0.4);
+}
+
+input, textarea {
+  color: #0f172a;
+}
+
+.progress-bar {
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+}
+
+.progress-bar div {
+  height: 100%;
+  background: linear-gradient(135deg, #34d399, #22d3ee);
+}

--- a/jury/aijudge/vercel.json
+++ b/jury/aijudge/vercel.json
@@ -1,0 +1,13 @@
+{
+  "functions": {
+    "api/*.js": {
+      "runtime": "nodejs18.x"
+    }
+  },
+  "crons": [
+    {
+      "path": "/api/runTrial",
+      "schedule": "0 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the AI Judge mini-app inside the jury collection with Tailwind-powered public pages
- provide flat-file JSON storage plus Vercel-style serverless API routes for uploads, voting, comments, sentiment summaries, and mock trials
- include cron schedule and starter data for judges and cases

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5212ce54c8322bf5cd3e4e2992f04