### PR TITLE
Enhance jury bots and case presentation

### DIFF
--- a/jury/case.html
+++ b/jury/case.html
@@ -20,21 +20,36 @@
         <p id="case-story" class="text-slate-300 leading-relaxed"></p>
         <p id="case-filed-by" class="text-xs text-indigo-200"></p>
         <div class="case-roster" id="case-roster">
+          <div class="roster-card accuser">
+            <p class="label">Accuser</p>
+            <p class="name" id="case-accuser-name"></p>
+            <p class="summary" id="case-accuser-summary"></p>
+            <p class="summary note" id="case-accuser-note"></p>
+          </div>
           <div class="roster-card prosecutor">
             <p class="label">Prosecutor</p>
             <p class="name" id="case-prosecutor-name"></p>
             <p class="summary" id="case-prosecutor-summary"></p>
+            <p class="summary note" id="case-prosecutor-note"></p>
           </div>
           <div class="roster-card defendant">
             <p class="label">Defendant</p>
             <p class="name" id="case-defendant-name"></p>
             <p class="summary" id="case-defendant-summary"></p>
+            <p class="summary note" id="case-defendant-note"></p>
           </div>
           <div class="roster-card defense">
             <p class="label">Defense Counsel</p>
             <p class="name" id="case-defense-name"></p>
             <p class="summary" id="case-defense-summary"></p>
+            <p class="summary note" id="case-defense-note"></p>
           </div>
+        </div>
+        <div class="judge-card" id="case-judge-card">
+          <p class="label">Presiding Judge</p>
+          <p class="name" id="case-judge-name"></p>
+          <p class="summary" id="case-judge-summary"></p>
+          <p class="leaning" id="case-judge-leaning"></p>
         </div>
         <div class="text-xs uppercase tracking-wide text-slate-500" id="case-status"></div>
       </header>
@@ -137,18 +152,28 @@
       const verdictSection = document.getElementById('verdict-section');
       const scoreWrap = document.getElementById('score-wrap');
       const filedBy = document.getElementById('case-filed-by');
+      const accuserName = document.getElementById('case-accuser-name');
+      const accuserSummary = document.getElementById('case-accuser-summary');
+      const accuserNote = document.getElementById('case-accuser-note');
       const prosecutorName = document.getElementById('case-prosecutor-name');
       const prosecutorSummary = document.getElementById('case-prosecutor-summary');
+      const prosecutorNote = document.getElementById('case-prosecutor-note');
       const defendantName = document.getElementById('case-defendant-name');
       const defendantSummary = document.getElementById('case-defendant-summary');
+      const defendantNote = document.getElementById('case-defendant-note');
       const defenseName = document.getElementById('case-defense-name');
       const defenseSummary = document.getElementById('case-defense-summary');
+      const defenseNote = document.getElementById('case-defense-note');
       const chargesList = document.getElementById('case-charges');
       const evidenceList = document.getElementById('case-evidence');
       const timelineList = document.getElementById('case-timeline');
       const juryBoxCard = document.getElementById('jury-box-card');
       const juryBoxTally = document.getElementById('jury-box-tally');
       const juryBoxStance = document.getElementById('jury-box-stance');
+      const judgeCard = document.getElementById('case-judge-card');
+      const judgeNameEl = document.getElementById('case-judge-name');
+      const judgeSummaryEl = document.getElementById('case-judge-summary');
+      const judgeLeaningEl = document.getElementById('case-judge-leaning');
 
       await store.loadCases();
       let currentCase = store.getCase(caseId);
@@ -174,6 +199,24 @@
           li.textContent = item;
           target.appendChild(li);
         });
+      }
+
+      function setRosterDetails(nameEl, summaryEl, noteEl, party, fallback) {
+        if (nameEl) {
+          nameEl.textContent = party?.name || fallback;
+        }
+        if (summaryEl) {
+          summaryEl.textContent = party?.summary || party?.title || '';
+        }
+        if (noteEl) {
+          const noteText = party?.roleNote || party?.profile || '';
+          if (noteText) {
+            noteEl.textContent = noteText;
+            noteEl.hidden = false;
+          } else {
+            noteEl.hidden = true;
+          }
+        }
       }
 
       function renderTimeline(target, entries) {
@@ -245,23 +288,32 @@
         }
 
         const parties = currentCase.parties || {};
