### PR TITLE
Implement client-side AI jury experience

### DIFF
--- a/jury/case.html
+++ b/jury/case.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Case Detail • AI Judge</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/inter@5.0.16/variable.css">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <main class="max-w-3xl mx-auto px-4 py-10 space-y-8">
+    <a href="index.html" class="inline-flex items-center gap-2 text-sm text-slate-300 hover:text-indigo-200">← Back to docket</a>
+    <article class="card space-y-6" id="case-card">
+      <header class="space-y-2">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <h1 class="text-2xl font-semibold" id="case-title"></h1>
+          <span class="badge"><span>🗳️</span><span id="case-votes"></span></span>
+        </div>
+        <p id="case-story" class="text-slate-300 leading-relaxed"></p>
+        <div class="text-xs uppercase tracking-wide text-slate-500" id="case-status"></div>
+      </header>
+      <section class="space-y-4" id="verdict-section" hidden>
+        <h2 class="text-lg font-semibold">Latest Verdict</h2>
+        <div class="grid gap-4 md:grid-cols-3 text-sm text-slate-200">
+          <div class="bg-slate-900/50 rounded-xl p-4">
+            <h3 class="font-semibold text-slate-100 mb-1">Verdict</h3>
+            <p id="verdict-decision" class="text-indigo-300"></p>
+          </div>
+          <div class="bg-slate-900/50 rounded-xl p-4 md:col-span-2">
+            <h3 class="font-semibold text-slate-100 mb-1">Judge Reasoning</h3>
+            <p id="verdict-reasoning" class="text-slate-300"></p>
+            <p class="text-xs text-slate-500 mt-2" id="verdict-meta"></p>
+            <div class="space-y-2 mt-3" id="score-wrap" hidden>
+              <div class="text-xs uppercase tracking-wide text-slate-500">Composite Score</div>
+              <div class="score-bar"><div id="score-fill" class="score-bar-fill"></div></div>
+              <p class="text-xs text-slate-400" id="score-note"></p>
+            </div>
+          </div>
+        </div>
+        <section class="space-y-3">
+          <h3 class="font-semibold text-slate-100">AI Arguments</h3>
+          <details class="bg-slate-900/40 rounded-xl p-4" id="prosecution">
+            <summary class="cursor-pointer text-sm font-semibold text-rose-300">Prosecution Case</summary>
+            <p class="mt-2 text-sm text-slate-300"></p>
+          </details>
+          <details class="bg-slate-900/40 rounded-xl p-4" id="defense">
+            <summary class="cursor-pointer text-sm font-semibold text-emerald-300">Defense Case</summary>
+            <p class="mt-2 text-sm text-slate-300"></p>
+          </details>
+        </section>
+      </section>
+    </article>
+
+    <section class="card space-y-4">
+      <header class="flex items-center justify-between">
+        <h2 class="text-xl font-semibold">Community Reactions</h2>
+        <span id="sentiment-score" class="text-sm text-slate-400"></span>
+      </header>
+      <ul id="comment-list" class="space-y-3"></ul>
+      <form id="comment-form" class="space-y-3">
+        <div class="grid gap-3 md:grid-cols-2">
+          <input type="text" name="user" placeholder="Username" required class="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 focus:border-indigo-400">
+          <select name="sentiment" class="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 focus:border-indigo-400">
+            <option value="0.6">Supportive</option>
+            <option value="0.2">Mixed</option>
+            <option value="-0.4">Critical</option>
+          </select>
+        </div>
+        <textarea name="text" rows="3" placeholder="Share your view" required class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 focus:border-indigo-400"></textarea>
+        <button type="submit" class="button-primary w-full">Add Comment</button>
+      </form>
+    </section>
+
+    <section class="card space-y-3" id="summary-section" hidden>
+      <h2 class="text-xl font-semibold">Community Summary</h2>
+      <ul id="summary-list" class="summary-list"></ul>
+    </section>
+  </main>
+
+  <script src="js/juryStore.js"></script>
+  <script>
+    (async function () {
+      const params = new URLSearchParams(window.location.search);
+      const caseId = params.get('id');
+      if (!caseId) {
+        window.location.replace('index.html');
+        return;
+      }
+
+      const store = window.JuryStore;
+      const ai = window.JuryAI;
+      const commentForm = document.getElementById('comment-form');
+      const summarySection = document.getElementById('summary-section');
+      const summaryList = document.getElementById('summary-list');
+      const sentimentScore = document.getElementById('sentiment-score');
+      const commentList = document.getElementById('comment-list');
+      const verdictSection = document.getElementById('verdict-section');
+      const scoreWrap = document.getElementById('score-wrap');
+
+      await store.loadCases();
+      let currentCase = store.getCase(caseId);
+      if (!currentCase) {
+        document.getElementById('case-card').innerHTML = '<p class="text-slate-300">Case not found.</p>';
+        commentForm.hidden = true;
+        summarySection.hidden = true;
+        return;
+      }
+
+      function renderCase() {
+        document.getElementById('case-title').textContent = currentCase.title;
+        document.getElementById('case-story').textContent = currentCase.story;
+        document.getElementById('case-votes').textContent = currentCase.votes;
+        document.getElementById('case-status').textContent = currentCase.status === 'judged' ? 'VERDICT PUBLISHED' : 'AWAITING TRIAL';
+
+        if (currentCase.verdict) {
+          verdictSection.hidden = false;
+          document.getElementById('verdict-decision').textContent = currentCase.verdict.decision;
+          document.getElementById('verdict-reasoning').textContent = currentCase.verdict.reasoning;
+          const judgeName = currentCase.verdict.judge || 'Unknown Judge';
+          const metaBits = [judgeName];
+          if (Number.isFinite(currentCase.verdict.confidence)) {
+            metaBits.push(`Confidence ${currentCase.verdict.confidence}%`);
+          }
+          document.getElementById('verdict-meta').textContent = metaBits.join(' • ');
+          if (Number.isFinite(currentCase.finalScore)) {
+            scoreWrap.hidden = false;
+            const scoreFill = document.getElementById('score-fill');
+            const clamped = Math.max(0, Math.min(100, Math.round(currentCase.finalScore)));
+            scoreFill.style.width = clamped + '%';
+            document.getElementById('score-note').textContent = `Composite score ${clamped}/100 from judge and crowd weighting.`;
+          } else {
+            scoreWrap.hidden = true;
+          }
+          document.querySelector('#prosecution p').textContent = currentCase.prosecution || 'Awaiting trial.';
+          document.querySelector('#defense p').textContent = currentCase.defense || 'Awaiting trial.';
+        } else {
+          verdictSection.hidden = true;
+          scoreWrap.hidden = true;
+        }
+
+        const summaryInfo = currentCase.ai_summary
+          ? { lines: currentCase.ai_summary.split('\n').filter(Boolean), average: currentCase.publicSentiment ?? ai.summariseComments(currentCase.comments || []).average }
+          : ai.summariseComments(currentCase.comments || []);
+        if (summaryInfo.lines.length) {
+          summarySection.hidden = false;
+          summaryList.innerHTML = '';
+          summaryInfo.lines.forEach((line) => {
+            const entry = document.createElement('li');
+            entry.textContent = line.replace(/^•\s*/, '');
+            summaryList.appendChild(entry);
+          });
+        } else {
+          summarySection.hidden = true;
+        }
+
+        commentList.innerHTML = '';
+        (currentCase.comments || []).forEach((comment) => {
+          const li = document.createElement('li');
+          li.className = 'bg-slate-900/40 rounded-xl p-3 text-sm flex flex-col gap-1';
+          li.innerHTML = `<div class="flex items-center justify-between text-slate-400"><span>${comment.user}</span><span>${formatSentiment(comment.sentiment)}</span></div><p class="text-slate-200">${comment.text}</p>`;
+          commentList.appendChild(li);
+        });
+        const average = ai.summariseComments(currentCase.comments || []).average;
+        sentimentScore.textContent = `Crowd Sentiment: ${(average * 100).toFixed(0)} / 100`;
+      }
+
+      function formatSentiment(score = 0) {
+        if (score > 0.25) return 'Supportive';
+        if (score < -0.25) return 'Critical';
+        return 'Mixed';
+      }
+
+      commentForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const comment = {
+          user: (formData.get('user') || '').toString().trim() || 'anon',
+          text: (formData.get('text') || '').toString().trim(),
+          sentiment: Number(formData.get('sentiment')) || 0
+        };
+        if (!comment.text) {
+          return;
+        }
+        currentCase = store.updateCase(caseId, (entry) => {
+          const next = { ...entry };
+          next.comments = [...(entry.comments || []), comment];
+          const summary = ai.summariseComments(next.comments);
+          next.ai_summary = summary.lines.join('\n');
+          next.publicSentiment = summary.average;
+          return next;
+        });
+        event.target.reset();
+        renderCase();
+      });
+
+      renderCase();
+    })();
+  </script>
+</body>
+</html>

