### PR TITLE
Make AI jury demo run locally without serverless API

### DIFF
--- a/jury/aijudge/public/case.html
+++ b/jury/aijudge/public/case.html
@@ -79,111 +79,132 @@
   </main>
 
   <script>
-    const params = new URLSearchParams(window.location.search);
-    const caseId = params.get('id');
-    if (!caseId) {
-      window.location.replace('index.html');
-    }
-
-    async function loadCase() {
-      const response = await fetch('../data/cases.json?_=' + Date.now());
-      const cases = await response.json();
-      const item = cases.find((entry) => entry.id === caseId);
-      if (!item) {
-        document.getElementById('case-card').innerHTML = '<p class="text-slate-300">Case not found.</p>';
+    window.JuryConfig = {
+      casesPath: '../data/cases.json',
+      storageKey: 'jury_cases_public_v1'
+    };
+  </script>
+  <script src="../../js/juryStore.js"></script>
+  <script>
+    (async function () {
+      const params = new URLSearchParams(window.location.search);
+      const caseId = params.get('id');
+      if (!caseId) {
+        window.location.replace('index.html');
         return;
       }
-      document.getElementById('case-title').textContent = item.title;
-      document.getElementById('case-story').textContent = item.story;
-      document.getElementById('case-votes').textContent = item.votes;
-      document.getElementById('case-status').textContent = item.status === 'judged' ? 'VERDICT PUBLISHED' : 'AWAITING TRIAL';
 
+      const store = window.JuryStore;
+      const ai = window.JuryAI;
+      const commentForm = document.getElementById('comment-form');
+      const summarySection = document.getElementById('summary-section');
+      const summaryList = document.getElementById('summary-list');
+      const sentimentScore = document.getElementById('sentiment-score');
+      const commentList = document.getElementById('comment-list');
       const verdictSection = document.getElementById('verdict-section');
       const scoreWrap = document.getElementById('score-wrap');
 
-      if (item.verdict) {
-        verdictSection.hidden = false;
-        document.getElementById('verdict-decision').textContent = item.verdict.decision;
-        document.getElementById('verdict-reasoning').textContent = item.verdict.reasoning;
-        const judgeName = item.verdict.judge || 'Unknown Judge';
-        const metaBits = [judgeName];
-        if (Number.isFinite(item.verdict.confidence)) {
-          metaBits.push(`Confidence ${item.verdict.confidence}%`);
-        }
-        document.getElementById('verdict-meta').textContent = metaBits.join(' • ');
-        if (Number.isFinite(item.finalScore)) {
-          scoreWrap.hidden = false;
-          const scoreFill = document.getElementById('score-fill');
-          const clamped = Math.max(0, Math.min(100, Math.round(item.finalScore)));
-          scoreFill.style.width = clamped + '%';
-          document.getElementById('score-note').textContent = `Composite score ${clamped}/100 from judge and crowd weighting.`;
-        } else {
-          scoreWrap.hidden = true;
-        }
-        document.querySelector('#prosecution p').textContent = item.prosecution || 'Awaiting trial.';
-        document.querySelector('#defense p').textContent = item.defense || 'Awaiting trial.';
-      } else {
-        verdictSection.hidden = true;
-        scoreWrap.hidden = true;
+      await store.loadCases();
+      let currentCase = store.getCase(caseId);
+      if (!currentCase) {
+        document.getElementById('case-card').innerHTML = '<p class="text-slate-300">Case not found.</p>';
+        commentForm.hidden = true;
+        summarySection.hidden = true;
+        return;
       }
 
-      const summarySection = document.getElementById('summary-section');
-      const summaryList = document.getElementById('summary-list');
-      if (item.ai_summary) {
-        summarySection.hidden = false;
-        summaryList.innerHTML = '';
-        item.ai_summary
-          .split('\n')
-          .map((line) => line.trim())
-          .filter(Boolean)
-          .forEach((line) => {
+      function renderCase() {
+        document.getElementById('case-title').textContent = currentCase.title;
+        document.getElementById('case-story').textContent = currentCase.story;
+        document.getElementById('case-votes').textContent = currentCase.votes;
+        document.getElementById('case-status').textContent = currentCase.status === 'judged' ? 'VERDICT PUBLISHED' : 'AWAITING TRIAL';
+
+        if (currentCase.verdict) {
+          verdictSection.hidden = false;
+          document.getElementById('verdict-decision').textContent = currentCase.verdict.decision;
+          document.getElementById('verdict-reasoning').textContent = currentCase.verdict.reasoning;
+          const judgeName = currentCase.verdict.judge || 'Unknown Judge';
+          const metaBits = [judgeName];
+          if (Number.isFinite(currentCase.verdict.confidence)) {
+            metaBits.push(`Confidence ${currentCase.verdict.confidence}%`);
+          }
+          document.getElementById('verdict-meta').textContent = metaBits.join(' • ');
+          if (Number.isFinite(currentCase.finalScore)) {
+            scoreWrap.hidden = false;
+            const scoreFill = document.getElementById('score-fill');
+            const clamped = Math.max(0, Math.min(100, Math.round(currentCase.finalScore)));
+            scoreFill.style.width = clamped + '%';
+            document.getElementById('score-note').textContent = `Composite score ${clamped}/100 from judge and crowd weighting.`;
+          } else {
+            scoreWrap.hidden = true;
+          }
+          document.querySelector('#prosecution p').textContent = currentCase.prosecution || 'Awaiting trial.';
+          document.querySelector('#defense p').textContent = currentCase.defense || 'Awaiting trial.';
+        } else {
+          verdictSection.hidden = true;
+          scoreWrap.hidden = true;
+        }
+
+        const summaryInfo = currentCase.ai_summary
+          ? { lines: currentCase.ai_summary.split('\n').filter(Boolean), average: currentCase.publicSentiment ?? ai.summariseComments(currentCase.comments || []).average }
+          : ai.summariseComments(currentCase.comments || []);
+        if (summaryInfo.lines.length) {
+          summarySection.hidden = false;
+          summaryList.innerHTML = '';
+          summaryInfo.lines.forEach((line) => {
             const entry = document.createElement('li');
             entry.textContent = line.replace(/^•\s*/, '');
             summaryList.appendChild(entry);
           });
-      } else {
-        summarySection.hidden = true;
-      }
+        } else {
+          summarySection.hidden = true;
+        }
 
-      const comments = item.comments || [];
-      const list = document.getElementById('comment-list');
-      list.innerHTML = '';
-      comments.forEach((comment) => {
-        const li = document.createElement('li');
-        li.className = 'bg-slate-900/40 rounded-xl p-3 text-sm flex flex-col gap-1';
-        li.innerHTML = `<div class="flex items-center justify-between text-slate-400"><span>${comment.user}</span><span>${formatSentiment(comment.sentiment)}</span></div><p class="text-slate-200">${comment.text}</p>`;
-        list.appendChild(li);
-      });
-      const average = comments.reduce((acc, c) => acc + (c.sentiment || 0), 0) / Math.max(1, comments.length);
-      document.getElementById('sentiment-score').textContent = `Crowd Sentiment: ${(average * 100).toFixed(0)} / 100`;
-    }
-
-    function formatSentiment(score = 0) {
-      if (score > 0.25) return 'Supportive';
-      if (score < -0.25) return 'Critical';
-      return 'Mixed';
-    }
-
-    document.getElementById('comment-form').addEventListener('submit', async (event) => {
-      event.preventDefault();
-      const formData = new FormData(event.target);
-      const payload = Object.fromEntries(formData.entries());
-      payload.sentiment = Number(payload.sentiment);
-      payload.id = caseId;
-      try {
-        await fetch('/api/comment', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload)
+        commentList.innerHTML = '';
+        (currentCase.comments || []).forEach((comment) => {
+          const li = document.createElement('li');
+          li.className = 'bg-slate-900/40 rounded-xl p-3 text-sm flex flex-col gap-1';
+          li.innerHTML = `<div class="flex items-center justify-between text-slate-400"><span>${comment.user}</span><span>${formatSentiment(comment.sentiment)}</span></div><p class="text-slate-200">${comment.text}</p>`;
+          commentList.appendChild(li);
         });
-        event.target.reset();
-        loadCase();
-      } catch (error) {
-        console.error('Comment failed', error);
-      }
-    });
 
-    loadCase();
+        const summary = ai.summariseComments(currentCase.comments || []);
+        sentimentScore.textContent = `Crowd Sentiment: ${(summary.average * 100).toFixed(0)} / 100`;
+      }
+
+      function formatSentiment(score = 0) {
+        if (score > 0.25) return 'Supportive';
+        if (score < -0.25) return 'Critical';
+        return 'Mixed';
+      }
+
+      commentForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const formData = new FormData(commentForm);
+        const user = (formData.get('user') || '').toString().trim();
+        const text = (formData.get('text') || '').toString().trim();
+        const sentiment = Number(formData.get('sentiment') || 0);
+        if (!user || !text) return;
+
+        currentCase = store.updateCase(caseId, (item) => {
+          const comments = Array.isArray(item.comments) ? item.comments.slice() : [];
+          comments.push({ user: user.slice(0, 40), text: text.slice(0, 500), sentiment });
+          const summary = ai.summariseComments(comments);
+          const next = {
+            ...item,
+            comments,
+            ai_summary: summary.lines.join('\n'),
+            publicSentiment: summary.average
+          };
+          return next;
+        });
+
+        commentForm.reset();
+        renderCase();
+      });
+
+      renderCase();
+    })();
   </script>
 </body>
 </html>

--- a/jury/aijudge/public/index.html
+++ b/jury/aijudge/public/index.html
@@ -49,8 +49,9 @@
           </div>
           <button type="submit" class="button-primary w-full">Send to the Jury</button>
           <p class="text-xs text-slate-400">
-            Uploads run through a quick moderation check before joining the docket.
+            Uploads are stored locally in this browser so you can keep iterating before sharing.
           </p>
+          <p id="upload-feedback" class="text-xs text-emerald-300" hidden>Case added to the docket. Refresh the page to reset.</p>
         </form>
       </aside>
     </section>
@@ -99,125 +100,163 @@
   </template>
 
   <script>
-    const feed = document.getElementById('case-feed');
-    const template = document.getElementById('case-template');
-    const uploadForm = document.getElementById('upload-form');
-    const runTrialButton = document.getElementById('run-trial');
-    const trialMessage = document.getElementById('trial-message');
+    window.JuryConfig = {
+      casesPath: '../data/cases.json',
+      storageKey: 'jury_cases_public_v1'
+    };
+  </script>
+  <script src="../../js/juryStore.js"></script>
+  <script>
+    (async function () {
+      const store = window.JuryStore;
+      const ai = window.JuryAI;
+      const feed = document.getElementById('case-feed');
+      const template = document.getElementById('case-template');
+      const uploadForm = document.getElementById('upload-form');
+      const runTrialButton = document.getElementById('run-trial');
+      const trialMessage = document.getElementById('trial-message');
+      const uploadFeedback = document.getElementById('upload-feedback');
 
-    async function fetchCases() {
-      try {
-        const response = await fetch('../data/cases.json?_=' + Date.now());
-        if (!response.ok) throw new Error('Failed to fetch cases');
-        const cases = await response.json();
-        renderCases(cases);
-      } catch (error) {
-        console.error('Failed to load cases', error);
-        feed.innerHTML = '<p class="text-sm text-rose-300">Unable to load the docket right now. Try again shortly.</p>';
-      }
-    }
+      let cases = [];
 
-    function renderCases(cases) {
-      feed.innerHTML = '';
-      if (!cases.length) {
-        feed.innerHTML = '<p class="text-sm text-slate-300">No cases yet. Submit a dilemma to start the debate.</p>';
-        return;
-      }
-
-      cases.forEach((item) => {
-        const node = template.content.cloneNode(true);
-        node.querySelector('h3').textContent = item.title;
-        node.querySelector('.story').textContent = item.story;
-        node.querySelector('.votes').textContent = item.votes;
-        const summaryText = item.ai_summary ? item.ai_summary.split('\n')[0].replace(/^•\s*/, '') : 'Awaiting community input.';
-        node.querySelector('.summary').textContent = summaryText;
-        const status = node.querySelector('.status');
-        if (item.status === 'judged') {
-          const details = [item.verdict?.decision, item.verdict?.judge ? `Judge ${item.verdict.judge}` : null];
-          if (Number.isFinite(item.finalScore)) {
-            details.push(`Score ${item.finalScore}`);
-          }
-          status.textContent = details.filter(Boolean).join(' • ') || 'Verdict published';
-        } else {
-          status.textContent = 'Awaiting trial';
+      async function initialise() {
+        try {
+          cases = await store.loadCases();
+          renderCases();
+        } catch (error) {
+          console.error('Failed to load cases', error);
+          feed.innerHTML = '<p class="text-sm text-rose-300">Unable to load the docket right now. Try again shortly.</p>';
         }
-        const sentiment = Math.max(0, Math.min(100, Math.round(((item.comments || []).reduce((acc, c) => acc + (c.sentiment || 0), 0) / Math.max(1, (item.comments || []).length) + 1) * 50)));
-        node.querySelector('.sentiment').style.width = sentiment + '%';
-        node.querySelector('a').href = `case.html?id=${encodeURIComponent(item.id)}`;
-        node.querySelector('.vote-up').addEventListener('click', () => vote(item.id, 1));
-        node.querySelector('.vote-down').addEventListener('click', () => vote(item.id, -1));
-        feed.appendChild(node);
-      });
-    }
-
-    async function triggerTrial() {
-      if (!runTrialButton) return;
-      runTrialButton.disabled = true;
-      runTrialButton.textContent = 'Running…';
-      if (trialMessage) {
-        trialMessage.hidden = true;
       }
-      try {
-        const response = await fetch('/api/runTrial', { method: 'POST' });
-        if (!response.ok) throw new Error('Trial failed');
-        const result = await response.json();
-        const processed = result.processed || [];
-        if (trialMessage) {
-          if (processed.length) {
-            trialMessage.textContent = `Processed ${processed.length} case${processed.length > 1 ? 's' : ''}: ${processed.join(', ')}`;
+
+      function renderCases() {
+        feed.innerHTML = '';
+        if (!cases.length) {
+          feed.innerHTML = '<p class="text-sm text-slate-300">No cases yet. Submit a dilemma to start the debate.</p>';
+          return;
+        }
+
+        cases.forEach((item) => {
+          const node = template.content.cloneNode(true);
+          node.querySelector('h3').textContent = item.title;
+          node.querySelector('.story').textContent = item.story;
+          node.querySelector('.votes').textContent = item.votes;
+
+          const summaryText = item.ai_summary
+            ? item.ai_summary.split('\n')[0].replace(/^•\s*/, '')
+            : ai.summariseComments(item.comments || []).lines[0].replace(/^•\s*/, '');
+          node.querySelector('.summary').textContent = summaryText;
+
+          const status = node.querySelector('.status');
+          if (item.status === 'judged') {
+            const details = [item.verdict?.decision, item.verdict?.judge ? `Judge ${item.verdict.judge}` : null];
+            if (Number.isFinite(item.finalScore)) {
+              details.push(`Score ${Math.round(item.finalScore)}`);
+            }
+            status.textContent = details.filter(Boolean).join(' • ') || 'Verdict published';
           } else {
-            trialMessage.textContent = 'No pending cases were ready for trial yet.';
+            status.textContent = 'Awaiting trial';
           }
-          trialMessage.hidden = false;
-        }
-        fetchCases();
-      } catch (error) {
-        console.error('Trial run failed', error);
+
+          const sentimentInfo = ai.summariseComments(item.comments || []);
+          const sentimentWidth = Math.max(0, Math.min(100, Math.round((sentimentInfo.average + 1) * 50)));
+          node.querySelector('.sentiment').style.width = sentimentWidth + '%';
+
+          const link = node.querySelector('a');
+          link.href = `case.html?id=${encodeURIComponent(item.id)}`;
+
+          node.querySelector('.vote-up').addEventListener('click', () => adjustVotes(item.id, 1));
+          node.querySelector('.vote-down').addEventListener('click', () => adjustVotes(item.id, -1));
+
+          feed.appendChild(node);
+        });
+      }
+
+      function adjustVotes(id, delta) {
+        cases = cases.map((item) => {
+          if (item.id !== id) return item;
+          const nextVotes = Math.max(0, (Number(item.votes) || 0) + delta);
+          return { ...item, votes: nextVotes };
+        });
+        cases = store.saveCases(cases);
+        renderCases();
+      }
+
+      async function runTrial() {
+        if (!runTrialButton) return;
+        runTrialButton.disabled = true;
+        runTrialButton.textContent = 'Running…';
         if (trialMessage) {
-          trialMessage.textContent = 'Could not run the AI trial. Please try again.';
-          trialMessage.hidden = false;
+          trialMessage.hidden = true;
         }
-      } finally {
-        runTrialButton.disabled = false;
-        runTrialButton.textContent = 'Run AI Trial';
+        try {
+          const pending = cases.filter((item) => item.status !== 'judged');
+          const toProcess = pending.slice(0, 3);
+          if (!toProcess.length) {
+            if (trialMessage) {
+              trialMessage.textContent = 'No pending cases were ready for trial yet.';
+              trialMessage.hidden = false;
+            }
+            return;
+          }
+          const ids = new Set(toProcess.map((item) => item.id));
+          cases = cases.map((item) => (ids.has(item.id) ? ai.processCaseForVerdict(item) : item));
+          cases = store.saveCases(cases);
+          if (trialMessage) {
+            const processed = Array.from(ids);
+            trialMessage.textContent = `Processed ${processed.length} case${processed.length > 1 ? 's' : ''}: ${processed.join(', ')}`;
+            trialMessage.hidden = false;
+          }
+          renderCases();
+        } catch (error) {
+          console.error('Trial run failed', error);
+          if (trialMessage) {
+            trialMessage.textContent = 'Could not run the AI trial. Please try again.';
+            trialMessage.hidden = false;
+          }
+        } finally {
+          runTrialButton.disabled = false;
+          runTrialButton.textContent = 'Run AI Trial';
+        }
       }
-    }
 
-    async function vote(id, delta) {
-      try {
-        await fetch('/api/vote', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id, delta })
-        });
-        fetchCases();
-      } catch (error) {
-        console.error('Vote failed', error);
-      }
-    }
+      uploadForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const formData = new FormData(uploadForm);
+        const title = (formData.get('title') || '').toString().trim();
+        const story = (formData.get('story') || '').toString().trim();
+        if (!title || !story) return;
 
-    if (runTrialButton) {
-      runTrialButton.addEventListener('click', triggerTrial);
-    }
-
-    uploadForm.addEventListener('submit', async (event) => {
-      event.preventDefault();
-      const formData = new FormData(uploadForm);
-      const payload = Object.fromEntries(formData.entries());
-      try {
-        await fetch('/api/upload', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload)
-        });
+        const emptySummary = ai.summariseComments([]);
+        const newCase = {
+          id: `local_${Date.now().toString(36)}`,
+          title: title.slice(0, 120),
+          story,
+          votes: 0,
+          comments: [],
+          ai_summary: emptySummary.lines.join('\n'),
+          status: 'pending',
+          prosecution: '',
+          defense: '',
+          verdict: null,
+          publicSentiment: emptySummary.average
+        };
+        cases = [newCase, ...cases];
+        cases = store.saveCases(cases);
         uploadForm.reset();
-        fetchCases();
-      } catch (error) {
-        console.error('Upload failed', error);
-      }
-    });
+        if (uploadFeedback) {
+          uploadFeedback.hidden = false;
+          uploadFeedback.textContent = 'Case added to the docket. It lives in your browser storage.';
+        }
+        renderCases();
+      });
 
-    fetchCases();
+      if (runTrialButton) {
+        runTrialButton.addEventListener('click', runTrial);
+      }
+
+      initialise();
+    })();
   </script>
 </body>
 </html>