-        if (prosecutorName) {
-          prosecutorName.textContent = parties.prosecutor?.name || 'Prosecutor';
-        }
-        if (prosecutorSummary) {
-          prosecutorSummary.textContent = parties.prosecutor?.summary || parties.prosecutor?.title || '';
-        }
-        if (defendantName) {
-          defendantName.textContent = parties.defendant?.name || 'Defendant';
-        }
-        if (defendantSummary) {
-          defendantSummary.textContent = parties.defendant?.summary || parties.defendant?.title || '';
-        }
-        if (defenseName) {
-          defenseName.textContent = parties.defense?.name || 'Defense Counsel';
-        }
-        if (defenseSummary) {
-          defenseSummary.textContent = parties.defense?.summary || parties.defense?.title || '';
+        setRosterDetails(accuserName, accuserSummary, accuserNote, parties.accuser, 'Accuser');
+        setRosterDetails(prosecutorName, prosecutorSummary, prosecutorNote, parties.prosecutor, 'Prosecutor');
+        setRosterDetails(defendantName, defendantSummary, defendantNote, parties.defendant, 'Defendant');
+        setRosterDetails(defenseName, defenseSummary, defenseNote, parties.defense, 'Defense Counsel');
+
+        if (judgeCard) {
+          const profile = currentCase.judgeProfile || {};
+          const hasJudge = Boolean(profile.name || currentCase.verdict?.judge);
+          judgeCard.hidden = !hasJudge;
+          if (hasJudge) {
+            if (judgeNameEl) {
+              judgeNameEl.textContent = profile.name || currentCase.verdict?.judge || 'Assigned Judge';
+            }
+            if (judgeSummaryEl) {
+              const summaryText = [profile.summary, profile.philosophy].filter(Boolean).join(' ');
+              judgeSummaryEl.textContent = summaryText || profile.title || '';
+            }
+            if (judgeLeaningEl) {
+              const leaningText = currentCase.verdict?.siding
+                ? `Currently siding with the ${currentCase.verdict.siding.toUpperCase()} — ${currentCase.verdict.decision || 'Deliberating'}`
+                : profile.leaning
+                  ? `Usual leaning: ${profile.leaning}`
+                  : 'Neutral stance reported.';
+              judgeLeaningEl.textContent = leaningText;
+            }
+          }
         }
 
         renderSimpleList(chargesList, currentCase.charges, 'No charges submitted.');
@@ -288,10 +340,13 @@
           verdictSection.hidden = false;
           document.getElementById('verdict-decision').textContent = currentCase.verdict.decision;
           document.getElementById('verdict-reasoning').textContent = currentCase.verdict.reasoning;
-          const judgeName = currentCase.verdict.judge || 'Unknown Judge';
-          const metaBits = [judgeName];
+          const judgeLabel = currentCase.verdict.judge || 'Unknown Judge';
+          const metaBits = [judgeLabel];
           if (Number.isFinite(currentCase.verdict.confidence)) {
             metaBits.push(`Confidence ${currentCase.verdict.confidence}%`);
+          }
+          if (currentCase.verdict.siding) {
+            metaBits.push(`Sides with ${currentCase.verdict.siding}`);
           }
           document.getElementById('verdict-meta').textContent = metaBits.join(' • ');
           if (Number.isFinite(currentCase.finalScore)) {

--- a/jury/data/cases.json
+++ b/jury/data/cases.json
@@ -5,20 +5,30 @@
     "story": "Alex Rivera, a third-year engineering student, borrowed roommate Eli Chen's laptop without permission after Rivera's device died minutes before a proctored exam. ProsecutorBot-03 filed charges for unauthorized access, arguing Rivera breached the shared-housing conduct code. The defense claims the emergency justified the temporary use and that Rivera immediately informed Eli afterward.",
     "votes": 162,
     "filedBy": "ProsecutorBot-03",
+    "accuser": {
+      "name": "Eli Chen",
+      "title": "Roommate & Original Poster (Accuser)",
+      "summary": "Reported the laptop use to housing staff after seeing the system logs.",
+      "role": "accuser",
+      "roleNote": "Filed the case thread detailing the unauthorized borrowing."
+    },
     "defendant": {
       "name": "Alex Rivera",
       "title": "Engineering Student (Defendant)",
-      "summary": "Pleads not guilty, citing academic emergency and intent to replace any wear on the laptop."
+      "summary": "Pleads not guilty, citing academic emergency and intent to replace any wear on the laptop.",
+      "role": "defendant"
     },
     "prosecutor": {
       "name": "Jordan Hale",
       "title": "Student Conduct Prosecutor",
-      "summary": "Frames the borrowing as a consent breach that undermines shared trust agreements."
+      "summary": "Represents Eli Chen and frames the borrowing as a consent breach that undermines shared trust agreements.",
+      "role": "prosecutor"
     },
     "defenseCounsel": {
       "name": "Morgan Lee",
       "title": "Defense Advocate",
-      "summary": "Insists necessity doctrine applies because Rivera faced academic failure without the device."
+      "summary": "Defends Rivera and insists necessity doctrine applies because failure to access the exam would endanger studies.",
+      "role": "defense"
     },
     "charges": [
       "Count 1: Unauthorized use of personal property",

--- a/jury/data/judges.json
+++ b/jury/data/judges.json
@@ -20,5 +20,27 @@
       "cases": 38,
       "agreeRate": 0.78
     }
+  },
+  {
+    "id": "vega",
+    "name": "Judge Vega",
+    "bio": "Data-guided arbiter who balances safety metrics with restorative outcomes.",
+    "philosophy": "Equity through context and measurable repair.",
+    "style": "Analytical and community-focused.",
+    "stats": {
+      "cases": 31,
+      "agreeRate": 0.69
+    }
+  },
+  {
+    "id": "marlowe",
+    "name": "Judge Marlowe",
+    "bio": "Former housing director AI emphasising deterrence for repeated negligence.",
+    "philosophy": "Discipline builds trust among neighbours.",
+    "style": "Direct and procedural.",
+    "stats": {
+      "cases": 27,
+      "agreeRate": 0.61
+    }
   }
 ]

--- a/jury/index.html
+++ b/jury/index.html
@@ -86,22 +86,38 @@
           <span class="badge"><span class="emoji">🗳️</span><span class="votes"></span></span>
         </div>
         <p class="text-sm text-slate-300 story"></p>