--- a/jury/data/cases.json
+++ b/jury/data/cases.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "case_001",
+    "title": "Borrowed laptop for remote class",
+    "story": "I borrowed my roommate's laptop while he was out because my own died before an online exam. I returned it the same day, but he was upset that I didn't ask first.",
+    "votes": 12,
+    "comments": [
+      { "user": "anon1", "text": "You should have left a note.", "sentiment": -0.1 },
+      { "user": "anon2", "text": "Saving your grade seems fair.", "sentiment": 0.6 }
+    ],
+    "ai_summary": "Split: some say borrowing without asking was wrong, others prioritize the exam emergency.",
+    "status": "pending",
+    "prosecution": "",
+    "defense": "",
+    "verdict": null
+  }
+]

--- a/jury/data/judges.json
+++ b/jury/data/judges.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "iron",
+    "name": "Judge Iron",
+    "bio": "Former prosecutor AI obsessed with order and consequence.",
+    "philosophy": "Rule of law above emotion.",
+    "style": "Short, decisive, formal.",
+    "stats": {
+      "cases": 42,
+      "agreeRate": 0.64
+    }
+  },
+  {
+    "id": "mercy",
+    "name": "Judge Mercy",
+    "bio": "Empathetic and human-centered; always sees intent before act.",
+    "philosophy": "Compassion over rigidity.",
+    "style": "Warm and reflective.",
+    "stats": {
+      "cases": 38,
+      "agreeRate": 0.78
+    }
+  }
+]