--- a/jury/js/juryStore.js
+++ b/jury/js/juryStore.js
@@ -1,5 +1,19 @@
 (function () {
-  const STORAGE_KEY = 'jury_cases_v1';
+  const globalObject = typeof window !== 'undefined' ? window : globalThis;
+  const config = (globalObject && globalObject.JuryConfig) || {};
+  if (globalObject && globalObject.JuryConfig) {
+    try {
+      delete globalObject.JuryConfig;
+    } catch (error) {
+      globalObject.JuryConfig = undefined;
+    }
+  }
+  const STORAGE_KEY = typeof config.storageKey === 'string' && config.storageKey.trim().length
+    ? config.storageKey.trim()
+    : 'jury_cases_v1';
+  const CASES_PATH = typeof config.casesPath === 'string' && config.casesPath.trim().length
+    ? config.casesPath.trim()
+    : 'data/cases.json';
   const memoryFallback = (() => {
     const data = {};
     return {
@@ -40,7 +54,7 @@
 
   async function fetchBaseCases() {
     if (!baseLoadPromise) {
-      baseLoadPromise = fetch('data/cases.json')
+      baseLoadPromise = fetch(CASES_PATH)
         .then((response) => {
           if (!response.ok) {
             throw new Error('Failed to load base cases');


### PR DESCRIPTION
## Summary
- allow the shared JuryStore to read a runtime configuration for case data paths and storage keys so multiple demos can reuse it
- switch the public AI Judge index and case views to the in-browser JuryStore/JuryAI engine, enabling trials and comments without hitting serverless endpoints
- refresh copy and feedback messaging so uploads clearly stay in local storage when the demo runs offline

## Testing
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68e52f4fb6388322826735d9b4ade130