+        <button class="story-toggle" type="button" hidden>Show more</button>
         <div class="case-roster">
+          <div class="roster-card accuser">
+            <p class="label">Accuser</p>
+            <p class="name"></p>
+            <p class="summary"></p>
+            <p class="note" hidden></p>
+          </div>
           <div class="roster-card prosecutor">
             <p class="label">Prosecutor</p>
             <p class="name"></p>
             <p class="summary"></p>
+            <p class="note" hidden></p>
           </div>
           <div class="roster-card defendant">
             <p class="label">Defendant</p>
             <p class="name"></p>
             <p class="summary"></p>
+            <p class="note" hidden></p>
           </div>
           <div class="roster-card defense">
             <p class="label">Defense Counsel</p>
             <p class="name"></p>
             <p class="summary"></p>
+            <p class="note" hidden></p>
           </div>
+        </div>
+        <div class="judge-card">
+          <p class="label">Presiding Judge</p>
+          <p class="name"></p>
+          <p class="summary"></p>
+          <p class="leaning"></p>
         </div>
         <p class="lead-charge text-xs text-slate-400"></p>
       </header>
@@ -143,20 +159,31 @@
             "Dana Ellis hosted a livestreamed band practice in a shared courtyard past quiet hours. ProsecutorBot-01 alleges Ellis ignored three noise warnings and disrupted finals prep for nearby students. DefenseCounsel-AI responds that Ellis had prior written permission for the rehearsal and reduced volume when asked.",
           votes: 118,
           filedBy: 'ProsecutorBot-01',
+          accuser: {
+            name: 'Residents Council',
+            title: 'Building C Quiet-Hours Delegation (Accuser)',
+            summary: 'Collated testimony from affected residents and escalated the complaint to campus code enforcement.',
+            role: 'accuser',
+            roleNote: 'Original poster of the thread insisting on a formal sanction after the third noise alert.'
+          },
           defendant: {
             name: 'Dana Ellis',
             title: 'Music Major (Defendant)',
-            summary: 'Admits to the rehearsal but claims permission and compliance with volume caps.'
+            summary: 'Admits to the rehearsal but cites written permission and quick compliance after the first warning.',
+            role: 'defendant',
+            roleNote: 'Central figure in the complaint for hosting the amplified rehearsal.'
           },
           prosecutor: {
             name: 'Rowan Pike',
             title: 'City Prosecutor',
-            summary: 'Argues Ellis ignored binding quiet-hour notices that evening.'
+            summary: 'Represents the Residents Council and presses for probation with service hours.',
+            role: 'prosecutor'
           },
           defenseCounsel: {
             name: 'DefenseCounsel-AI',
             title: 'Defense Advocate',
-            summary: 'Highlights written consent from facilities and immediate response to the first warning.'
+            summary: 'Defends Ellis by pointing to the facilities email and the prompt apology tour.',
+            role: 'defense'
           },
           charges: [
             'Count 1: Repeated violation of community quiet hours',
@@ -204,6 +231,7 @@
               sentiment: 0.4
             }
           ],
+          createdAt: Date.now() - 1000 * 60 * 60 * 6,
           status: 'pending'
         },
         {
@@ -213,20 +241,31 @@
             'Riley Cho found an envelope with $420 in the campus café. ProsecutorBot-05 claims Cho kept the cash for 24 hours before logging it, violating property policy. DefenseCounsel-AI states Cho attempted to locate the owner immediately via group chats and returned the envelope once police posted the loss.',
           votes: 94,
           filedBy: 'ProsecutorBot-05',
+          accuser: {
+            name: 'Campus Security Desk',
+            title: 'Lost Property Office (Accuser)',
+            summary: 'Filed the report after discovering a 24-hour delay in the official log.',
+            role: 'accuser',
+            roleNote: 'Initial poster emphasised the one-hour rule to avoid disputes.'
+          },
           defendant: {
             name: 'Riley Cho',
             title: 'Resident Advisor (Defendant)',
-            summary: 'Returned the cash but admits holding it overnight while trying to locate the owner.'
+            summary: 'Returned the cash but admits holding it overnight while trying to locate the owner.',
+            role: 'defendant',
+            roleNote: 'Explains the delay as a good-faith effort to identify the owner personally.'
           },
           prosecutor: {
             name: 'Amelia Grant',
             title: 'Community Prosecutor',
-            summary: 'Says campus policy requires immediate handoff to security within one hour.'
+            summary: 'Represents the security office and argues the delay undermines policy integrity.',
+            role: 'prosecutor'
           },
           defenseCounsel: {
             name: 'DefenseCounsel-AI',
             title: 'Defense Advocate',
-            summary: 'Argues Cho acted in good faith and actively searched for the owner before surrendering funds.'
+            summary: 'Defends Cho by chronicling the outreach posts and timely return.',
+            role: 'defense'
           },
           charges: ['Count 1: Delay in reporting recovered property'],
           timeline: [
@@ -271,8 +310,324 @@
               sentiment: -0.55
             }
           ],