--- a/jury/index.html
+++ b/jury/index.html
@@ -1,1 +1,256 @@
-!
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Judge • Moral Court</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/inter@5.0.16/variable.css">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <main class="max-w-5xl mx-auto px-4 py-10 space-y-12">
+    <header class="text-center space-y-4">
+      <span class="badge">Hourly AI Trials</span>
+      <h1 class="text-4xl font-semibold tracking-tight">AI Judge — Moral Court</h1>
+      <p class="text-slate-300 max-w-2xl mx-auto">
+        Upload dilemmas, debate with the crowd, then let our AI tribunal deliver a nightly verdict.
+      </p>
+      <div class="flex flex-wrap justify-center gap-3 text-sm text-slate-400">
+        <span>🚀 Upload cases</span>
+        <span>💬 Sentiment-weighted comments</span>
+        <span>⚖️ AI prosecution, defense &amp; judge</span>
+      </div>
+    </header>
+
+    <section class="grid gap-6 md:grid-cols-[2fr,1fr]">
+      <article class="card space-y-6">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div class="flex items-center gap-3">
+            <h2 class="text-xl font-semibold">Live Docket</h2>
+            <button id="run-trial" class="button-secondary text-sm">Run AI Trial</button>
+          </div>
+          <a href="judges.html" class="text-sm text-indigo-300 hover:text-indigo-200">Meet the Judges →</a>
+        </div>
+        <p id="trial-message" class="text-xs text-indigo-200" hidden></p>
+        <div id="case-feed" class="space-y-4"></div>
+      </article>
+
+      <aside class="card space-y-4">
+        <h2 class="text-xl font-semibold">Submit a Case</h2>
+        <form id="upload-form" class="space-y-3">
+          <div>
+            <label class="block text-sm text-slate-300 mb-1">Title</label>
+            <input type="text" name="title" required class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 focus:border-indigo-400" placeholder="Caught lying to a friend" />
+          </div>
+          <div>
+            <label class="block text-sm text-slate-300 mb-1">Story</label>
+            <textarea name="story" rows="5" required class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 focus:border-indigo-400" placeholder="Explain what happened"></textarea>
+          </div>
+          <button type="submit" class="button-primary w-full">Send to the Jury</button>
+          <p class="text-xs text-slate-400">
+            Uploads are saved in your browser so you can keep refining the debate.
+          </p>
+          <p id="upload-feedback" class="text-xs text-emerald-300" hidden>Case added to the docket. Refresh the page to reset.</p>
+        </form>
+      </aside>
+    </section>
+
+    <section class="card space-y-4">
+      <h2 class="text-xl font-semibold">How the Court Works</h2>
+      <div class="grid md:grid-cols-3 gap-4 text-sm text-slate-300">
+        <div>
+          <h3 class="font-semibold text-slate-100 mb-2">Daytime Debate</h3>
+          <p>People vote and leave comments. A sentiment bot keeps score and builds the crowd summary.</p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-slate-100 mb-2">Hourly Session</h3>
+          <p>Top cases face prosecution, defense, and a neutral judge prompt. Verdicts land automatically.</p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-slate-100 mb-2">Transparency</h3>
+          <p>Every verdict includes public mood, AI arguments, and judge confidence.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <template id="case-template">
+    <article class="rounded-2xl border border-slate-800 bg-slate-900/60 p-5 space-y-4">
+      <header class="space-y-1">
+        <div class="flex items-center justify-between gap-4">
+          <h3 class="text-lg font-semibold"></h3>
+          <span class="badge"><span class="emoji">🗳️</span><span class="votes"></span></span>
+        </div>
+        <p class="text-sm text-slate-300 story"></p>
+      </header>
+      <div class="space-y-2 text-sm text-slate-400">
+        <div class="progress-bar"><div class="sentiment" style="width:50%"></div></div>
+        <p><strong class="text-slate-200">Public Mood:</strong> <span class="summary"></span></p>
+        <p class="status text-xs uppercase tracking-wide text-slate-500"></p>
+      </div>
+      <footer class="flex items-center justify-between text-sm">
+        <div class="flex gap-2">
+          <button class="px-3 py-1 rounded-full bg-slate-800 hover:bg-slate-700 vote-up">👍</button>
+          <button class="px-3 py-1 rounded-full bg-slate-800 hover:bg-slate-700 vote-down">👎</button>
+        </div>
+        <a class="text-indigo-300 hover:text-indigo-200 text-sm" href="#">View Case →</a>
+      </footer>
+    </article>
+  </template>
+
+  <script src="js/juryStore.js"></script>
+  <script>
+    (async function () {
+      const store = window.JuryStore;
+      const ai = window.JuryAI;
+      const feed = document.getElementById('case-feed');
+      const template = document.getElementById('case-template');
+      const uploadForm = document.getElementById('upload-form');
+      const runTrialButton = document.getElementById('run-trial');
+      const trialMessage = document.getElementById('trial-message');
+      const uploadFeedback = document.getElementById('upload-feedback');
+
+      let cases = [];
+
+      async function initialise() {
+        try {
+          cases = await store.loadCases();
+          renderCases();
+        } catch (error) {
+          console.error('Failed to load cases', error);
+          feed.innerHTML = '<p class="text-sm text-rose-300">Unable to load the docket right now. Try again shortly.</p>';
+        }
+      }
+
+      function renderCases() {
+        feed.innerHTML = '';
+        if (!cases.length) {
+          feed.innerHTML = '<p class="text-sm text-slate-300">No cases yet. Submit a dilemma to start the debate.</p>';
+          return;
+        }
+
+        cases.forEach((item) => {
+          const node = template.content.cloneNode(true);
+          node.querySelector('h3').textContent = item.title;
+          node.querySelector('.story').textContent = item.story;
+          node.querySelector('.votes').textContent = item.votes;
+
+          const summaryText = item.ai_summary
+            ? item.ai_summary.split('\n')[0].replace(/^•\s*/, '')
+            : ai.summariseComments(item.comments || []).lines[0].replace(/^•\s*/, '');
+          node.querySelector('.summary').textContent = summaryText;
+
+          const status = node.querySelector('.status');
+          if (item.status === 'judged') {
+            const details = [item.verdict?.decision, item.verdict?.judge ? `Judge ${item.verdict.judge}` : null];
+            if (Number.isFinite(item.finalScore)) {
+              details.push(`Score ${Math.round(item.finalScore)}`);
+            }
+            status.textContent = details.filter(Boolean).join(' • ') || 'Verdict published';
+          } else {
+            status.textContent = 'Awaiting trial';
+          }
+
+          const sentimentInfo = ai.summariseComments(item.comments || []);
+          const sentimentWidth = Math.max(0, Math.min(100, Math.round((sentimentInfo.average + 1) * 50)));
+          node.querySelector('.sentiment').style.width = sentimentWidth + '%';
+
+          const link = node.querySelector('a');
+          link.href = `case.html?id=${encodeURIComponent(item.id)}`;
+
+          node.querySelector('.vote-up').addEventListener('click', () => adjustVotes(item.id, 1));
+          node.querySelector('.vote-down').addEventListener('click', () => adjustVotes(item.id, -1));
+
+          feed.appendChild(node);
+        });
+      }
+
+      function adjustVotes(id, delta) {
+        cases = cases.map((item) => {
+          if (item.id !== id) return item;
+          const nextVotes = Math.max(0, (Number(item.votes) || 0) + delta);
+          return { ...item, votes: nextVotes };
+        });
+        cases = store.saveCases(cases);
+        renderCases();
+      }
+
+      async function runTrial() {
+        if (!runTrialButton) return;
+        runTrialButton.disabled = true;
+        runTrialButton.textContent = 'Running…';
+        if (trialMessage) {
+          trialMessage.hidden = true;
+        }
+        try {
+          const pending = cases.filter((item) => item.status !== 'judged');
+          const toProcess = pending.slice(0, 3);
+          if (!toProcess.length) {
+            if (trialMessage) {
+              trialMessage.textContent = 'No pending cases were ready for trial yet.';
+              trialMessage.hidden = false;
+            }
+            return;
+          }
+          const ids = new Set(toProcess.map((item) => item.id));
+          cases = cases.map((item) => (ids.has(item.id) ? ai.processCaseForVerdict(item) : item));
+          cases = store.saveCases(cases);
+          if (trialMessage) {
+            const processed = Array.from(ids);
+            trialMessage.textContent = `Processed ${processed.length} case${processed.length > 1 ? 's' : ''}: ${processed.join(', ')}`;
+            trialMessage.hidden = false;
+          }
+          renderCases();
+        } catch (error) {
+          console.error('Trial run failed', error);
+          if (trialMessage) {
+            trialMessage.textContent = 'Could not run the AI trial. Please try again.';
+            trialMessage.hidden = false;
+          }
+        } finally {
+          runTrialButton.disabled = false;
+          runTrialButton.textContent = 'Run AI Trial';
+        }
+      }
+
+      uploadForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const formData = new FormData(uploadForm);
+        const title = (formData.get('title') || '').toString().trim();
+        const story = (formData.get('story') || '').toString().trim();
+        if (!title || !story) return;
+
+        const emptySummary = ai.summariseComments([]);
+        const newCase = {
+          id: `local_${Date.now().toString(36)}`,
+          title: title.slice(0, 120),
+          story,
+          votes: 0,
+          comments: [],
+          ai_summary: emptySummary.lines.join('\n'),
+          status: 'pending',
+          prosecution: '',
+          defense: '',
+          verdict: null,
+          publicSentiment: emptySummary.average
+        };
+        cases = [newCase, ...cases];
+        cases = store.saveCases(cases);
+        uploadForm.reset();
+        if (uploadFeedback) {
+          uploadFeedback.hidden = false;
+          uploadFeedback.textContent = 'Case added to the docket. It lives in your browser storage.';
+        }
+        renderCases();
+      });
+
+      if (runTrialButton) {
+        runTrialButton.addEventListener('click', runTrial);
+      }
+
+      initialise();
+    })();
+  </script>
+</body>
+</html>

