### PR TITLE
Allow jury bots to engage daily

### DIFF
--- a/jury/index.html
+++ b/jury/index.html
@@ -927,9 +927,23 @@
         const comments = Array.isArray(working.comments) ? working.comments : [];
         const existingUsers = new Set(comments.map((comment) => comment.user));
         const newComments = [];
+        const previousVoiceLog =
+          working.botMeta && typeof working.botMeta.voiceLog === 'object' && !Array.isArray(working.botMeta.voiceLog)
+            ? working.botMeta.voiceLog
+            : {};
+        const voiceLog = { ...previousVoiceLog };
+        let voiceLogChanged = false;
         const voices = [...botCommentAuthors, ...publicVoices];
         voices.forEach((author) => {
-          if (!forceComments && existingUsers.has(author.user)) {
+          const user = author.user;
+          const lastVoiceDay = voiceLog[user];
+          const hasSpokenBefore = existingUsers.has(user);
+          const alreadyLoggedToday = lastVoiceDay === dayKey;
+          if (!forceComments && hasSpokenBefore && alreadyLoggedToday) {
+            return;
+          }
+          const canSpeak = forceComments || !hasSpokenBefore || lastVoiceDay !== dayKey;
+          if (!canSpeak) {
             return;
           }
           const stance = author.stance || 'mixed';
@@ -940,10 +954,15 @@
             sentiment = -0.45;
           }
           newComments.push({
-            user: author.user,
+            user,
             text: composeBotComment(working, author),
             sentiment
           });
+          existingUsers.add(user);
+          if (voiceLog[user] !== dayKey) {
+            voiceLog[user] = dayKey;
+            voiceLogChanged = true;
+          }
         });
         let changed = false;
         if (newComments.length) {
@@ -965,6 +984,9 @@
           trendingScore,
           uploads: Number(working.botMeta?.uploads) || (working.botMeta?.uploadedOn ? 1 : 0)
         };
+        if (voiceLogChanged || Object.keys(voiceLog).length) {
+          botMeta.voiceLog = voiceLog;
+        }
         if (JSON.stringify(botMeta) !== JSON.stringify(working.botMeta || {})) {
           working.botMeta = botMeta;
           changed = true;

--- a/jury/js/juryStore.js
+++ b/jury/js/juryStore.js
@@ -219,6 +219,26 @@
       return {};
     }
     const result = {};
+    if (meta.voiceLog && typeof meta.voiceLog === 'object' && !Array.isArray(meta.voiceLog)) {
+      const entries = Object.entries(meta.voiceLog).reduce((acc, [user, day]) => {
+        if (typeof user !== 'string' && typeof user !== 'number') {
+          return acc;
+        }
+        const key = user.toString().slice(0, 80);
+        if (!key) {
+          return acc;
+        }
+        if (day === null || day === undefined) {
+          return acc;
+        }
+        const value = day.toString().slice(0, 24);
+        acc[key] = value;
+        return acc;
+      }, {});
+      if (Object.keys(entries).length) {
+        result.voiceLog = entries;
+      }
+    }
     if (meta.uploadedOn) {
       result.uploadedOn = meta.uploadedOn.toString().slice(0, 24);
     }


### PR DESCRIPTION
## Summary
- allow automated voices in the jury feed to add new commentary each day by tracking their participation
- persist per-bot engagement history in stored metadata so follow-up posts trigger fresh vote bumps

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e54604048883229b43d12d7430be4c