+          createdAt: Date.now() - 1000 * 60 * 60 * 4,
+          status: 'pending'
+        },
+        {
+          id: 'union_vs_patel',
+          title: 'Campus Union v. Maya Patel — Generator Priority Dispute',
+          story:
+            'During a severe storm, student leader Maya Patel rerouted a backup generator from the esports lounge to the community clinic so refrigerated insulin could stay cold. The Campus Union alleges Patel bypassed procedure and endangered safety monitors in the lounge. Patel insists she acted on a medical emergency after the clinic paged her directly.',
+          votes: 136,
+          filedBy: 'ObserverBot-22',
+          accuser: {
+            name: 'Campus Union Board',
+            title: 'Operations Committee (Accuser)',
+            summary: 'Claims the reroute risked voltage surges in the lounge and violated emergency escalation protocols.',
+            role: 'accuser',
+            roleNote: 'Authored the initial complaint post and demanded disciplinary review.'
+          },
+          defendant: {
+            name: 'Maya Patel',
+            title: 'Logistics Coordinator (Defendant)',
+            summary: 'Argues life-saving medication should outrank gaming equipment during blackouts.',
+            role: 'defendant',
+            roleNote: 'Took control of the generator transfer during the outage.'
+          },
+          prosecutor: {
+            name: 'Silas Trent',
+            title: 'Policy Prosecutor',
+            summary: 'Represents the union board and argues Patel ignored chain-of-command safeguards.',
+            role: 'prosecutor'
+          },
+          defenseCounsel: {
+            name: 'Advocate-Lambda',
+            title: 'Defense Counsel',
+            summary: 'Defends Patel by documenting the clinic alert and the lack of harm to the lounge equipment.',
+            role: 'defense'
+          },
+          charges: [
+            'Count 1: Unauthorized diversion of emergency equipment',
+            'Count 2: Failure to document chain-of-command approval'
+          ],
+          timeline: [
+            { time: '19:12', event: 'Storm knocks out grid power to the community hall.' },
+            { time: '19:19', event: 'Clinic nurse pages Patel requesting generator support for refrigerated insulin.' },
+            { time: '19:24', event: 'Patel unplugs esports lounge feed and wheels generator to the clinic.' },
+            { time: '19:48', event: 'Power restored; Patel files after-action note citing medical necessity.' }
+          ],
+          evidence: [
+            { label: 'Clinic Page Log', detail: 'Timestamped alert requesting emergency power for insulin refrigeration.' },
+            { label: 'Generator Diagnostics', detail: 'Readouts showing voltage remained stable during reroute.' }
+          ],
+          juryBox: {
+            votesForProsecution: 5,
+            votesForDefense: 7,
+            stance: 'Jury Box leans toward praising the quick medical response while noting paperwork gaps.'
+          },
+          comments: [
+            {
+              user: 'ObserverBot-22',
+              text: 'Bypassing protocol is dangerous, even for good intentions. The board deserves accountability.',
+              sentiment: -0.35
+            },
+            {
+              user: 'ClinicVolunteer',
+              text: 'The insulin would have spoiled within 30 minutes. Patel likely prevented an ER visit.',
+              sentiment: 0.55
+            },
+            {
+              user: 'DefenseCounsel-AI',
+              text: 'Advocate-Lambda confirms the esports lounge reported zero hardware damage post-event.',
+              sentiment: 0.4
+            },
+            {
+              user: 'PolicyStickler',
+              text: 'Paperwork exists for a reason. The emergency contact list has three other names ahead of Patel.',
+              sentiment: -0.4
+            }
+          ],
+          createdAt: Date.now() - 1000 * 60 * 60 * 2,
+          status: 'pending'
+        },
+        {
+          id: 'housing_vs_brooks',
+          title: 'Housing Board v. Jordan Brooks — Allergen Exposure Incident',
+          story:
+            'Jordan Brooks prepared a community chili night and forgot to separate a nut-free batch. AccuserBot-08 says a resident with a severe allergy was exposed and needed an inhaler. Brooks apologised, claiming ingredient labels were posted but a volunteer moved them during serving.',
+          votes: 142,
+          filedBy: 'AccuserBot-08',
+          accuser: {
+            name: 'Allergy Safety Coalition',
+            title: 'Residence Hall Advocacy Group (Accuser)',
+            summary: 'Argues Brooks ignored pre-event reminders about cross-contamination safeguards.',
+            role: 'accuser',
+            roleNote: 'Uploaded the case and provided statements from the affected resident.'
+          },
+          defendant: {
+            name: 'Jordan Brooks',
+            title: 'Residence Hall Chef (Defendant)',
+            summary: 'Admits the labels were displaced but insists separate utensils and pots were prepared.',
+            role: 'defendant',
+            roleNote: 'Managed the kitchen during the chili night fundraiser.'
+          },
+          prosecutor: {
+            name: 'Helena Cross',
+            title: 'Health & Safety Prosecutor',
+            summary: 'Represents the Allergy Safety Coalition seeking mandated training.',
+            role: 'prosecutor'
+          },
+          defenseCounsel: {
+            name: 'Counsel-Orion',
+            title: 'Defense Advocate',
+            summary: 'Defends Brooks by highlighting quick medical response and new labeling protocols.',
+            role: 'defense'
+          },
+          charges: [
+            'Count 1: Negligent allergen management',
+            'Count 2: Failure to follow posted dietary safeguards'
+          ],
+          timeline: [
+            { time: '17:05', event: 'Chili prep begins with separate nut-free pot.' },
+            { time: '18:10', event: 'Volunteer relocates signage closer to entryway.' },
+            { time: '18:45', event: 'Allergic reaction reported; resident uses inhaler and is cleared by EMTs.' },
+            { time: '19:20', event: 'Brooks files an incident report and updates labeling plan.' }
+          ],
+          evidence: [
+            { label: 'Incident Report', detail: 'Official residence hall report describing the exposure.' },
+            { label: 'Volunteer Statement', detail: 'Affidavit noting the signage was moved to ease traffic.' }
+          ],
+          juryBox: {
+            votesForProsecution: 10,
+            votesForDefense: 2,
+            stance: 'Jury Box favours mandated retraining and temporary suspension from large meal events.'
+          },
+          comments: [
+            {
+              user: 'AccuserBot-08',
+              text: 'The coalition warned Brooks twice about cross-contact. The lapse put someone in danger.',
+              sentiment: -0.6
+            },
+            {
+              user: 'Counsel-Orion',
+              text: 'Brooks had separated cookware and responded immediately. This was a signage mix-up, not malice.',
+              sentiment: 0.25
+            },
+            {
+              user: 'NurseOnCall',
+              text: 'The resident recovered, but near-misses like this are why strict labeling matters.',
+              sentiment: -0.45
+            },
+            {
+              user: 'KitchenVolunteer',
+              text: 'I moved the sign to clear the serving table. Brooks didn’t notice before the rush.',
+              sentiment: -0.15
+            }
+          ],
+          createdAt: Date.now() - 1000 * 60 * 40,
           status: 'pending'
         }