--- a/jury/js/juryStore.js
+++ b/jury/js/juryStore.js
@@ -1,0 +1,254 @@
+(function () {
+  const STORAGE_KEY = 'jury_cases_v1';
+  const memoryFallback = (() => {
+    const data = {};
+    return {
+      getItem(key) {
+        return Object.prototype.hasOwnProperty.call(data, key) ? data[key] : null;
+      },
+      setItem(key, value) {
+        data[key] = value;
+      },
+      removeItem(key) {
+        delete data[key];
+      }
+    };
+  })();
+
+  function safeStorage() {
+    try {
+      if (typeof window === 'undefined' || !window.localStorage) {
+        return memoryFallback;
+      }
+      const testKey = '__jury_test__';
+      window.localStorage.setItem(testKey, '1');
+      window.localStorage.removeItem(testKey);
+      return window.localStorage;
+    } catch (error) {
+      console.warn('Local storage unavailable, using in-memory fallback.', error);
+      return memoryFallback;
+    }
+  }
+
+  const storage = safeStorage();
+  let cache = null;
+  let baseLoadPromise = null;
+
+  function clone(value) {
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  async function fetchBaseCases() {
+    if (!baseLoadPromise) {
+      baseLoadPromise = fetch('data/cases.json')
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error('Failed to load base cases');
+          }
+          return response.json();
+        })
+        .catch((error) => {
+          console.warn('Could not fetch base cases', error);
+          return [];
+        });
+    }
+    const result = await baseLoadPromise;
+    return Array.isArray(result) ? clone(result) : [];
+  }
+
+  function normaliseComment(comment) {
+    return {
+      user: (comment?.user || 'anon').toString().slice(0, 40),
+      text: (comment?.text || '').toString().slice(0, 500),
+      sentiment: Number.isFinite(Number(comment?.sentiment)) ? Number(comment.sentiment) : 0
+    };
+  }
+
+  function computeAverageSentiment(comments = []) {
+    if (!comments.length) return 0;
+    const total = comments.reduce((acc, item) => acc + (Number(item.sentiment) || 0), 0);
+    return total / comments.length;
+  }
+
+  function normaliseCase(item) {
+    const comments = Array.isArray(item?.comments) ? item.comments.map(normaliseComment) : [];
+    const base = {
+      id: item?.id || `case_${Date.now().toString(36)}`,
+      title: (item?.title || 'Untitled case').toString(),
+      story: (item?.story || '').toString(),
+      votes: Number.isFinite(Number(item?.votes)) ? Number(item.votes) : 0,
+      comments,
+      ai_summary: typeof item?.ai_summary === 'string' ? item.ai_summary : '',
+      status: item?.status === 'judged' ? 'judged' : 'pending',
+      prosecution: typeof item?.prosecution === 'string' ? item.prosecution : '',
+      defense: typeof item?.defense === 'string' ? item.defense : '',
+      verdict: item?.verdict && typeof item.verdict === 'object' ? clone(item.verdict) : null
+    };
+    if (Number.isFinite(Number(item?.finalScore))) {
+      base.finalScore = Number(item.finalScore);
+    }
+    const sentiment = Number.isFinite(Number(item?.publicSentiment))
+      ? Number(item.publicSentiment)
+      : computeAverageSentiment(comments);
+    base.publicSentiment = sentiment;
+    return base;
+  }
+
+  async function loadCases() {
+    if (cache) {
+      return clone(cache);
+    }
+    let stored;
+    try {
+      stored = storage.getItem(STORAGE_KEY);
+    } catch (error) {
+      console.warn('Failed to read stored cases', error);
+    }
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+          cache = parsed.map(normaliseCase);
+          return clone(cache);
+        }
+      } catch (error) {
+        console.warn('Unable to parse stored cases', error);
+      }
+    }
+    const baseCases = (await fetchBaseCases()).map(normaliseCase);
+    cache = baseCases;
+    persist();
+    return clone(cache);
+  }
+
+  function persist() {
+    try {
+      storage.setItem(STORAGE_KEY, JSON.stringify(cache));
+    } catch (error) {
+      console.warn('Failed to persist cases', error);
+    }
+  }
+
+  function saveCases(list) {
+    cache = Array.isArray(list) ? list.map(normaliseCase) : [];
+    persist();
+    return clone(cache);
+  }
+
+  function addCase(newCase) {
+    if (!cache) {
+      throw new Error('Cases not loaded yet');
+    }
+    const list = [normaliseCase(newCase), ...cache];
+    return saveCases(list);
+  }
+
+  function updateCase(id, updater) {
+    if (!cache) {
+      throw new Error('Cases not loaded yet');
+    }
+    const list = cache.map((item) => {
+      if (item.id !== id) {
+        return item;
+      }
+      const next = typeof updater === 'function' ? updater(clone(item)) : item;
+      return normaliseCase(next);
+    });
+    const updatedList = saveCases(list);
+    return updatedList.find((item) => item.id === id) || null;
+  }
+
+  function getCase(id) {
+    if (!cache) {
+      throw new Error('Cases not loaded yet');
+    }
+    return clone(cache.find((item) => item.id === id) || null);
+  }
+
+  function generateArgument(role, story) {
+    const intro = (story || '')
+      .split(/(?<=[.!?])\s+/)
+      .slice(0, 2)
+      .join(' ')
+      .trim();
+    if (role === 'prosecution') {
+      return `The prosecution argues that the actor's choices created tangible harm. ${intro} This reflects avoidable disrespect for shared boundaries and poor communication.`;
+    }
+    return `The defense highlights the context and intent behind the decision. ${intro} Considering the pressures involved, the actor attempted to minimise fallout while solving an urgent problem.`;
+  }
+
+  function summariseComments(comments = []) {
+    if (!comments.length) {
+      return {
+        average: 0,
+        lines: ['• No public comments yet.', '• Jury sentiment pending.']
+      };
+    }
+    const average = computeAverageSentiment(comments);
+    const tone = average > 0.25 ? 'supportive' : average < -0.25 ? 'critical' : 'mixed';
+    const reasons = comments.slice(-3).map((comment) => `• ${comment.text.slice(0, 90)}`);
+    return {
+      average,
+      lines: [`• Crowd tone: ${tone}.`, ...reasons]
+    };
+  }
+
+  function judgeVerdict(story, prosecution, defense, summary) {
+    const severity = Math.max(0, prosecution.length - defense.length);
+    const judgeScore = severity > 0 ? 70 : 30;
+    const toneLine = summary.lines.find((line) => line.toLowerCase().includes('crowd tone')) || '';
+    const publicScore = toneLine.includes('supportive') ? 30 : toneLine.includes('critical') ? 70 : 50;
+    const juryScore = Math.round((summary.average + 1) * 50);
+    const finalScore = Math.max(0, Math.min(100, Math.round(0.5 * judgeScore + 0.3 * publicScore + 0.2 * juryScore)));
+
+    let decision;
+    if (finalScore <= 25) decision = 'Morally Justified';
+    else if (finalScore <= 50) decision = 'Mostly Justified';
+    else if (finalScore <= 75) decision = 'Morally Wrong';
+    else decision = 'Severe Violation';
+
+    return {
+      decision,
+      reasoning: `Considering the arguments and public reaction (${toneLine || 'no sentiment yet'}), the judge leans toward ${decision.toLowerCase()}.`,
+      confidence: 65,
+      judge: 'Judge Iron',
+      finalScore
+    };
+  }
+
+  function processCaseForVerdict(caseItem) {
+    const base = normaliseCase(caseItem);
+    const summary = summariseComments(base.comments);
+    const prosecution = generateArgument('prosecution', base.story);
+    const defense = generateArgument('defense', base.story);
+    const verdict = judgeVerdict(base.story, prosecution, defense, summary);
+    base.prosecution = prosecution;
+    base.defense = defense;
+    base.ai_summary = summary.lines.join('\n');
+    base.publicSentiment = summary.average;
+    base.status = 'judged';
+    base.verdict = {
+      decision: verdict.decision,
+      reasoning: verdict.reasoning,
+      confidence: verdict.confidence,
+      judge: verdict.judge
+    };
+    base.finalScore = verdict.finalScore;
+    return base;
+  }
+
+  window.JuryStore = {
+    loadCases,
+    saveCases,
+    addCase,
+    updateCase,
+    getCase
+  };
+
+  window.JuryAI = {
+    generateArgument,
+    summariseComments,
+    judgeVerdict,
+    processCaseForVerdict
+  };
+})();

