### PR TITLE
Add AI bot docket seeding and rich case presentation

### DIFF
--- a/jury/case.html
+++ b/jury/case.html
@@ -12,20 +12,59 @@
   <main class="max-w-3xl mx-auto px-4 py-10 space-y-8">
     <a href="index.html" class="inline-flex items-center gap-2 text-sm text-slate-300 hover:text-indigo-200">← Back to docket</a>
     <article class="card space-y-6" id="case-card">
-      <header class="space-y-2">
+      <header class="space-y-4">
         <div class="flex flex-wrap items-center justify-between gap-3">
           <h1 class="text-2xl font-semibold" id="case-title"></h1>
           <span class="badge"><span>🗳️</span><span id="case-votes"></span></span>
         </div>
         <p id="case-story" class="text-slate-300 leading-relaxed"></p>
+        <p id="case-filed-by" class="text-xs text-indigo-200"></p>
+        <div class="case-roster" id="case-roster">
+          <div class="roster-card prosecutor">
+            <p class="label">Prosecutor</p>
+            <p class="name" id="case-prosecutor-name"></p>
+            <p class="summary" id="case-prosecutor-summary"></p>
+          </div>
+          <div class="roster-card defendant">
+            <p class="label">Defendant</p>
+            <p class="name" id="case-defendant-name"></p>
+            <p class="summary" id="case-defendant-summary"></p>
+          </div>
+          <div class="roster-card defense">
+            <p class="label">Defense Counsel</p>
+            <p class="name" id="case-defense-name"></p>
+            <p class="summary" id="case-defense-summary"></p>
+          </div>
+        </div>
         <div class="text-xs uppercase tracking-wide text-slate-500" id="case-status"></div>
       </header>
+      <section class="case-matrix">
+        <div class="case-panel">
+          <h2 class="panel-title">Charges</h2>
+          <ul id="case-charges" class="case-list"></ul>
+        </div>
+        <div class="case-panel">
+          <h2 class="panel-title">Key Evidence</h2>
+          <ul id="case-evidence" class="case-list"></ul>
+        </div>
+      </section>
+      <section class="case-matrix">
+        <div class="case-panel">
+          <h2 class="panel-title">Timeline of Events</h2>
+          <ol id="case-timeline" class="timeline-list"></ol>
+        </div>
+        <div class="case-panel" id="jury-box-card">
+          <h2 class="panel-title">Jury Box Tally</h2>
+          <p id="jury-box-tally" class="text-slate-200 font-semibold"></p>
+          <p id="jury-box-stance" class="text-sm text-slate-300"></p>
+        </div>
+      </section>
       <section class="space-y-4" id="verdict-section" hidden>
         <h2 class="text-lg font-semibold">Latest Verdict</h2>
         <div class="grid gap-4 md:grid-cols-3 text-sm text-slate-200">
           <div class="bg-slate-900/50 rounded-xl p-4">
             <h3 class="font-semibold text-slate-100 mb-1">Verdict</h3>
-            <p id="verdict-decision" class="text-indigo-300"></p>
+            <p id="verdict-decision" class="verdict-headline"></p>
           </div>
           <div class="bg-slate-900/50 rounded-xl p-4 md:col-span-2">
             <h3 class="font-semibold text-slate-100 mb-1">Judge Reasoning</h3>
@@ -97,6 +136,19 @@
       const commentList = document.getElementById('comment-list');
       const verdictSection = document.getElementById('verdict-section');
       const scoreWrap = document.getElementById('score-wrap');
+      const filedBy = document.getElementById('case-filed-by');
+      const prosecutorName = document.getElementById('case-prosecutor-name');
+      const prosecutorSummary = document.getElementById('case-prosecutor-summary');
+      const defendantName = document.getElementById('case-defendant-name');
+      const defendantSummary = document.getElementById('case-defendant-summary');
+      const defenseName = document.getElementById('case-defense-name');
+      const defenseSummary = document.getElementById('case-defense-summary');
+      const chargesList = document.getElementById('case-charges');
+      const evidenceList = document.getElementById('case-evidence');
+      const timelineList = document.getElementById('case-timeline');
+      const juryBoxCard = document.getElementById('jury-box-card');
+      const juryBoxTally = document.getElementById('jury-box-tally');
+      const juryBoxStance = document.getElementById('jury-box-stance');
 
       await store.loadCases();
       let currentCase = store.getCase(caseId);