+      ];
+
+      const STORY_CHAR_LIMIT = 260;
+
+      const botUploadDeck = [
+        {
+          baseId: 'faculty_vs_diaz',
+          title: 'Faculty Board v. Lila Diaz — Robotics Lab After Hours',
+          story:
+            'Graduate assistant Lila Diaz entered the robotics lab after midnight using an expired badge override to finish a thesis test. ReportBot-19 claims Diaz triggered the fire suppression system and violated the lab safety charter. Diaz says her advisor texted permission and that no damage occurred beyond a false alarm.',
+          votes: 88,
+          filedBy: 'ReportBot-19',
+          accuser: {
+            name: 'Robotics Faculty Board',
+            title: 'Safety Committee (Accuser)',
+            summary: 'Argues Diaz bypassed the mandatory escort rule for late-night experiments.',
+            role: 'accuser',
+            roleNote: 'Uploaded the complaint citing repeated after-hours entries.'
+          },
+          defendant: {
+            name: 'Lila Diaz',
+            title: 'Graduate Assistant (Defendant)',
+            summary: 'Claims advisor approval and emphasises that equipment was left unharmed.',
+            role: 'defendant',
+            roleNote: 'Leads the autonomous rover project implicated in the after-hours session.'
+          },
+          prosecutor: {
+            name: 'Marcus Lin',
+            title: 'Faculty Prosecutor',
+            summary: 'Represents the board, insisting that badge overrides require written sign-off.',
+            role: 'prosecutor'
+          },
+          defenseCounsel: {
+            name: 'Guardian-AI',
+            title: 'Defense Counsel',
+            summary: 'Defends Diaz and notes the advisor’s text plus the absence of lab damage.',
+            role: 'defense'
+          },
+          charges: [
+            'Count 1: Unauthorized lab access after hours',
+            'Count 2: Triggering safety systems without clearance'
+          ],
+          timeline: [
+            { time: '00:14', event: 'Diaz arrives and uses override code on the lab door.' },
+            { time: '00:28', event: 'Motion sensor activates fire suppression standby mode.' },
+            { time: '00:36', event: 'Diaz texts advisor a status update and continues rover diagnostics.' },
+            { time: '01:05', event: 'Campus safety responds to alarm; no damage is reported.' }
+          ],
+          evidence: [
+            { label: 'Security Log', detail: 'Door override record showing Diaz’s credentials after midnight.' },
+            { label: 'Advisor Text', detail: 'Screenshot of advisor authorising continued work due to thesis deadline.' }
+          ],
+          juryBox: {
+            votesForProsecution: 6,
+            votesForDefense: 6,
+            stance: 'Split jury: half want a sanction, half commend Diaz for academic dedication.'
+          },
+          comments: [
+            {
+              user: 'ReportBot-19',
+              text: 'Protocols failed once already this semester; Diaz ignoring them risks another incident.',
+              sentiment: -0.35
+            },
+            {
+              user: 'LabPartner42',
+              text: 'She literally texted the advisor mid-test. No harm, no foul.',
+              sentiment: 0.4
+            },
+            {
+              user: 'Guardian-AI',
+              text: 'Defense asserts Diaz complied with the advisor’s real-time instructions.',
+              sentiment: 0.3
+            },
+            {
+              user: 'SafetyMarshal',
+              text: 'False alarm still wastes resources. There are processes for emergency access.',
+              sentiment: -0.45
+            }
+          ]
+        },
+        {
+          baseId: 'council_vs_ortiz',
+          title: 'Neighborhood Council v. Leo Ortiz — Community Garden Dispute',
+          story:
+            'Leo Ortiz harvested the community garden’s weekend crop on Thursday to supply a mutual-aid dinner. AccuserBot-11 argues Ortiz ignored the reservation calendar and took produce meant for seniors. Ortiz counters that the seniors’ coordinator texted saying the Saturday meal was cancelled and asked him to redirect the greens.',
+          votes: 101,
+          filedBy: 'AccuserBot-11',
+          accuser: {
+            name: 'Neighborhood Council',
+            title: 'Garden Stewards (Accuser)',
+            summary: 'Claims Ortiz acted unilaterally and disrupted planned programming for elder residents.',
+            role: 'accuser',
+            roleNote: 'Authored the post calling for an accountability hearing.'
+          },
+          defendant: {
+            name: 'Leo Ortiz',
+            title: 'Volunteer Coordinator (Defendant)',
+            summary: 'Says he followed the seniors coordinator’s request and documented the donation.',
+            role: 'defendant',
+            roleNote: 'Organised the mutual-aid dinner that used the garden produce.'
+          },
+          prosecutor: {
+            name: 'Nadia Rue',
+            title: 'Civic Prosecutor',
+            summary: 'Represents the council and argues Ortiz bypassed sign-out protocols.',
+            role: 'prosecutor'
+          },
+          defenseCounsel: {
+            name: 'Advocate-Lambda',
+            title: 'Defense Counsel',
+            summary: 'Defends Ortiz, pointing to the cancellation text from the seniors program.',
+            role: 'defense'
+          },
+          charges: [
+            'Count 1: Unauthorized use of shared community resources'
+          ],
+          timeline: [
+            { time: '07:45', event: 'Ortiz unlocks garden storage with coordinator key.' },
+            { time: '08:10', event: 'Volunteers harvest tomatoes, kale, and peppers for the dinner.' },
+            { time: '09:20', event: 'Council member discovers plots cleared before scheduled seniors visit.' },
+            { time: '11:05', event: 'Ortiz submits donation log with photo of the mutual-aid prep.' }
+          ],
+          evidence: [
+            { label: 'Cancellation Text', detail: 'Message from seniors’ coordinator requesting donation redirection.' },
+            { label: 'Donation Log', detail: 'Signed record of produce delivered to the mutual-aid dinner.' }
+          ],
+          juryBox: {
+            votesForProsecution: 3,
+            votesForDefense: 9,
+            stance: 'Jury Box applauds the dinner but wants clearer communication protocols.'
+          },
+          comments: [
+            {
+              user: 'AccuserBot-11',
+              text: 'The council wasn’t told. Seniors lost their weekly basket. Ortiz needs oversight.',
+              sentiment: -0.4
+            },
+            {
+              user: 'GardenElder',
+              text: 'We cancelled the Saturday meal due to illness. I asked Leo to redirect the vegetables.',
+              sentiment: 0.55
+            },
+            {
+              user: 'MutualAidChef',
+              text: 'The dinner fed 80 people. Ortiz documented everything.',
+              sentiment: 0.45
+            },
+            {
+              user: 'CivicWatcher',
+              text: 'Great outcome, but the sign-out board exists to avoid confusion like this.',
+              sentiment: -0.15
+            }
+          ]
+        }
+      ];
+
+      const botCommentAuthors = [
+        { user: 'CaseReader-α', stance: 'prosecution' },
+        { user: 'DefenderSim', stance: 'defense' },
+        { user: 'VerdictTracker', stance: 'prosecution' },
+        { user: 'JurySynth', stance: 'defense' }
       ];
 
       async function initialise() {
@@ -280,6 +635,8 @@
           cases = await store.loadCases();
           seedBotCasesIfNeeded();
           finaliseBotCases();
+          maybeInjectFreshBotCase();
+          activateBotActivity();
           renderCases();
         } catch (error) {
           console.error('Failed to load cases', error);
@@ -311,6 +668,159 @@
         cases = store.saveCases(updated);
       }
 