--- a/jury/judges.html
+++ b/jury/judges.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Meet the Judges • AI Judge</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/inter@5.0.16/variable.css">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-slate-950 text-slate-100">
+  <main class="max-w-4xl mx-auto px-4 py-10 space-y-8">
+    <header class="text-center space-y-3">
+      <a href="index.html" class="inline-flex items-center gap-2 text-sm text-slate-300 hover:text-indigo-200">← Back to docket</a>
+      <h1 class="text-3xl font-semibold tracking-tight">Meet the Bench</h1>
+      <p class="text-slate-300 max-w-2xl mx-auto">
+        Each AI judge brings a distinct philosophy. We rotate them through hourly court sessions to balance compassion and order.
+      </p>
+    </header>
+
+    <section id="judge-grid" class="grid gap-6 md:grid-cols-2"></section>
+  </main>
+
+  <template id="judge-card">
+    <article class="card space-y-3">
+      <header>
+        <h2 class="text-xl font-semibold"></h2>
+        <p class="text-sm text-slate-400 philosophy"></p>
+      </header>
+      <p class="text-slate-300 bio"></p>
+      <div class="text-xs text-slate-500 uppercase tracking-wide">Style</div>
+      <p class="text-sm text-indigo-300 style"></p>
+      <div class="flex items-center justify-between text-sm text-slate-400">
+        <span class="cases"></span>
+        <span class="agree"></span>
+      </div>
+    </article>
+  </template>
+
+  <script>
+    async function loadJudges() {
+      const response = await fetch('data/judges.json');
+      const judges = await response.json();
+      const grid = document.getElementById('judge-grid');
+      const template = document.getElementById('judge-card');
+      judges.forEach((judge) => {
+        const node = template.content.cloneNode(true);
+        node.querySelector('h2').textContent = judge.name;
+        node.querySelector('.philosophy').textContent = judge.philosophy;
+        node.querySelector('.bio').textContent = judge.bio;
+        node.querySelector('.style').textContent = judge.style;
+        if (judge.stats) {
+          node.querySelector('.cases').textContent = `${judge.stats.cases} cases heard`;
+          node.querySelector('.agree').textContent = `${Math.round(judge.stats.agreeRate * 100)}% public agreement`;
+        }
+        grid.appendChild(node);
+      });
+    }
+    loadJudges();
+  </script>
+</body>
+</html>