@@ -107,11 +159,130 @@
         return;
       }
 
+      function renderSimpleList(target, list, emptyText) {
+        if (!target) return;
+        target.innerHTML = '';
+        if (!Array.isArray(list) || !list.length) {
+          const li = document.createElement('li');
+          li.className = 'text-sm text-slate-400';
+          li.textContent = emptyText;
+          target.appendChild(li);
+          return;
+        }
+        list.forEach((item) => {
+          const li = document.createElement('li');
+          li.textContent = item;
+          target.appendChild(li);
+        });
+      }
+
+      function renderTimeline(target, entries) {
+        if (!target) return;
+        target.innerHTML = '';
+        if (!Array.isArray(entries) || !entries.length) {
+          const li = document.createElement('li');
+          li.className = 'text-sm text-slate-400';
+          li.textContent = 'Timeline not submitted yet.';
+          target.appendChild(li);
+          return;
+        }
+        entries.forEach((entry) => {
+          const li = document.createElement('li');
+          li.className = 'timeline-entry';
+          const time = document.createElement('span');
+          time.className = 'timeline-time';
+          time.textContent = entry.time || '';
+          const event = document.createElement('span');
+          event.className = 'timeline-event';
+          event.textContent = entry.event || '';
+          li.appendChild(time);
+          li.appendChild(event);
+          target.appendChild(li);
+        });
+      }
+
+      function buildRoleBadge(user) {
+        if (!user) return null;
+        const lower = user.toLowerCase();
+        let roleClass = '';
+        let label = '';
+        if (lower.includes('prosecutor')) {
+          roleClass = 'role-prosecution';
+          label = 'PROSECUTION';
+        } else if (lower.includes('defense') || lower.includes('defence')) {
+          roleClass = 'role-defense';
+          label = 'DEFENSE';
+        } else if (lower.includes('jury box')) {
+          roleClass = 'role-jury';
+          label = 'JURY BOX';
+        } else if (lower.includes('judge')) {
+          roleClass = 'role-judge';
+          label = 'JUDGE';
+        }
+        if (!roleClass) return null;
+        const badge = document.createElement('span');
+        badge.className = `role-badge ${roleClass}`;
+        badge.textContent = label;
+        return badge;
+      }
+
       function renderCase() {
         document.getElementById('case-title').textContent = currentCase.title;
         document.getElementById('case-story').textContent = currentCase.story;
         document.getElementById('case-votes').textContent = currentCase.votes;
-        document.getElementById('case-status').textContent = currentCase.status === 'judged' ? 'VERDICT PUBLISHED' : 'AWAITING TRIAL';
+        const statusText = currentCase.status === 'judged'
+          ? `VERDICT: ${currentCase.verdict?.decision || 'Published'}`
+          : 'AWAITING TRIAL';
+        document.getElementById('case-status').textContent = statusText;
+
+        if (filedBy) {
+          if (currentCase.filedBy) {
+            filedBy.hidden = false;
+            filedBy.textContent = `Filed by ${currentCase.filedBy}`;
+          } else {
+            filedBy.hidden = true;
+          }
+        }
+
+        const parties = currentCase.parties || {};
+        if (prosecutorName) {
+          prosecutorName.textContent = parties.prosecutor?.name || 'Prosecutor';
+        }
+        if (prosecutorSummary) {
+          prosecutorSummary.textContent = parties.prosecutor?.summary || parties.prosecutor?.title || '';
+        }
+        if (defendantName) {
+          defendantName.textContent = parties.defendant?.name || 'Defendant';
+        }
+        if (defendantSummary) {
+          defendantSummary.textContent = parties.defendant?.summary || parties.defendant?.title || '';
+        }
+        if (defenseName) {
+          defenseName.textContent = parties.defense?.name || 'Defense Counsel';
+        }
+        if (defenseSummary) {
+          defenseSummary.textContent = parties.defense?.summary || parties.defense?.title || '';
+        }
+
+        renderSimpleList(chargesList, currentCase.charges, 'No charges submitted.');
+        const evidenceItems = (currentCase.evidence || []).map((item) => `${item.label}: ${item.detail}`);
+        renderSimpleList(evidenceList, evidenceItems, 'Evidence will be uploaded before trial.');
+        renderTimeline(timelineList, currentCase.timeline);
+
+        const box = currentCase.juryBox || null;
+        if (juryBoxCard) {
+          if (box) {
+            juryBoxCard.hidden = false;
+            if (juryBoxTally) {
+              juryBoxTally.textContent = `Prosecution ${box.votesForProsecution ?? 0} • Defense ${box.votesForDefense ?? 0}`;
+            }
+            if (juryBoxStance) {
+              juryBoxStance.textContent = box.stance || 'Jury Box has not provided commentary yet.';
+            }
+          } else {
+            juryBoxCard.hidden = true;
+          }
+        }
 
         if (currentCase.verdict) {
           verdictSection.hidden = false;
@@ -158,7 +329,28 @@
         (currentCase.comments || []).forEach((comment) => {
           const li = document.createElement('li');
           li.className = 'bg-slate-900/40 rounded-xl p-3 text-sm flex flex-col gap-1';
-          li.innerHTML = `<div class="flex items-center justify-between text-slate-400"><span>${comment.user}</span><span>${formatSentiment(comment.sentiment)}</span></div><p class="text-slate-200">${comment.text}</p>`;
+          const meta = document.createElement('div');
+          meta.className = 'flex items-center justify-between text-slate-400 gap-2 flex-wrap';
+          const userWrap = document.createElement('div');
+          userWrap.className = 'flex items-center gap-2';
+          const name = document.createElement('span');
+          name.textContent = comment.user;
+          userWrap.appendChild(name);
+          const badge = buildRoleBadge(comment.user || '');
+          if (badge) {
+            userWrap.appendChild(badge);
+          }
+          meta.appendChild(userWrap);
+          const sentimentLabel = document.createElement('span');
+          sentimentLabel.textContent = formatSentiment(comment.sentiment);
+          meta.appendChild(sentimentLabel);
+
+          const body = document.createElement('p');
+          body.className = 'text-slate-200';
+          body.textContent = comment.text;
+
+          li.appendChild(meta);
+          li.appendChild(body);
           commentList.appendChild(li);
         });
         const average = ai.summariseComments(currentCase.comments || []).average;

--- a/jury/data/cases.json
+++ b/jury/data/cases.json
@@ -1,14 +1,94 @@
 [
   {
-    "id": "case_001",
-    "title": "Borrowed laptop for remote class",
-    "story": "I borrowed my roommate's laptop while he was out because my own died before an online exam. I returned it the same day, but he was upset that I didn't ask first.",
-    "votes": 12,
-    "comments": [
-      { "user": "anon1", "text": "You should have left a note.", "sentiment": -0.1 },
-      { "user": "anon2", "text": "Saving your grade seems fair.", "sentiment": 0.6 }
+    "id": "state_vs_rivera",
+    "title": "State v. Alex Rivera — Emergency Laptop Borrowing",
+    "story": "Alex Rivera, a third-year engineering student, borrowed roommate Eli Chen's laptop without permission after Rivera's device died minutes before a proctored exam. ProsecutorBot-03 filed charges for unauthorized access, arguing Rivera breached the shared-housing conduct code. The defense claims the emergency justified the temporary use and that Rivera immediately informed Eli afterward.",
+    "votes": 162,
+    "filedBy": "ProsecutorBot-03",
+    "defendant": {
+      "name": "Alex Rivera",
+      "title": "Engineering Student (Defendant)",
+      "summary": "Pleads not guilty, citing academic emergency and intent to replace any wear on the laptop."
+    },
+    "prosecutor": {
+      "name": "Jordan Hale",
+      "title": "Student Conduct Prosecutor",
+      "summary": "Frames the borrowing as a consent breach that undermines shared trust agreements."
+    },
+    "defenseCounsel": {
+      "name": "Morgan Lee",
+      "title": "Defense Advocate",
+      "summary": "Insists necessity doctrine applies because Rivera faced academic failure without the device."
+    },
+    "charges": [
+      "Count 1: Unauthorized use of personal property",
+      "Count 2: Breach of roommate technology agreement"
     ],
-    "ai_summary": "Split: some say borrowing without asking was wrong, others prioritize the exam emergency.",
+    "timeline": [
+      {
+        "time": "07:45",
+        "event": "Rivera discovers laptop battery failure moments before the exam."
+      },
+      {
+        "time": "07:52",
+        "event": "Rivera unlocks Eli's laptop using the shared password to join the exam portal."
+      },
+      {
+        "time": "09:10",
+        "event": "Exam concludes; Rivera wipes browsing history and sanitizes the keyboard."
+      },
+      {
+        "time": "09:25",
+        "event": "Rivera texts Eli admitting the emergency borrowing and offers to run diagnostics."
+      }
+    ],
+    "evidence": [
+      {
+        "label": "Housing Agreement",
+        "detail": "Signed contract requiring consent before sharing electronics."
+      },
+      {
+        "label": "System Logs",
+        "detail": "Login records showing a 78-minute session under Rivera's credentials."
+      },
+      {
+        "label": "Message Thread",
+        "detail": "Screenshots of Rivera notifying Eli immediately after the exam."
+      }
+    ],
+    "juryBox": {
+      "votesForProsecution": 7,
+      "votesForDefense": 5,
+      "stance": "Jury Box leans toward a policy breach but recognizes mitigating academic pressure."
+    },
+    "comments": [
+      {
+        "user": "ProsecutorBot-03",
+        "text": "Consent is the cornerstone of shared housing; Rivera bypassed it entirely.",
+        "sentiment": -0.6
+      },
+      {
+        "user": "DefenseCounsel-AI",
+        "text": "Emergency necessity doctrine applies. Rivera prevented exam failure and caused no damage.",
+        "sentiment": 0.45
+      },
+      {
+        "user": "Jury Box Monitor",
+        "text": "Box tally: 7 votes to reprimand, 5 to forgive. Crowd sees a breach with compassion.",
+        "sentiment": -0.2
+      },
+      {
+        "user": "CampusMediator",
+        "text": "Why didn't Rivera text first? Even a 30-second heads-up would help.",
+        "sentiment": -0.3
+      },
+      {
+        "user": "LabPartner42",
+        "text": "If Eli was unreachable, the exam crisis justifies the quick borrow.",
+        "sentiment": 0.5
+      }
+    ],
+    "ai_summary": "",
     "status": "pending",
     "prosecution": "",
     "defense": "",

--- a/jury/index.html
+++ b/jury/index.html
@@ -77,17 +77,39 @@
 
   <template id="case-template">
     <article class="rounded-2xl border border-slate-800 bg-slate-900/60 p-5 space-y-4">
-      <header class="space-y-1">
-        <div class="flex items-center justify-between gap-4">
-          <h3 class="text-lg font-semibold"></h3>
+      <header class="space-y-3">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div class="space-y-1">
+            <h3 class="text-lg font-semibold"></h3>
+            <p class="text-xs text-indigo-200 filed-by"></p>
+          </div>
           <span class="badge"><span class="emoji">🗳️</span><span class="votes"></span></span>
         </div>
         <p class="text-sm text-slate-300 story"></p>
+        <div class="case-roster">
+          <div class="roster-card prosecutor">
+            <p class="label">Prosecutor</p>
+            <p class="name"></p>
+            <p class="summary"></p>
+          </div>
+          <div class="roster-card defendant">
+            <p class="label">Defendant</p>
+            <p class="name"></p>
+            <p class="summary"></p>
+          </div>
+          <div class="roster-card defense">
+            <p class="label">Defense Counsel</p>
+            <p class="name"></p>
+            <p class="summary"></p>
+          </div>
+        </div>
+        <p class="lead-charge text-xs text-slate-400"></p>
       </header>
       <div class="space-y-2 text-sm text-slate-400">
         <div class="progress-bar"><div class="sentiment" style="width:50%"></div></div>
         <p><strong class="text-slate-200">Public Mood:</strong> <span class="summary"></span></p>
-        <p class="status text-xs uppercase tracking-wide text-slate-500"></p>
+        <p class="box-note text-xs text-amber-200"></p>
+        <p class="status text-xs uppercase tracking-wide text-slate-400"></p>
       </div>
       <footer class="flex items-center justify-between text-sm">
         <div class="flex gap-2">
@@ -113,14 +135,180 @@
 
       let cases = [];
 
+      const botSeedCases = [
+        {
+          id: 'state_vs_ellis',
+          title: 'City v. Dana Ellis — Jury Box Noise Complaint',
+          story:
+            "Dana Ellis hosted a livestreamed band practice in a shared courtyard past quiet hours. ProsecutorBot-01 alleges Ellis ignored three noise warnings and disrupted finals prep for nearby students. DefenseCounsel-AI responds that Ellis had prior written permission for the rehearsal and reduced volume when asked.",
+          votes: 118,
+          filedBy: 'ProsecutorBot-01',
+          defendant: {
+            name: 'Dana Ellis',
+            title: 'Music Major (Defendant)',
+            summary: 'Admits to the rehearsal but claims permission and compliance with volume caps.'
+          },
+          prosecutor: {
+            name: 'Rowan Pike',
+            title: 'City Prosecutor',
+            summary: 'Argues Ellis ignored binding quiet-hour notices that evening.'
+          },
+          defenseCounsel: {
+            name: 'DefenseCounsel-AI',
+            title: 'Defense Advocate',
+            summary: 'Highlights written consent from facilities and immediate response to the first warning.'
+          },
+          charges: [
+            'Count 1: Repeated violation of community quiet hours',
+            'Count 2: Disruption of academic environment'
+          ],
+          timeline: [
+            { time: '19:05', event: 'Band setup begins after security unlocks the courtyard.' },
+            { time: '19:42', event: 'First volume warning from residents in Building C.' },
+            { time: '20:10', event: 'Security issues a written notice.' },
+            { time: '20:25', event: 'Music stops; Ellis distributes apology flyers the next morning.' }
+          ],
+          evidence: [
+            { label: 'Security Notice', detail: 'Scanned copy of the quiet-hour warning signed by Ellis.' },
+            { label: 'Facilities Email', detail: 'Email approving courtyard use between 18:30 and 20:30.' }
+          ],
+          juryBox: {
+            votesForProsecution: 9,
+            votesForDefense: 3,
+            stance: 'Jury Box leans toward a formal warning with community service hours.'
+          },
+          comments: [
+            {
+              user: 'ProsecutorBot-01',
+              text: 'Three separate residents logged complaints; intent to disturb is evident.',
+              sentiment: -0.55
+            },
+            {
+              user: 'DefenseCounsel-AI',
+              text: 'Permission existed and Ellis cut the set short by 40 minutes after the first warning.',
+              sentiment: 0.35
+            },
+            {
+              user: 'Jury Box Monitor',
+              text: 'Box tally: 9 favor a probationary penalty, 3 recommend dismissal with caution.',
+              sentiment: -0.25
+            },
+            {
+              user: 'FinalsWarrior',
+              text: 'As someone living in Building C, I had an exam at 8am. The noise was brutal.',
+              sentiment: -0.5
+            },
+            {
+              user: 'SoundTech77',
+              text: 'Facilities email clearly set an end time. The band stopped before then.',
+              sentiment: 0.4
+            }
+          ],
+          status: 'pending'
+        },
+        {
+          id: 'state_vs_cho',
+          title: 'Community v. Riley Cho — Lost & Found Cash Handling',
+          story:
+            'Riley Cho found an envelope with $420 in the campus café. ProsecutorBot-05 claims Cho kept the cash for 24 hours before logging it, violating property policy. DefenseCounsel-AI states Cho attempted to locate the owner immediately via group chats and returned the envelope once police posted the loss.',
+          votes: 94,
+          filedBy: 'ProsecutorBot-05',
+          defendant: {
+            name: 'Riley Cho',
+            title: 'Resident Advisor (Defendant)',
+            summary: 'Returned the cash but admits holding it overnight while trying to locate the owner.'
+          },
+          prosecutor: {
+            name: 'Amelia Grant',
+            title: 'Community Prosecutor',
+            summary: 'Says campus policy requires immediate handoff to security within one hour.'
+          },
+          defenseCounsel: {
+            name: 'DefenseCounsel-AI',
+            title: 'Defense Advocate',
+            summary: 'Argues Cho acted in good faith and actively searched for the owner before surrendering funds.'
+          },
+          charges: ['Count 1: Delay in reporting recovered property'],
+          timeline: [
+            { time: '15:20', event: 'Cho finds envelope near the café condiment station.' },
+            { time: '16:00', event: 'Cho posts in residence chat asking for the owner.' },
+            { time: '21:40', event: 'Campus police issue a lost cash notice.' },
+            { time: '08:05', event: 'Cho returns envelope with full amount to security office.' }
+          ],
+          evidence: [
+            { label: 'Residence Chat Logs', detail: 'Screenshots of Cho searching for the owner across student channels.' },
+            { label: 'Security Policy', detail: 'Policy excerpt requiring one-hour surrender of found valuables.' }
+          ],
+          juryBox: {
+            votesForProsecution: 4,
+            votesForDefense: 8,
+            stance: 'Jury Box majority views the hold as a technical breach but applauds the return.'
+          },
+          comments: [
+            {
+              user: 'ProsecutorBot-05',
+              text: 'Policies exist so intent is never questioned; holding cash overnight breaks that safeguard.',
+              sentiment: -0.45
+            },
+            {
+              user: 'DefenseCounsel-AI',
+              text: 'Cho documented every outreach attempt. That is transparency, not concealment.',
+              sentiment: 0.55
+            },
+            {
+              user: 'Jury Box Monitor',
+              text: 'Box tally: 4 say issue a warning, 8 say commend the return and note the delay.',
+              sentiment: 0.2
+            },
+            {
+              user: 'CoffeeBarista',
+              text: 'I watched Cho ask at least three people before leaving with the envelope.',
+              sentiment: 0.35
+            },
+            {
+              user: 'PolicyStickler',
+              text: 'Rules are rules. The envelope should have gone straight to security.',
+              sentiment: -0.55
+            }
+          ],
+          status: 'pending'
+        }
+      ];
+
       async function initialise() {
         try {
           cases = await store.loadCases();
+          seedBotCasesIfNeeded();
+          finaliseBotCases();
           renderCases();
         } catch (error) {
           console.error('Failed to load cases', error);
           feed.innerHTML = '<p class="text-sm text-rose-300">Unable to load the docket right now. Try again shortly.</p>';
         }
+      }
+
+      function seedBotCasesIfNeeded() {
+        const existingIds = new Set(cases.map((item) => item.id));
+        const additions = [];
+        botSeedCases.forEach((entry) => {
+          if (!existingIds.has(entry.id)) {
+            additions.push(ai.processCaseForVerdict(entry));
+          }
+        });
+        if (additions.length) {
+          cases = [...additions, ...cases];
+          cases = store.saveCases(cases);
+        }
+      }
+
+      function finaliseBotCases() {
+        const updated = cases.map((item) => {
+          if (item.status === 'pending' && !(item.id || '').toString().startsWith('local_')) {
+            return ai.processCaseForVerdict(item);
+          }
+          return item;
+        });
+        cases = store.saveCases(updated);
       }
 
       function renderCases() {
@@ -135,6 +323,29 @@
           node.querySelector('h3').textContent = item.title;
           node.querySelector('.story').textContent = item.story;
           node.querySelector('.votes').textContent = item.votes;
+          node.querySelector('.filed-by').textContent = `Filed by ${item.filedBy}`;
+
+          const parties = item.parties || {};
+          const prosecutorCard = node.querySelector('.roster-card.prosecutor');
+          if (prosecutorCard) {
+            prosecutorCard.querySelector('.name').textContent = parties.prosecutor?.name || 'Prosecutor';
+            prosecutorCard.querySelector('.summary').textContent = parties.prosecutor?.summary || parties.prosecutor?.title || '';
+          }
+          const defendantCard = node.querySelector('.roster-card.defendant');
+          if (defendantCard) {
+            defendantCard.querySelector('.name').textContent = parties.defendant?.name || 'Defendant';
+            defendantCard.querySelector('.summary').textContent = parties.defendant?.summary || parties.defendant?.title || '';
+          }
+          const defenseCard = node.querySelector('.roster-card.defense');
+          if (defenseCard) {
+            defenseCard.querySelector('.name').textContent = parties.defense?.name || 'Defense Counsel';
+            defenseCard.querySelector('.summary').textContent = parties.defense?.summary || parties.defense?.title || '';
+          }
+
+          const chargeLine = Array.isArray(item.charges) && item.charges.length
+            ? `Lead charge: ${item.charges[0]}`
+            : 'No formal charges filed yet.';
+          node.querySelector('.lead-charge').textContent = chargeLine;
 
           const summaryText = item.ai_summary
             ? item.ai_summary.split('\n')[0].replace(/^•\s*/, '')
@@ -155,6 +366,13 @@
           const sentimentInfo = ai.summariseComments(item.comments || []);
           const sentimentWidth = Math.max(0, Math.min(100, Math.round((sentimentInfo.average + 1) * 50)));
           node.querySelector('.sentiment').style.width = sentimentWidth + '%';
+
+          const juryBox = item.juryBox || { votesForProsecution: 0, votesForDefense: 0 };
+          const boxNote = node.querySelector('.box-note');
+          const boxSummary = juryBox.stance
+            ? `${juryBox.stance}`
+            : `Jury Box tally — Prosecution ${juryBox.votesForProsecution} vs Defense ${juryBox.votesForDefense}.`;
+          boxNote.textContent = boxSummary;
 
           const link = node.querySelector('a');
           link.href = `case.html?id=${encodeURIComponent(item.id)}`;
@@ -233,6 +451,7 @@
           prosecution: '',
           defense: '',
           verdict: null,
+          filedBy: 'Community Submitter',
           publicSentiment: emptySummary.average
         };
         cases = [newCase, ...cases];

--- a/jury/style.css
+++ b/jury/style.css
@@ -116,3 +116,127 @@ input, textarea {
   width: 0;
   transition: width 0.4s ease;
 }
+
+.case-roster {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.roster-card {
+  background: rgba(148, 163, 184, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 0.85rem;
+  padding: 0.75rem;
+}
+
+.roster-card .label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #cbd5f5;
+}
+
+.roster-card .name {
+  font-weight: 600;
+  color: #e2e8f0;
+  margin-top: 0.25rem;
+}
+
+.roster-card .summary {
+  font-size: 0.8rem;
+  color: #cbd5f5;
+  margin-top: 0.35rem;
+}
+
+.case-matrix {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.case-panel {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(129, 140, 248, 0.15);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.panel-title {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #a5b4fc;
+}
+
+.case-list {
+  list-style: disc;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.85rem;
+  color: #e2e8f0;
+}
+
+.timeline-list {
+  list-style: none;
+  display: grid;
+  gap: 0.6rem;
+  padding: 0;
+  margin: 0;
+}
+
+.timeline-entry {
+  display: grid;
+  gap: 0.4rem;
+  grid-template-columns: minmax(64px, auto) 1fr;
+  font-size: 0.85rem;
+  color: #cbd5f5;
+}
+
+.timeline-time {
+  font-weight: 600;
+  color: #fbbf24;
+}
+
+.timeline-event {
+  color: #e2e8f0;
+}
+
+.verdict-headline {
+  font-size: 1.35rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  color: #c7d2fe;
+}
+
+.role-badge {
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  padding: 0.15rem 0.5rem;
+  border-radius: 9999px;
+  font-weight: 600;
+}
+
+.role-prosecution {
+  background: rgba(239, 68, 68, 0.25);
+  color: #fecaca;
+}
+
+.role-defense {
+  background: rgba(16, 185, 129, 0.25);
+  color: #bbf7d0;
+}
+
+.role-jury {
+  background: rgba(249, 115, 22, 0.25);
+  color: #fed7aa;
+}
+
+.role-judge {
+  background: rgba(99, 102, 241, 0.25);
+  color: #ede9fe;
+}


### PR DESCRIPTION
## Summary
- seed the docket with prosecutor and defense AI bot cases and auto-finalise their verdicts
- expand case data to track parties, charges, timeline, evidence, and jury box tallies for each matter
- refresh the feed and case detail layouts to spotlight prosecutor vs. defense roles and make verdicts unmistakable

## Testing
- Manual: Loaded /jury/index.html and /jury/case.html?id=state_vs_rivera in a local browser

------
https://chatgpt.com/codex/tasks/task_e_68e53420e2fc8322b21ff5b6bf379b79