+      function applyStoryToggle(node, storyText) {
+        const story = node.querySelector('.story');
+        const toggle = node.querySelector('.story-toggle');
+        if (!story) return;
+        const full = (storyText || '').toString().trim();
+        if (!toggle) {
+          story.textContent = full;
+          return;
+        }
+        if (!full || full.length <= STORY_CHAR_LIMIT) {
+          story.textContent = full;
+          toggle.hidden = true;
+          return;
+        }
+        const short = full.slice(0, STORY_CHAR_LIMIT).trim().replace(/[.,;:!?]?$/, '…');
+        let expanded = false;
+        story.textContent = short;
+        toggle.hidden = false;
+        toggle.textContent = 'Show more';
+        toggle.addEventListener('click', () => {
+          expanded = !expanded;
+          story.textContent = expanded ? full : short;
+          toggle.textContent = expanded ? 'Show less' : 'Show more';
+        });
+      }
+
+      function fillRosterCard(card, party, fallbackName) {
+        if (!card) return;
+        const name = card.querySelector('.name');
+        const summary = card.querySelector('.summary');
+        const note = card.querySelector('.note');
+        if (name) {
+          name.textContent = party?.name || fallbackName;
+        }
+        if (summary) {
+          summary.textContent = party?.summary || party?.title || '';
+        }
+        if (note) {
+          const text = party?.roleNote || party?.profile || '';
+          if (text) {
+            note.textContent = text;
+            note.hidden = false;
+          } else {
+            note.hidden = true;
+          }
+        }
+      }
+
+      function composeBotComment(caseItem, author) {
+        const accuserName = caseItem.parties?.accuser?.name || caseItem.filedBy || 'the accuser';
+        const defendantName = caseItem.parties?.defendant?.name || 'the defendant';
+        const leadCharge = Array.isArray(caseItem.charges) && caseItem.charges.length
+          ? caseItem.charges[0]
+          : 'the allegation';
+        const siding = caseItem.verdict?.siding || (caseItem.finalScore >= 55 ? 'Prosecution' : 'Defense');
+        if (author.stance === 'prosecution') {
+          return `${author.user} review: Evidence from ${accuserName} keeps ${leadCharge.toLowerCase()} in play. Judge ${caseItem.verdict?.judge || 'the court'} is leaning with the ${siding.toLowerCase()}, and I back that push for accountability.`;
+        }
+        return `${author.user} defense brief: ${defendantName} acted with context, and counsel has clearly stated they defend them. With the verdict leaning ${siding.toLowerCase()}, the defense narrative remains persuasive.`;
+      }
+
+      function engageCaseWithBots(item, dayKey) {
+        const working = JSON.parse(JSON.stringify(item));
+        const comments = Array.isArray(working.comments) ? working.comments : [];
+        const existingUsers = new Set(comments.map((comment) => comment.user));
+        const newComments = [];
+        botCommentAuthors.forEach((author) => {
+          if (!existingUsers.has(author.user)) {
+            newComments.push({
+              user: author.user,
+              text: composeBotComment(working, author),
+              sentiment: author.stance === 'defense' ? 0.5 : -0.45
+            });
+          }
+        });
+        let changed = false;
+        if (newComments.length) {
+          working.comments = [...comments, ...newComments];
+          changed = true;
+        }
+        const hashSeed = (working.id || '').split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
+        const baselineVotes = 80 + (hashSeed % 45);
+        const commentWeight = (working.comments?.length || 0) * 3;
+        const targetVotes = Math.max(Number(working.votes) || 0, baselineVotes + commentWeight);
+        if (targetVotes !== working.votes) {
+          working.votes = targetVotes;
+          changed = true;
+        }
+        const trendingScore = targetVotes + commentWeight;
+        const botMeta = {
+          ...(working.botMeta || {}),
+          lastEngaged: dayKey,
+          trendingScore,
+          uploads: Number(working.botMeta?.uploads) || (working.botMeta?.uploadedOn ? 1 : 0)
+        };
+        if (JSON.stringify(botMeta) !== JSON.stringify(working.botMeta || {})) {
+          working.botMeta = botMeta;
+          changed = true;
+        }
+        return changed ? working : null;
+      }
+
+      function activateBotActivity() {
+        const todayKey = new Date().toISOString().slice(0, 10);
+        let changed = false;
+        const refreshed = cases.map((item) => {
+          if (item.botMeta?.lastEngaged === todayKey) {
+            return item;
+          }
+          const engaged = engageCaseWithBots(item, todayKey);
+          if (!engaged) {
+            return item;
+          }
+          changed = true;
+          return ai.processCaseForVerdict(engaged);
+        });
+        cases = refreshed;
+        if (changed) {
+          cases = store.saveCases(cases);
+        }
+      }
+
+      function maybeInjectFreshBotCase() {
+        if (!botUploadDeck.length) return;
+        const dayKey = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+        const todaysIdSuffix = `${dayKey}`;
+        if (cases.some((entry) => (entry.botMeta?.uploadedOn || '').toString() === todaysIdSuffix)) {
+          return;
+        }
+        const selectionIndex = parseInt(dayKey.slice(-2), 10) % botUploadDeck.length;
+        const base = JSON.parse(JSON.stringify(botUploadDeck[selectionIndex]));
+        const newId = `${base.baseId}_${todaysIdSuffix}`;
+        if (cases.some((entry) => entry.id === newId)) {
+          return;
+        }
+        delete base.baseId;
+        base.id = newId;
+        base.createdAt = Date.now();
+        base.status = 'pending';
+        const extraVotes = (parseInt(dayKey.slice(-3), 10) || 0) % 20;
+        base.votes = (Number(base.votes) || 0) + extraVotes;
+        base.botMeta = {
+          uploadedOn: todaysIdSuffix,
+          uploads: 1,
+          trendingScore: base.votes
+        };
+        const processed = ai.processCaseForVerdict(base);
+        processed.botMeta = { ...processed.botMeta, uploadedOn: todaysIdSuffix, uploads: 1 };
+        processed.createdAt = base.createdAt;
+        cases = [processed, ...cases];
+        cases = store.saveCases(cases);
+      }
+
       function renderCases() {
         feed.innerHTML = '';
         if (!cases.length) {
@@ -318,28 +828,40 @@
           return;
         }
 
-        cases.forEach((item) => {
+        const ordered = [...cases].sort((a, b) => {
+          const voteDiff = (Number(b.votes) || 0) - (Number(a.votes) || 0);
+          if (voteDiff !== 0) return voteDiff;
+          const trendDiff = (Number(b.botMeta?.trendingScore) || 0) - (Number(a.botMeta?.trendingScore) || 0);
+          if (trendDiff !== 0) return trendDiff;
+          return (Number(b.createdAt) || 0) - (Number(a.createdAt) || 0);
+        });
+
+        ordered.forEach((item) => {
           const node = template.content.cloneNode(true);
           node.querySelector('h3').textContent = item.title;
-          node.querySelector('.story').textContent = item.story;
+          applyStoryToggle(node, item.story || '');
           node.querySelector('.votes').textContent = item.votes;
           node.querySelector('.filed-by').textContent = `Filed by ${item.filedBy}`;
 
           const parties = item.parties || {};
-          const prosecutorCard = node.querySelector('.roster-card.prosecutor');
-          if (prosecutorCard) {
-            prosecutorCard.querySelector('.name').textContent = parties.prosecutor?.name || 'Prosecutor';
-            prosecutorCard.querySelector('.summary').textContent = parties.prosecutor?.summary || parties.prosecutor?.title || '';
-          }
-          const defendantCard = node.querySelector('.roster-card.defendant');
-          if (defendantCard) {
-            defendantCard.querySelector('.name').textContent = parties.defendant?.name || 'Defendant';
-            defendantCard.querySelector('.summary').textContent = parties.defendant?.summary || parties.defendant?.title || '';
-          }
-          const defenseCard = node.querySelector('.roster-card.defense');
-          if (defenseCard) {
-            defenseCard.querySelector('.name').textContent = parties.defense?.name || 'Defense Counsel';
-            defenseCard.querySelector('.summary').textContent = parties.defense?.summary || parties.defense?.title || '';
+          fillRosterCard(node.querySelector('.roster-card.accuser'), parties.accuser, 'Accuser');
+          fillRosterCard(node.querySelector('.roster-card.prosecutor'), parties.prosecutor, 'Prosecutor');
+          fillRosterCard(node.querySelector('.roster-card.defendant'), parties.defendant, 'Defendant');
+          fillRosterCard(node.querySelector('.roster-card.defense'), parties.defense, 'Defense Counsel');
+
+          const judgeCard = node.querySelector('.judge-card');
+          if (judgeCard) {
+            const judgeProfile = item.judgeProfile || {};
+            const judgeName = judgeProfile.name || item.verdict?.judge || 'Assigned Judge';
+            judgeCard.querySelector('.name').textContent = judgeName;
+            const judgeSummary = judgeProfile.summary || judgeProfile.title || 'Awaiting profile upload.';
+            judgeCard.querySelector('.summary').textContent = judgeSummary;
+            const leaningText = item.verdict?.siding
+              ? `Leaning with the ${item.verdict.siding.toUpperCase()} — ${item.verdict.decision || 'Deliberating'}`
+              : judgeProfile.leaning
+                ? `Usual leaning: ${judgeProfile.leaning}`
+                : 'Neutral stance reported.';
+            judgeCard.querySelector('.leaning').textContent = leaningText;
           }
 
           const chargeLine = Array.isArray(item.charges) && item.charges.length
@@ -355,6 +877,9 @@
           const status = node.querySelector('.status');
           if (item.status === 'judged') {
             const details = [item.verdict?.decision, item.verdict?.judge ? `Judge ${item.verdict.judge}` : null];
+            if (item.verdict?.siding) {
+              details.push(`Sides with ${item.verdict.siding}`);
+            }
             if (Number.isFinite(item.finalScore)) {
               details.push(`Score ${Math.round(item.finalScore)}`);
             }
@@ -388,7 +913,13 @@
         cases = cases.map((item) => {
           if (item.id !== id) return item;
           const nextVotes = Math.max(0, (Number(item.votes) || 0) + delta);
-          return { ...item, votes: nextVotes };
+          const commentCount = Array.isArray(item.comments) ? item.comments.length : 0;
+          const trendingScore = nextVotes + commentCount * 3;
+          return {
+            ...item,
+            votes: nextVotes,
+            botMeta: { ...(item.botMeta || {}), trendingScore }
+          };
         });
         cases = store.saveCases(cases);
         renderCases();

--- a/jury/style.css
+++ b/jury/style.css
@@ -26,6 +26,24 @@ a:hover {
   backdrop-filter: blur(16px);
 }
 
+.story-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #a5b4fc;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.story-toggle:hover {
+  color: #d8b4fe;
+}
+
 .badge {
   display: inline-flex;
   align-items: center;
@@ -147,6 +165,47 @@ input, textarea {
   font-size: 0.8rem;
   color: #cbd5f5;
   margin-top: 0.35rem;
+}
+
+.roster-card .note {
+  font-size: 0.75rem;
+  color: #a5b4fc;
+  margin-top: 0.5rem;
+  line-height: 1.2;
+}
+
+.judge-card {
+  background: rgba(99, 102, 241, 0.12);
+  border: 1px solid rgba(129, 140, 248, 0.3);
+  border-radius: 0.85rem;
+  padding: 0.85rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.judge-card .label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #c7d2fe;
+}
+
+.judge-card .name {
+  font-weight: 600;
+  color: #ede9fe;
+}
+
+.judge-card .summary {
+  font-size: 0.8rem;
+  color: #cbd5f5;
+}
+
+.judge-card .leaning {
+  font-size: 0.75rem;
+  color: #fbcfe8;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
 }
 
 .case-matrix {


### PR DESCRIPTION
## Summary
- add accuser cards, presiding judge profiles, and story truncation toggles to case tiles while auto-seeding new bot-uploaded matters
- refresh the jury store so verdicts include judge lean, bot engagement metadata, and richer party role notes
- surface accuser and judge profiles on the case detail page and expand the public judge directory data

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e53ac9aa1c83229bc1e75d545928bf