--- a/jury/style.css
+++ b/jury/style.css
@@ -1,0 +1,118 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(79, 70, 229, 0.08), transparent 60%), #0f172a;
+  color: #e2e8f0;
+}
+
+a {
+  color: #a855f7;
+}
+
+a:hover {
+  color: #d946ef;
+}
+
+.card {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.3);
+  backdrop-filter: blur(16px);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  border-radius: 9999px;
+  padding: 0.25rem 0.75rem;
+  background: rgba(59, 130, 246, 0.15);
+  color: #93c5fd;
+}
+
+.button-primary {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #6366f1, #a855f7);
+  color: white;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px rgba(99, 102, 241, 0.4);
+}
+
+.button-secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  background: rgba(129, 140, 248, 0.15);
+  color: #bfdbfe;
+  font-weight: 600;
+  border: 1px solid rgba(129, 140, 248, 0.4);
+  transition: background 0.2s ease, color 0.2s ease, opacity 0.2s ease;
+}
+
+.button-secondary:hover {
+  background: rgba(129, 140, 248, 0.25);
+  color: #e0f2fe;
+}
+
+.button-secondary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+input, textarea {
+  color: #0f172a;
+}
+
+.progress-bar {
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+}
+
+.progress-bar div {
+  height: 100%;
+  background: linear-gradient(135deg, #34d399, #22d3ee);
+}
+
+.summary-list {
+  list-style: disc;
+  padding-left: 1.5rem;
+  color: #cbd5f5;
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+}
+
+.score-bar {
+  position: relative;
+  height: 0.6rem;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+}
+
+.score-bar-fill {
+  height: 100%;
+  background: linear-gradient(135deg, #22d3ee, #6366f1);
+  width: 0;
+  transition: width 0.4s ease;
+}


### PR DESCRIPTION
## Summary
- replace the placeholder jury page with a fully interactive docket that persists cases in-browser and runs the AI trial simulator
- add a shared jury store module plus case detail page so players can add comments, view verdicts, and react to debates
- copy supporting styles and seed data so judges information and starter cases load from static assets

## Testing
- Manual QA in browser

------
https://chatgpt.com/codex/tasks/task_e_68e52c5f1a388322abeea6e3d2dc9cec