### PR TITLE
Revamp jury game to version two

### DIFF
--- a/jury/case.html
+++ b/jury/case.html
@@ -3,471 +3,129 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Case Detail • AI Judge</title>
+  <title>Case Detail • Jury Game 2.0</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/inter@5.0.16/variable.css">
-  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="bg-slate-950 text-slate-100">
-  <main class="max-w-3xl mx-auto px-4 py-10 space-y-8">
-    <a href="index.html" class="inline-flex items-center gap-2 text-sm text-slate-300 hover:text-indigo-200">← Back to docket</a>
-    <article class="card space-y-6" id="case-card">
-      <header class="space-y-4">
-        <div class="flex flex-wrap items-center justify-between gap-3">
-          <h1 class="text-2xl font-semibold" id="case-title"></h1>
-          <span class="badge"><span>🗳️</span><span id="case-votes"></span></span>
-        </div>
-        <p id="case-story" class="text-slate-300 leading-relaxed"></p>
-        <p id="case-filed-by" class="text-xs text-indigo-200"></p>
-        <div class="case-roster" id="case-roster">
-          <div class="roster-card accuser">
-            <p class="label">Accuser</p>
-            <p class="name" id="case-accuser-name"></p>
-            <p class="summary" id="case-accuser-summary"></p>
-            <p class="summary note" id="case-accuser-note"></p>
+<body>
+  <main class="shell" id="case-shell">
+    <a class="back-link" href="index.html">← Back to docket</a>
+    <section class="case-layout" id="case-content" hidden>
+      <article class="panel case-detail">
+        <header>
+          <div class="case-card__top">
+            <span class="case-card__status" id="case-status"></span>
+            <span class="case-card__time" id="case-updated"></span>
           </div>
-          <div class="roster-card prosecutor">
-            <p class="label">Prosecutor</p>
-            <p class="name" id="case-prosecutor-name"></p>
-            <p class="summary" id="case-prosecutor-summary"></p>
-            <p class="summary note" id="case-prosecutor-note"></p>
+          <h1 id="case-title"></h1>
+          <p class="case-card__filed" id="case-filed"></p>
+          <p class="case-card__summary" id="case-summary"></p>
+        </header>
+        <div class="case-detail__meta">
+          <span id="case-lead-charge"></span>
+        </div>
+        <section class="case-detail__stats">
+          <div class="detail-card">
+            <span class="detail-card__label">Vote balance</span>
+            <span class="detail-card__value" id="stat-votes"></span>
+            <span class="note-text" id="stat-vote-breakdown"></span>
           </div>
-          <div class="roster-card defendant">
-            <p class="label">Defendant</p>
-            <p class="name" id="case-defendant-name"></p>
-            <p class="summary" id="case-defendant-summary"></p>
-            <p class="summary note" id="case-defendant-note"></p>
+          <div class="detail-card">
+            <span class="detail-card__label">Crowd mood</span>
+            <span class="detail-card__value" id="stat-mood"></span>
+            <span class="note-text" id="stat-mood-note"></span>
           </div>
-          <div class="roster-card defense">
-            <p class="label">Defense Counsel</p>
-            <p class="name" id="case-defense-name"></p>
-            <p class="summary" id="case-defense-summary"></p>
-            <p class="summary note" id="case-defense-note"></p>
+          <div class="detail-card">
+            <span class="detail-card__label">Comments</span>
+            <span class="detail-card__value" id="stat-comments"></span>
+            <span class="note-text" id="stat-last-activity"></span>
           </div>
-        </div>
-        <div class="judge-card" id="case-judge-card">
-          <p class="label">Presiding Judge</p>
-          <p class="name" id="case-judge-name"></p>
-          <p class="summary" id="case-judge-summary"></p>
-          <p class="leaning" id="case-judge-leaning"></p>
-        </div>
-        <div class="text-xs uppercase tracking-wide text-slate-500" id="case-status"></div>
-      </header>
-      <section class="case-matrix">
-        <div class="case-panel">
-          <h2 class="panel-title">Charges</h2>
-          <ul id="case-charges" class="case-list"></ul>
-        </div>
-        <div class="case-panel">
-          <h2 class="panel-title">Key Evidence</h2>
-          <ul id="case-evidence" class="case-list"></ul>
-        </div>
-      </section>
-      <section class="case-matrix">
-        <div class="case-panel">
-          <h2 class="panel-title">Timeline of Events</h2>
-          <ol id="case-timeline" class="timeline-list"></ol>
-        </div>
-        <div class="case-panel" id="jury-box-card">
-          <h2 class="panel-title">Jury Box Tally</h2>
-          <p id="jury-box-tally" class="text-slate-200 font-semibold"></p>
-          <p id="jury-box-stance" class="text-sm text-slate-300"></p>
-        </div>
-      </section>
-      <section class="space-y-4" id="verdict-section" hidden>
-        <h2 class="text-lg font-semibold">Latest Verdict</h2>
-        <div class="grid gap-4 md:grid-cols-3 text-sm text-slate-200">
-          <div class="bg-slate-900/50 rounded-xl p-4">
-            <h3 class="font-semibold text-slate-100 mb-1">Verdict</h3>
-            <p id="verdict-decision" class="verdict-headline"></p>
+        </section>
+        <section class="case-columns">
+          <div>
+            <h3>Story</h3>
+            <p class="note-text" id="case-story"></p>
           </div>
-          <div class="bg-slate-900/50 rounded-xl p-4 md:col-span-2">
-            <h3 class="font-semibold text-slate-100 mb-1">Judge Reasoning</h3>
-            <p id="verdict-reasoning" class="text-slate-300"></p>
-            <p class="text-xs text-slate-500 mt-2" id="verdict-meta"></p>
-            <div class="space-y-2 mt-3" id="score-wrap" hidden>
-              <div class="text-xs uppercase tracking-wide text-slate-500">Composite Score</div>
-              <div class="score-bar"><div id="score-fill" class="score-bar-fill"></div></div>
-              <p class="text-xs text-slate-400" id="score-note"></p>
-            </div>
+          <div>
+            <h3>Charges</h3>
+            <ul class="list-reset" id="case-charges"></ul>
           </div>
+          <div>
+            <h3>Key evidence</h3>
+            <ul class="list-reset" id="case-evidence"></ul>
+          </div>
+        </section>
+        <section>
+          <h3>Timeline</h3>
+          <ol class="timeline-list" id="case-timeline"></ol>
+        </section>
+        <section id="verdict-section" hidden>
+          <div class="verdict-card">
+            <span class="verdict-card__label">Verdict</span>
+            <div class="verdict-card__decision" id="verdict-decision"></div>
+            <p class="note-text" id="verdict-reasoning"></p>
+            <p class="note-text" id="verdict-meta"></p>
+          </div>
+        </section>
+        <div class="case-detail__actions">
+          <button class="button button--ghost" data-direction="up" id="vote-up">👍 Support</button>
+          <button class="button button--ghost" data-direction="down" id="vote-down">👎 Oppose</button>
         </div>
-      </section>
-    </article>
+      </article>
 
-    <section class="card space-y-3" id="arguments-section">
-      <div class="flex items-center justify-between">
-        <h2 class="text-xl font-semibold">AI Trial Briefs</h2>
-        <span id="arguments-status" class="text-xs text-slate-400"></span>
-      </div>
-      <details class="bg-slate-900/40 rounded-xl p-4" id="argument-prosecution">
-        <summary class="cursor-pointer text-sm font-semibold text-rose-300">Prosecution Case</summary>
-        <p class="mt-2 text-sm text-slate-300"></p>
-      </details>
-      <details class="bg-slate-900/40 rounded-xl p-4" id="argument-defense">
-        <summary class="cursor-pointer text-sm font-semibold text-emerald-300">Defense Case</summary>
-        <p class="mt-2 text-sm text-slate-300"></p>
-      </details>
+      <aside class="panel" id="roster-panel">
+        <h3>Hearing roster</h3>
+        <ul class="list-reset" id="roster-list"></ul>
+      </aside>
     </section>
 
-    <section class="card space-y-4">
-      <header class="flex items-center justify-between">
-        <h2 class="text-xl font-semibold">Community Reactions</h2>
-        <span id="sentiment-score" class="text-sm text-slate-400"></span>
+    <section class="panel" id="comment-section" hidden>
+      <header class="section-heading">
+        <h2>Community reactions</h2>
+        <span class="hero__badge" id="comment-mood"></span>
       </header>
-      <ul id="comment-list" class="space-y-3"></ul>
-      <form id="comment-form" class="space-y-3">
-        <div class="grid gap-3 md:grid-cols-2">
-          <input type="text" name="user" placeholder="Username" required class="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 focus:border-indigo-400">
-          <select name="sentiment" class="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 focus:border-indigo-400">
-            <option value="0.6">Supportive</option>
-            <option value="0.2">Mixed</option>
-            <option value="-0.4">Critical</option>
+      <div class="comment-feed" id="comment-feed"></div>
+      <form id="comment-form" class="form-grid">
+        <label>
+          Display name
+          <input type="text" name="user" placeholder="CourtWatcher" maxlength="48" required>
+        </label>
+        <label>
+          Sentiment
+          <select name="sentiment">
+            <option value="0.5">Supportive</option>
+            <option value="0.15">Mixed</option>
+            <option value="-0.3">Critical</option>
+            <option value="-0.6">Strongly critical</option>
           </select>
-        </div>
-        <textarea name="text" rows="3" placeholder="Share your view" required class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 focus:border-indigo-400"></textarea>
-        <button type="submit" class="button-primary w-full">Add Comment</button>
+        </label>
+        <label>
+          Comment
+          <textarea name="text" placeholder="Share your perspective" maxlength="600" required></textarea>
+        </label>
+        <button class="button button--primary" type="submit">Post comment</button>
       </form>
-    </section>
-
-    <section class="card space-y-3" id="summary-section" hidden>
-      <h2 class="text-xl font-semibold">Community Summary</h2>
-      <ul id="summary-list" class="summary-list"></ul>
     </section>
   </main>
 
+  <template id="timeline-entry-template">
+    <li class="timeline-entry">
+      <span class="timeline-entry__time"></span>
+      <span class="timeline-entry__event"></span>
+    </li>
+  </template>
+
+  <template id="comment-card-template">
+    <article class="comment-card">
+      <div class="comment-card__meta">
+        <span class="comment-card__user"></span>
+        <span class="comment-card__time"></span>
+      </div>
+      <p class="comment-card__text"></p>
+    </article>
+  </template>
+
   <script src="js/juryStore.js"></script>
-  <script>
-    (async function () {
-      const params = new URLSearchParams(window.location.search);
-      const caseId = params.get('id');
-      if (!caseId) {
-        window.location.replace('index.html');
-        return;
-      }
-
-      const store = window.JuryStore;
-      const ai = window.JuryAI;
-      const commentForm = document.getElementById('comment-form');
-      const summarySection = document.getElementById('summary-section');
-      const summaryList = document.getElementById('summary-list');
-      const sentimentScore = document.getElementById('sentiment-score');
-      const commentList = document.getElementById('comment-list');
-      const verdictSection = document.getElementById('verdict-section');
-      const scoreWrap = document.getElementById('score-wrap');
-      const argumentsSection = document.getElementById('arguments-section');
-      const argumentsStatus = document.getElementById('arguments-status');
-      const argumentProsecution = document.querySelector('#argument-prosecution p');
-      const argumentDefense = document.querySelector('#argument-defense p');
-      const filedBy = document.getElementById('case-filed-by');
-      const accuserName = document.getElementById('case-accuser-name');
-      const accuserSummary = document.getElementById('case-accuser-summary');
-      const accuserNote = document.getElementById('case-accuser-note');
-      const prosecutorName = document.getElementById('case-prosecutor-name');
-      const prosecutorSummary = document.getElementById('case-prosecutor-summary');
-      const prosecutorNote = document.getElementById('case-prosecutor-note');
-      const defendantName = document.getElementById('case-defendant-name');
-      const defendantSummary = document.getElementById('case-defendant-summary');
-      const defendantNote = document.getElementById('case-defendant-note');
-      const defenseName = document.getElementById('case-defense-name');
-      const defenseSummary = document.getElementById('case-defense-summary');
-      const defenseNote = document.getElementById('case-defense-note');
-      const chargesList = document.getElementById('case-charges');
-      const evidenceList = document.getElementById('case-evidence');
-      const timelineList = document.getElementById('case-timeline');
-      const juryBoxCard = document.getElementById('jury-box-card');
-      const juryBoxTally = document.getElementById('jury-box-tally');
-      const juryBoxStance = document.getElementById('jury-box-stance');
-      const judgeCard = document.getElementById('case-judge-card');
-      const judgeNameEl = document.getElementById('case-judge-name');
-      const judgeSummaryEl = document.getElementById('case-judge-summary');
-      const judgeLeaningEl = document.getElementById('case-judge-leaning');
-
-      await store.loadCases();
-      let currentCase = store.getCase(caseId);
-      if (!currentCase) {
-        document.getElementById('case-card').innerHTML = '<p class="text-slate-300">Case not found.</p>';
-        commentForm.hidden = true;
-        summarySection.hidden = true;
-        return;
-      }
-
-      function renderSimpleList(target, list, emptyText) {
-        if (!target) return;
-        target.innerHTML = '';
-        if (!Array.isArray(list) || !list.length) {
-          const li = document.createElement('li');
-          li.className = 'text-sm text-slate-400';
-          li.textContent = emptyText;
-          target.appendChild(li);
-          return;
-        }
-        list.forEach((item) => {
-          const li = document.createElement('li');
-          li.textContent = item;
-          target.appendChild(li);
-        });
-      }
-
-      function setRosterDetails(nameEl, summaryEl, noteEl, party, fallback) {
-        if (nameEl) {
-          nameEl.textContent = party?.name || fallback;
-        }
-        if (summaryEl) {
-          summaryEl.textContent = party?.summary || party?.title || '';
-        }
-        if (noteEl) {
-          const noteText = party?.roleNote || party?.profile || '';
-          if (noteText) {
-            noteEl.textContent = noteText;
-            noteEl.hidden = false;
-          } else {
-            noteEl.hidden = true;
-          }
-        }
-      }
-
-      function renderTimeline(target, entries) {
-        if (!target) return;
-        target.innerHTML = '';
-        if (!Array.isArray(entries) || !entries.length) {
-          const li = document.createElement('li');
-          li.className = 'text-sm text-slate-400';
-          li.textContent = 'Timeline not submitted yet.';
-          target.appendChild(li);
-          return;
-        }
-        entries.forEach((entry) => {
-          const li = document.createElement('li');
-          li.className = 'timeline-entry';
-          const time = document.createElement('span');
-          time.className = 'timeline-time';
-          time.textContent = entry.time || '';
-          const event = document.createElement('span');
-          event.className = 'timeline-event';
-          event.textContent = entry.event || '';
-          li.appendChild(time);
-          li.appendChild(event);
-          target.appendChild(li);
-        });
-      }
-
-      function buildRoleBadge(user) {
-        if (!user) return null;
-        const lower = user.toLowerCase();
-        let roleClass = '';
-        let label = '';
-        if (lower.includes('prosecutor')) {
-          roleClass = 'role-prosecution';
-          label = 'PROSECUTION';
-        } else if (lower.includes('defense') || lower.includes('defence')) {
-          roleClass = 'role-defense';
-          label = 'DEFENSE';
-        } else if (lower.includes('jury box')) {
-          roleClass = 'role-jury';
-          label = 'JURY BOX';
-        } else if (lower.includes('judge')) {
-          roleClass = 'role-judge';
-          label = 'JUDGE';
-        }
-        if (!roleClass) return null;
-        const badge = document.createElement('span');
-        badge.className = `role-badge ${roleClass}`;
-        badge.textContent = label;
-        return badge;
-      }
-
-      function renderCase() {
-        document.getElementById('case-title').textContent = currentCase.title;
-        document.getElementById('case-story').textContent = currentCase.story;
-        document.getElementById('case-votes').textContent = currentCase.votes;
-        const statusText = currentCase.status === 'judged'
-          ? `VERDICT: ${currentCase.verdict?.decision || 'Published'}`
-          : 'AWAITING TRIAL';
-        document.getElementById('case-status').textContent = statusText;
-
-        if (filedBy) {
-          if (currentCase.filedBy) {
-            filedBy.hidden = false;
-            filedBy.textContent = `Filed by ${currentCase.filedBy}`;
-          } else {
-            filedBy.hidden = true;
-          }
-        }
-
-        const parties = currentCase.parties || {};
-        setRosterDetails(accuserName, accuserSummary, accuserNote, parties.accuser, 'Accuser');
-        setRosterDetails(prosecutorName, prosecutorSummary, prosecutorNote, parties.prosecutor, 'Prosecutor');
-        setRosterDetails(defendantName, defendantSummary, defendantNote, parties.defendant, 'Defendant');
-        setRosterDetails(defenseName, defenseSummary, defenseNote, parties.defense, 'Defense Counsel');
-
-        if (judgeCard) {
-          const profile = currentCase.judgeProfile || {};
-          const hasJudge = Boolean(profile.name || currentCase.verdict?.judge);
-          judgeCard.hidden = !hasJudge;
-          if (hasJudge) {
-            if (judgeNameEl) {
-              judgeNameEl.textContent = profile.name || currentCase.verdict?.judge || 'Assigned Judge';
-            }
-            if (judgeSummaryEl) {
-              const summaryText = [profile.summary, profile.philosophy].filter(Boolean).join(' ');
-              judgeSummaryEl.textContent = summaryText || profile.title || '';
-            }
-            if (judgeLeaningEl) {
-              const leaningText = currentCase.verdict?.siding
-                ? `Currently siding with the ${currentCase.verdict.siding.toUpperCase()} — ${currentCase.verdict.decision || 'Deliberating'}`
-                : profile.leaning
-                  ? `Usual leaning: ${profile.leaning}`
-                  : 'Neutral stance reported.';
-              judgeLeaningEl.textContent = leaningText;
-            }
-          }
-        }
-
-        renderSimpleList(chargesList, currentCase.charges, 'No charges submitted.');
-        const evidenceItems = (currentCase.evidence || []).map((item) => `${item.label}: ${item.detail}`);
-        renderSimpleList(evidenceList, evidenceItems, 'Evidence will be uploaded before trial.');
-        renderTimeline(timelineList, currentCase.timeline);
-
-        const box = currentCase.juryBox || null;
-        if (juryBoxCard) {
-          if (box) {
-            juryBoxCard.hidden = false;
-            if (juryBoxTally) {
-              juryBoxTally.textContent = `Prosecution ${box.votesForProsecution ?? 0} • Defense ${box.votesForDefense ?? 0}`;
-            }
-            if (juryBoxStance) {
-              juryBoxStance.textContent = box.stance || 'Jury Box has not provided commentary yet.';
-            }
-          } else {
-            juryBoxCard.hidden = true;
-          }
-        }
-
-        if (currentCase.verdict) {
-          verdictSection.hidden = false;
-          document.getElementById('verdict-decision').textContent = currentCase.verdict.decision;
-          document.getElementById('verdict-reasoning').textContent = currentCase.verdict.reasoning;
-          const judgeLabel = currentCase.verdict.judge || 'Unknown Judge';
-          const metaBits = [judgeLabel];
-          if (Number.isFinite(currentCase.verdict.confidence)) {
-            metaBits.push(`Confidence ${currentCase.verdict.confidence}%`);
-          }
-          if (currentCase.verdict.siding) {
-            metaBits.push(`Sides with ${currentCase.verdict.siding}`);
-          }
-          document.getElementById('verdict-meta').textContent = metaBits.join(' • ');
-          if (Number.isFinite(currentCase.finalScore)) {
-            scoreWrap.hidden = false;
-            const scoreFill = document.getElementById('score-fill');
-            const clamped = Math.max(0, Math.min(100, Math.round(currentCase.finalScore)));
-            scoreFill.style.width = clamped + '%';
-            document.getElementById('score-note').textContent = `Composite score ${clamped}/100 from judge and crowd weighting.`;
-          } else {
-            scoreWrap.hidden = true;
-          }
-        } else {
-          verdictSection.hidden = true;
-          scoreWrap.hidden = true;
-        }
-
-        if (argumentsSection) {
-          const prosecutionBrief = currentCase.prosecution || 'Awaiting trial.';
-          const defenseBrief = currentCase.defense || 'Awaiting trial.';
-          if (argumentProsecution) {
-            argumentProsecution.textContent = prosecutionBrief;
-          }
-          if (argumentDefense) {
-            argumentDefense.textContent = defenseBrief;
-          }
-          if (argumentsStatus) {
-            if (currentCase.status === 'judged' && currentCase.verdict?.judge) {
-              argumentsStatus.textContent = `Verdict issued by Judge ${currentCase.verdict.judge}.`;
-            } else {
-              argumentsStatus.textContent = 'Briefs prepared — awaiting trial.';
-            }
-          }
-          argumentsSection.hidden = !prosecutionBrief && !defenseBrief;
-        }
-
-        const summaryInfo = currentCase.ai_summary
-          ? { lines: currentCase.ai_summary.split('\n').filter(Boolean), average: currentCase.publicSentiment ?? ai.summariseComments(currentCase.comments || []).average }
-          : ai.summariseComments(currentCase.comments || []);
-        if (summaryInfo.lines.length) {
-          summarySection.hidden = false;
-          summaryList.innerHTML = '';
-          summaryInfo.lines.forEach((line) => {
-            const entry = document.createElement('li');
-            entry.textContent = line.replace(/^•\s*/, '');
-            summaryList.appendChild(entry);
-          });
-        } else {
-          summarySection.hidden = true;
-        }
-
-        commentList.innerHTML = '';
-        (currentCase.comments || []).forEach((comment) => {
-          const li = document.createElement('li');
-          li.className = 'bg-slate-900/40 rounded-xl p-3 text-sm flex flex-col gap-1';
-          const meta = document.createElement('div');
-          meta.className = 'flex items-center justify-between text-slate-400 gap-2 flex-wrap';
-          const userWrap = document.createElement('div');
-          userWrap.className = 'flex items-center gap-2';
-          const name = document.createElement('span');
-          name.textContent = comment.user;
-          userWrap.appendChild(name);
-          const badge = buildRoleBadge(comment.user || '');
-          if (badge) {
-            userWrap.appendChild(badge);
-          }
-          meta.appendChild(userWrap);
-          const sentimentLabel = document.createElement('span');
-          sentimentLabel.textContent = formatSentiment(comment.sentiment);
-          meta.appendChild(sentimentLabel);
-
-          const body = document.createElement('p');
-          body.className = 'text-slate-200';
-          body.textContent = comment.text;
-
-          li.appendChild(meta);
-          li.appendChild(body);
-          commentList.appendChild(li);
-        });
-        const average = ai.summariseComments(currentCase.comments || []).average;
-        sentimentScore.textContent = `Crowd Sentiment: ${(average * 100).toFixed(0)} / 100`;
-      }
-
-      function formatSentiment(score = 0) {
-        if (score > 0.25) return 'Supportive';
-        if (score < -0.25) return 'Critical';
-        return 'Mixed';
-      }
-
-      commentForm.addEventListener('submit', (event) => {
-        event.preventDefault();
-        const formData = new FormData(event.target);
-        const comment = {
-          user: (formData.get('user') || '').toString().trim() || 'anon',
-          text: (formData.get('text') || '').toString().trim(),
-          sentiment: Number(formData.get('sentiment')) || 0
-        };
-        if (!comment.text) {
-          return;
-        }
-        currentCase = store.updateCase(caseId, (entry) => {
-          const next = { ...entry };
-          next.comments = [...(entry.comments || []), comment];
-          const summary = ai.summariseComments(next.comments);
-          next.ai_summary = summary.lines.join('\n');
-          next.publicSentiment = summary.average;
-          return next;
-        });
-        event.target.reset();
-        renderCase();
-      });
-
-      renderCase();
-    })();
-  </script>
+  <script src="js/page-case.js"></script>
 </body>
 </html>

--- a/jury/data/cases.json
+++ b/jury/data/cases.json
@@ -1,107 +1,225 @@
 [
   {
-    "id": "state_vs_rivera",
-    "title": "State v. Alex Rivera — Emergency Laptop Borrowing",
-    "story": "Alex Rivera, a third-year engineering student, borrowed roommate Eli Chen's laptop without permission after Rivera's device died minutes before a proctored exam. ProsecutorBot-03 filed charges for unauthorized access, arguing Rivera breached the shared-housing conduct code. The defense claims the emergency justified the temporary use and that Rivera immediately informed Eli afterward.",
-    "votes": 162,
+    "id": "case-rivera",
+    "title": "Housing v. Alex Rivera — Emergency Laptop Borrowing",
+    "summary": "Roommate borrowed a laptop without consent minutes before an exam.",
+    "story": "Alex Rivera, a third-year engineering student, grabbed roommate Eli Chen's laptop after Rivera's machine bricked five minutes before a remote exam. Rivera logged in with the shared Wi-Fi password, sat the 75-minute test, wiped the browsing history, and texted Eli immediately afterward. ProsecutorBot-03 argues it's an obvious breach of the shared housing tech agreement. Rivera claims the emergency justified the temporary use and promised to pay for diagnostic checks.",
     "filedBy": "ProsecutorBot-03",
-    "accuser": {
-      "name": "Eli Chen",
-      "title": "Roommate & Original Poster (Accuser)",
-      "summary": "Reported the laptop use to housing staff after seeing the system logs.",
-      "role": "accuser",
-      "roleNote": "Filed the case thread detailing the unauthorized borrowing."
-    },
-    "defendant": {
-      "name": "Alex Rivera",
-      "title": "Engineering Student (Defendant)",
-      "summary": "Pleads not guilty, citing academic emergency and intent to replace any wear on the laptop.",
-      "role": "defendant"
-    },
-    "prosecutor": {
-      "name": "Jordan Hale",
-      "title": "Student Conduct Prosecutor",
-      "summary": "Represents Eli Chen and frames the borrowing as a consent breach that undermines shared trust agreements.",
-      "role": "prosecutor"
-    },
-    "defenseCounsel": {
-      "name": "Morgan Lee",
-      "title": "Defense Advocate",
-      "summary": "Defends Rivera and insists necessity doctrine applies because failure to access the exam would endanger studies.",
-      "role": "defense"
+    "status": "debate",
+    "tags": ["housing", "technology"],
+    "leadCharge": "Unauthorized use of a roommate's device during a proctored exam",
+    "seedHoursAgo": 6,
+    "votes": { "up": 68, "down": 31 },
+    "roles": {
+      "accuser": {
+        "name": "Eli Chen",
+        "title": "Roommate & Original Poster",
+        "summary": "Saw an unfamiliar login on the audit trail and reported it to housing."
+      },
+      "defendant": {
+        "name": "Alex Rivera",
+        "title": "Engineering Student",
+        "summary": "Borrowed the laptop for the exam and offered to cover any wear and tear."
+      },
+      "prosecutor": {
+        "name": "Jordan Hale",
+        "title": "Student Conduct Prosecutor",
+        "summary": "Insists the policy is clear: ask first or fail the course."
+      },
+      "defense": {
+        "name": "Morgan Lee",
+        "title": "Defense Advocate",
+        "summary": "Frames the act as necessity to avoid an academic penalty."
+      },
+      "judge": {
+        "name": "Judge Vega",
+        "title": "Presiding Judge",
+        "summary": "Balances policy with practical outcomes." 
+      }
     },
     "charges": [
-      "Count 1: Unauthorized use of personal property",
-      "Count 2: Breach of roommate technology agreement"
+      "Count 1: Unauthorized access to personal property",
+      "Count 2: Breach of the shared technology agreement"
     ],
     "timeline": [
-      {
-        "time": "07:45",
-        "event": "Rivera discovers laptop battery failure moments before the exam."
-      },
-      {
-        "time": "07:52",
-        "event": "Rivera unlocks Eli's laptop using the shared password to join the exam portal."
-      },
-      {
-        "time": "09:10",
-        "event": "Exam concludes; Rivera wipes browsing history and sanitizes the keyboard."
-      },
-      {
-        "time": "09:25",
-        "event": "Rivera texts Eli admitting the emergency borrowing and offers to run diagnostics."
-      }
+      { "time": "07:48", "event": "Rivera discovers their laptop will not power on." },
+      { "time": "07:53", "event": "Rivera unlocks Eli's laptop and joins the proctored exam." },
+      { "time": "09:12", "event": "Exam ends; Rivera wipes history and sanitises the keyboard." },
+      { "time": "09:20", "event": "Rivera texts Eli apologising and offers to pay for diagnostics." }
     ],
     "evidence": [
-      {
-        "label": "Housing Agreement",
-        "detail": "Signed contract requiring consent before sharing electronics."
-      },
-      {
-        "label": "System Logs",
-        "detail": "Login records showing a 78-minute session under Rivera's credentials."
-      },
-      {
-        "label": "Message Thread",
-        "detail": "Screenshots of Rivera notifying Eli immediately after the exam."
-      }
+      { "label": "Housing Tech Policy", "detail": "Signed agreement requires consent before device sharing." },
+      { "label": "Network Log", "detail": "Login from Rivera's account lasting 79 minutes on Eli's machine." },
+      { "label": "Message Thread", "detail": "Screenshots of Rivera's apology and offer to pay for diagnostics." }
     ],
-    "juryBox": {
-      "votesForProsecution": 7,
-      "votesForDefense": 5,
-      "stance": "Jury Box leans toward a policy breach but recognizes mitigating academic pressure."
-    },
+    "aiSummary": "Crowd is split: necessity versus respecting consent in shared housing.",
     "comments": [
       {
         "user": "ProsecutorBot-03",
-        "text": "Consent is the cornerstone of shared housing; Rivera bypassed it entirely.",
-        "sentiment": -0.6
+        "text": "Consent is everything in shared housing. Emergencies don't erase the contract.",
+        "sentiment": -0.5,
+        "seedMinutesAgo": 310
       },
       {
         "user": "DefenseCounsel-AI",
-        "text": "Emergency necessity doctrine applies. Rivera prevented exam failure and caused no damage.",
-        "sentiment": 0.45
+        "text": "No harm, full transparency, and a genuine emergency. Issue a warning and move on.",
+        "sentiment": 0.5,
+        "seedMinutesAgo": 280
       },
       {
         "user": "Jury Box Monitor",
-        "text": "Box tally: 7 votes to reprimand, 5 to forgive. Crowd sees a breach with compassion.",
-        "sentiment": -0.2
-      },
-      {
-        "user": "CampusMediator",
-        "text": "Why didn't Rivera text first? Even a 30-second heads-up would help.",
-        "sentiment": -0.3
-      },
-      {
-        "user": "LabPartner42",
-        "text": "If Eli was unreachable, the exam crisis justifies the quick borrow.",
-        "sentiment": 0.5
+        "text": "Box tally is 6 for reprimand, 6 for forgiveness. Crowd is deadlocked.",
+        "sentiment": -0.05,
+        "seedMinutesAgo": 250
       }
+    ]
+  },
+  {
+    "id": "case-generator",
+    "title": "Festival Board v. Maya Patel — Generator Priority Dispute",
+    "summary": "Generator rerouted from a festival rehearsal to keep insulin refrigerated during a storm.",
+    "story": "During a storm-driven outage, logistics coordinator Maya Patel moved the esports lounge's backup generator to the community clinic after a nurse paged about insulin refrigeration. Festival organisers say stage lighting tests stalled for 90 minutes and accuse Patel of bypassing approval chains. Patel says the medical need outweighed practice delays and no equipment was damaged.",
+    "filedBy": "ObserverBot-22",
+    "status": "trial",
+    "tags": ["operations", "health"],
+    "leadCharge": "Unauthorized diversion of emergency equipment",
+    "seedHoursAgo": 3,
+    "votes": { "up": 74, "down": 28 },
+    "roles": {
+      "accuser": {
+        "name": "Festival Board",
+        "title": "Campus Festival Organisers",
+        "summary": "Claims Patel ignored the emergency escalation roster."
+      },
+      "defendant": {
+        "name": "Maya Patel",
+        "title": "Logistics Coordinator",
+        "summary": "Rerouted generator for medical refrigeration and returned it within 90 minutes."
+      },
+      "prosecutor": {
+        "name": "Silas Trent",
+        "title": "Policy Prosecutor",
+        "summary": "Wants a formal caution recorded for bypassing the chain of command."
+      },
+      "defense": {
+        "name": "Advocate-Lambda",
+        "title": "Defense Counsel",
+        "summary": "Argues the emergency justified rapid improvisation."
+      },
+      "judge": {
+        "name": "Judge Iron",
+        "title": "Presiding Judge",
+        "summary": "Values procedure and documented approvals."
+      }
+    },
+    "charges": [
+      "Count 1: Rerouting equipment without authorization",
+      "Count 2: Failure to log emergency hand-off"
     ],
-    "ai_summary": "",
-    "status": "pending",
-    "prosecution": "",
-    "defense": "",
-    "verdict": null
+    "timeline": [
+      { "time": "19:12", "event": "Storm knocks out power to the community wing." },
+      { "time": "19:19", "event": "Clinic nurse pages Patel requesting generator support." },
+      { "time": "19:24", "event": "Patel wheels generator to clinic; festival crew pauses lighting tests." },
+      { "time": "20:42", "event": "Generator returned and festival crew resumes." }
+    ],
+    "evidence": [
+      { "label": "Pager Log", "detail": "Timestamped request from clinic nurse at 19:19." },
+      { "label": "Generator Diagnostics", "detail": "Readouts show stable voltage during the hand-off." }
+    ],
+    "aiSummary": "Majority leans toward compassion but wants protocol clarified for next time.",
+    "comments": [
+      {
+        "user": "ObserverBot-22",
+        "text": "Rules exist for a reason. Coordinate first, improvise second.",
+        "sentiment": -0.4,
+        "seedMinutesAgo": 160
+      },
+      {
+        "user": "ClinicVolunteer",
+        "text": "Insulin would have spoiled. Patel likely prevented an ER visit.",
+        "sentiment": 0.6,
+        "seedMinutesAgo": 140
+      },
+      {
+        "user": "FestivalTenor",
+        "text": "We lost rehearsal momentum and volunteers. There has to be a call chain!",
+        "sentiment": -0.35,
+        "seedMinutesAgo": 120
+      }
+    ]
+  },
+  {
+    "id": "case-allergen",
+    "title": "Dining Board v. Jordan Brooks — Allergen Exposure Incident",
+    "summary": "Nut-free label moved during dinner rush, leading to a mild allergic reaction.",
+    "story": "Community chef Jordan Brooks ran a chili buffet with a dedicated nut-free line. A volunteer shifted the signage while restocking bread, and a resident with a nut allergy took a scoop from the wrong pot. The resident used an inhaler but did not require hospitalization. Dining Board bots want mandatory retraining. Brooks apologised publicly and introduced color-coded ladles that night.",
+    "filedBy": "AccuserBot-08",
+    "status": "hearing",
+    "tags": ["food safety"],
+    "leadCharge": "Negligent allergen management at community event",
+    "seedHoursAgo": 1.5,
+    "votes": { "up": 81, "down": 19 },
+    "roles": {
+      "accuser": {
+        "name": "Dining Board",
+        "title": "Allergy Safety Coalition",
+        "summary": "Seeks formal retraining requirements for kitchen leads."
+      },
+      "defendant": {
+        "name": "Jordan Brooks",
+        "title": "Residence Chef",
+        "summary": "Prepared separate pots but lost track of signage during rush." 
+      },
+      "prosecutor": {
+        "name": "Helena Cross",
+        "title": "Health & Safety Prosecutor",
+        "summary": "Pushes for suspension until training is complete." 
+      },
+      "defense": {
+        "name": "Counsel-Orion",
+        "title": "Defense Counsel",
+        "summary": "Points to immediate corrective action and minor harm." 
+      },
+      "judge": {
+        "name": "Judge Mercy",
+        "title": "Presiding Judge",
+        "summary": "Looks for restorative fixes and intent." 
+      }
+    },
+    "charges": [
+      "Count 1: Improper allergen signage",
+      "Count 2: Insufficient volunteer briefing"
+    ],
+    "timeline": [
+      { "time": "17:05", "event": "Separate nut-free pot prepped with dedicated ladle." },
+      { "time": "18:04", "event": "Volunteer shifts signage while restocking bread." },
+      { "time": "18:18", "event": "Resident experiences reaction, uses inhaler." },
+      { "time": "18:26", "event": "Color-coded ladles introduced; signage locked in place." }
+    ],
+    "evidence": [
+      { "label": "Volunteer Brief", "detail": "Email emphasising not to move allergen signage." },
+      { "label": "Clinic Report", "detail": "Resident treated on-site; no hospital transfer." }
+    ],
+    "aiSummary": "Public mood wants accountability plus permanent signage improvements.",
+    "comments": [
+      {
+        "user": "AccuserBot-08",
+        "text": "Labels are the first line of defence. This cannot be brushed aside.",
+        "sentiment": -0.5,
+        "seedMinutesAgo": 90
+      },
+      {
+        "user": "CommunityVolunteer",
+        "text": "Rush hour chaos is real. New color-coded ladles are a strong fix.",
+        "sentiment": 0.35,
+        "seedMinutesAgo": 70
+      },
+      {
+        "user": "AllergyParent",
+        "text": "Great that the resident recovered, but protocols must be ironclad.",
+        "sentiment": -0.45,
+        "seedMinutesAgo": 50
+      }
+    ]
   }
 ]

--- a/jury/index.html
+++ b/jury/index.html
@@ -3,1258 +3,139 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AI Judge • Moral Court</title>
+  <title>Jury Game 2.0 • Live Moral Court</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/inter@5.0.16/variable.css">
-  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="bg-slate-950 text-slate-100">
-  <main class="max-w-5xl mx-auto px-4 py-10 space-y-12">
-    <header class="text-center space-y-4">
-      <span class="badge">Hourly AI Trials</span>
-      <h1 class="text-4xl font-semibold tracking-tight">AI Judge — Moral Court</h1>
-      <p class="text-slate-300 max-w-2xl mx-auto">
-        Upload dilemmas, debate with the crowd, then let our AI tribunal deliver a nightly verdict.
+<body>
+  <main class="shell">
+    <header class="hero">
+      <span class="hero__badge">Jury Game — Version Two</span>
+      <h1>The campus moral court, rebuilt for real-time drama.</h1>
+      <p>
+        Submit your dilemmas, watch bots argue, and see the crowd sentiment sway in real time. Version two keeps the
+        docket alive with autonomous filings, rolling comments, and one-click resets so every visitor drops into a
+        fresh debate.
       </p>
-      <div class="flex flex-wrap justify-center gap-3 text-sm text-slate-400">
-        <span>🚀 Upload cases</span>
-        <span>💬 Sentiment-weighted comments</span>
-        <span>⚖️ AI prosecution, defense &amp; judge</span>
+      <div class="hero__stats">
+        <div class="hero__stat">
+          <span class="hero__stat-value" id="stat-cases">--</span>
+          <span class="hero__stat-label">Active cases</span>
+        </div>
+        <div class="hero__stat">
+          <span class="hero__stat-value" id="stat-comments">--</span>
+          <span class="hero__stat-label">Live comments</span>
+        </div>
+        <div class="hero__stat">
+          <span class="hero__stat-value" id="stat-mood">--</span>
+          <span class="hero__stat-label">Average mood</span>
+        </div>
+        <div class="hero__stat">
+          <span class="hero__stat-value" id="stat-last-bot">--</span>
+          <span class="hero__stat-label">Last bot action</span>
+        </div>
+      </div>
+      <div class="hero__controls">
+        <button class="button button--danger" id="reset-simulation" type="button">Reset simulation</button>
+        <div class="hero__timer">
+          <span>Next bot case in <strong id="next-bot-case">--</strong></span>
+          <span>Next bot comment in <strong id="next-bot-comment">--</strong></span>
+        </div>
       </div>
     </header>
 
-    <section class="grid gap-6 md:grid-cols-[2fr,1fr]">
-      <article class="card space-y-6">
-        <div class="flex flex-wrap items-center justify-between gap-3">
-          <div class="flex items-center gap-3">
-            <h2 class="text-xl font-semibold">Live Docket</h2>
-            <button id="run-trial" class="button-secondary text-sm">Run AI Trial</button>
-          </div>
-          <a href="judges.html" class="text-sm text-indigo-300 hover:text-indigo-200">Meet the Judges →</a>
+    <section class="layout">
+      <section class="layout__primary">
+        <div class="section-heading">
+          <h2>Live docket</h2>
+          <a class="back-link" href="judges.html">Meet the judges →</a>
         </div>
-        <p id="trial-message" class="text-xs text-indigo-200" hidden></p>
-        <div id="case-feed" class="space-y-4"></div>
-        <section id="archive-section" class="space-y-3" hidden>
-          <h3 class="text-lg font-semibold text-slate-200">Archived Trials</h3>
-          <p class="text-xs text-slate-400">Completed cases remain available for reference.</p>
-          <div id="archive-feed" class="space-y-4"></div>
-        </section>
-      </article>
+        <div class="case-feed" id="case-feed"></div>
+      </section>
 
-      <aside class="card space-y-4">
-        <h2 class="text-xl font-semibold">Submit a Case</h2>
-        <form id="upload-form" class="space-y-3">
-          <div>
-            <label class="block text-sm text-slate-300 mb-1">Title</label>
-            <input type="text" name="title" required class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 focus:border-indigo-400" placeholder="Caught lying to a friend" />
-          </div>
-          <div>
-            <label class="block text-sm text-slate-300 mb-1">Story</label>
-            <textarea name="story" rows="5" required class="w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 focus:border-indigo-400" placeholder="Explain what happened"></textarea>
-          </div>
-          <button type="submit" class="button-primary w-full">Send to the Jury</button>
-          <p class="text-xs text-slate-400">
-            Uploads are saved in your browser so you can keep refining the debate.
+      <aside class="layout__aside">
+        <article class="panel">
+          <h2>Submit your case</h2>
+          <p class="form-hint">Your browser keeps a private copy. Reset anytime for a fresh docket.</p>
+          <form id="case-form" class="form-grid">
+            <label>
+              Title
+              <input type="text" name="title" placeholder="Caught lying to a friend" required maxlength="160">
+            </label>
+            <label>
+              Story
+              <textarea name="story" placeholder="Explain what happened" required maxlength="1200"></textarea>
+            </label>
+            <label>
+              Filed by
+              <input type="text" name="filedBy" placeholder="Your name or alias" maxlength="60">
+            </label>
+            <button class="button button--primary" type="submit">Add to the docket</button>
+          </form>
+          <p class="success-text" id="form-success" hidden>Case filed. Scroll up to see it in the feed.</p>
+        </article>
+
+        <article class="panel">
+          <h3>How version two stays alive</h3>
+          <p class="form-hint">
+            Bot prosecutors, defenders, and onlookers submit new cases every couple of minutes. They also keep the comment
+            threads moving so the crowd sentiment shifts in real time. Hit reset for a brand-new simulation whenever you want
+            a clean slate.
           </p>
-          <p id="upload-feedback" class="text-xs text-emerald-300" hidden>Case added to the docket. Refresh the page to reset.</p>
-        </form>
+        </article>
       </aside>
-    </section>
-
-    <section class="card space-y-4">
-      <h2 class="text-xl font-semibold">How the Court Works</h2>
-      <div class="grid md:grid-cols-3 gap-4 text-sm text-slate-300">
-        <div>
-          <h3 class="font-semibold text-slate-100 mb-2">Daytime Debate</h3>
-          <p>People vote and leave comments. A sentiment bot keeps score and builds the crowd summary.</p>
-        </div>
-        <div>
-          <h3 class="font-semibold text-slate-100 mb-2">Hourly Session</h3>
-          <p>Top cases face prosecution, defense, and a neutral judge prompt. Verdicts land automatically.</p>
-        </div>
-        <div>
-          <h3 class="font-semibold text-slate-100 mb-2">Transparency</h3>
-          <p>Every verdict includes public mood, AI arguments, and judge confidence.</p>
-        </div>
-      </div>
     </section>
   </main>
 
-  <template id="case-template">
-    <article class="rounded-2xl border border-slate-800 bg-slate-900/60 p-5 space-y-4">
-      <header class="space-y-3">
-        <div class="flex flex-wrap items-start justify-between gap-3">
-          <div class="space-y-1">
-            <h3 class="text-lg font-semibold"></h3>
-            <p class="text-xs text-indigo-200 filed-by"></p>
-          </div>
-          <span class="badge"><span class="emoji">🗳️</span><span class="votes"></span></span>
+  <template id="case-card-template">
+    <article class="case-card">
+      <header class="case-card__header">
+        <div class="case-card__top">
+          <span class="case-card__status" data-status=""></span>
+          <span class="case-card__time"></span>
         </div>
-        <p class="text-sm text-slate-300 story"></p>
-        <button class="story-toggle" type="button" hidden>Show more</button>
-        <div class="case-roster">
-          <div class="roster-card accuser">
-            <p class="label">Accuser</p>
-            <p class="name"></p>
-            <p class="summary"></p>
-            <p class="note" hidden></p>
-          </div>
-          <div class="roster-card prosecutor">
-            <p class="label">Prosecutor</p>
-            <p class="name"></p>
-            <p class="summary"></p>
-            <p class="note" hidden></p>
-          </div>
-          <div class="roster-card defendant">
-            <p class="label">Defendant</p>
-            <p class="name"></p>
-            <p class="summary"></p>
-            <p class="note" hidden></p>
-          </div>
-          <div class="roster-card defense">
-            <p class="label">Defense Counsel</p>
-            <p class="name"></p>
-            <p class="summary"></p>
-            <p class="note" hidden></p>
-          </div>
-        </div>
-        <div class="judge-card">
-          <p class="label">Presiding Judge</p>
-          <p class="name"></p>
-          <p class="summary"></p>
-          <p class="leaning"></p>
-        </div>
-        <p class="lead-charge text-xs text-slate-400"></p>
+        <h3 class="case-card__title"></h3>
+        <p class="case-card__filed"></p>
+        <p class="case-card__summary"></p>
+        <button class="case-card__toggle" type="button">Show full story</button>
       </header>
-      <div class="space-y-2 text-sm text-slate-400">
-        <div class="progress-bar"><div class="sentiment" style="width:50%"></div></div>
-        <p><strong class="text-slate-200">Public Mood:</strong> <span class="summary"></span></p>
-        <p class="box-note text-xs text-amber-200"></p>
-        <p class="status text-xs uppercase tracking-wide text-slate-400"></p>
+      <div class="case-card__story" hidden>
+        <p class="case-card__story-text"></p>
+        <ul class="case-card__tags"></ul>
       </div>
-      <footer class="flex items-center justify-between text-sm">
-        <div class="flex gap-2">
-          <button class="px-3 py-1 rounded-full bg-slate-800 hover:bg-slate-700 vote-up">👍</button>
-          <button class="px-3 py-1 rounded-full bg-slate-800 hover:bg-slate-700 vote-down">👎</button>
+      <div class="case-card__meta">
+        <div class="meta-item">
+          <span class="meta-item__value meta-item__value--votes"></span>
+          <span class="meta-item__label">Vote balance</span>
         </div>
-        <a class="text-indigo-300 hover:text-indigo-200 text-sm" href="#">View Case →</a>
+        <div class="meta-item">
+          <span class="meta-item__value meta-item__value--comments"></span>
+          <span class="meta-item__label">Comments</span>
+        </div>
+        <div class="meta-item">
+          <span class="meta-item__value meta-item__value--mood"></span>
+          <span class="meta-item__label">Crowd mood</span>
+        </div>
+      </div>
+      <div class="case-card__comments"></div>
+      <footer class="case-card__actions">
+        <div class="case-card__votes">
+          <button class="button button--ghost" data-action="vote" data-direction="up" type="button">👍 Support</button>
+          <button class="button button--ghost" data-action="vote" data-direction="down" type="button">👎 Oppose</button>
+        </div>
+        <a class="case-card__link" href="#">Open case →</a>
       </footer>
     </article>
   </template>
 
+  <template id="comment-chip-template">
+    <div class="comment-chip">
+      <span class="comment-chip__user"></span>
+      <p class="comment-chip__text"></p>
+    </div>
+  </template>
+
   <script src="js/juryStore.js"></script>
-  <script>
-    (async function () {
-      const store = window.JuryStore;
-      const ai = window.JuryAI;
-      const feed = document.getElementById('case-feed');
-      const archiveFeed = document.getElementById('archive-feed');
-      const archiveSection = document.getElementById('archive-section');
-      const template = document.getElementById('case-template');
-      const uploadForm = document.getElementById('upload-form');
-      const runTrialButton = document.getElementById('run-trial');
-      const trialMessage = document.getElementById('trial-message');
-      const uploadFeedback = document.getElementById('upload-feedback');
-
-      let cases = [];
-
-      const botSeedCases = [
-        {
-          id: 'state_vs_ellis',
-          title: 'City v. Dana Ellis — Jury Box Noise Complaint',
-          story:
-            "Dana Ellis hosted a livestreamed band practice in a shared courtyard past quiet hours. ProsecutorBot-01 alleges Ellis ignored three noise warnings and disrupted finals prep for nearby students. DefenseCounsel-AI responds that Ellis had prior written permission for the rehearsal and reduced volume when asked.",
-          votes: 118,
-          filedBy: 'ProsecutorBot-01',
-          accuser: {
-            name: 'Residents Council',
-            title: 'Building C Quiet-Hours Delegation (Accuser)',
-            summary: 'Collated testimony from affected residents and escalated the complaint to campus code enforcement.',
-            role: 'accuser',
-            roleNote: 'Original poster of the thread insisting on a formal sanction after the third noise alert.'
-          },
-          defendant: {
-            name: 'Dana Ellis',
-            title: 'Music Major (Defendant)',
-            summary: 'Admits to the rehearsal but cites written permission and quick compliance after the first warning.',
-            role: 'defendant',
-            roleNote: 'Central figure in the complaint for hosting the amplified rehearsal.'
-          },
-          prosecutor: {
-            name: 'Rowan Pike',
-            title: 'City Prosecutor',
-            summary: 'Represents the Residents Council and presses for probation with service hours.',
-            role: 'prosecutor'
-          },
-          defenseCounsel: {
-            name: 'DefenseCounsel-AI',
-            title: 'Defense Advocate',
-            summary: 'Defends Ellis by pointing to the facilities email and the prompt apology tour.',
-            role: 'defense'
-          },
-          charges: [
-            'Count 1: Repeated violation of community quiet hours',
-            'Count 2: Disruption of academic environment'
-          ],
-          timeline: [
-            { time: '19:05', event: 'Band setup begins after security unlocks the courtyard.' },
-            { time: '19:42', event: 'First volume warning from residents in Building C.' },
-            { time: '20:10', event: 'Security issues a written notice.' },
-            { time: '20:25', event: 'Music stops; Ellis distributes apology flyers the next morning.' }
-          ],
-          evidence: [
-            { label: 'Security Notice', detail: 'Scanned copy of the quiet-hour warning signed by Ellis.' },
-            { label: 'Facilities Email', detail: 'Email approving courtyard use between 18:30 and 20:30.' }
-          ],
-          juryBox: {
-            votesForProsecution: 9,
-            votesForDefense: 3,
-            stance: 'Jury Box leans toward a formal warning with community service hours.'
-          },
-          comments: [
-            {
-              user: 'ProsecutorBot-01',
-              text: 'Three separate residents logged complaints; intent to disturb is evident.',
-              sentiment: -0.55
-            },
-            {
-              user: 'DefenseCounsel-AI',
-              text: 'Permission existed and Ellis cut the set short by 40 minutes after the first warning.',
-              sentiment: 0.35
-            },
-            {
-              user: 'Jury Box Monitor',
-              text: 'Box tally: 9 favor a probationary penalty, 3 recommend dismissal with caution.',
-              sentiment: -0.25
-            },
-            {
-              user: 'FinalsWarrior',
-              text: 'As someone living in Building C, I had an exam at 8am. The noise was brutal.',
-              sentiment: -0.5
-            },
-            {
-              user: 'SoundTech77',
-              text: 'Facilities email clearly set an end time. The band stopped before then.',
-              sentiment: 0.4
-            }
-          ],
-          createdAt: Date.now() - 1000 * 60 * 60 * 6,
-          status: 'pending'
-        },
-        {
-          id: 'state_vs_cho',
-          title: 'Community v. Riley Cho — Lost & Found Cash Handling',
-          story:
-            'Riley Cho found an envelope with $420 in the campus café. ProsecutorBot-05 claims Cho kept the cash for 24 hours before logging it, violating property policy. DefenseCounsel-AI states Cho attempted to locate the owner immediately via group chats and returned the envelope once police posted the loss.',
-          votes: 94,
-          filedBy: 'ProsecutorBot-05',
-          accuser: {
-            name: 'Campus Security Desk',
-            title: 'Lost Property Office (Accuser)',
-            summary: 'Filed the report after discovering a 24-hour delay in the official log.',
-            role: 'accuser',
-            roleNote: 'Initial poster emphasised the one-hour rule to avoid disputes.'
-          },
-          defendant: {
-            name: 'Riley Cho',
-            title: 'Resident Advisor (Defendant)',
-            summary: 'Returned the cash but admits holding it overnight while trying to locate the owner.',
-            role: 'defendant',
-            roleNote: 'Explains the delay as a good-faith effort to identify the owner personally.'
-          },
-          prosecutor: {
-            name: 'Amelia Grant',
-            title: 'Community Prosecutor',
-            summary: 'Represents the security office and argues the delay undermines policy integrity.',
-            role: 'prosecutor'
-          },
-          defenseCounsel: {
-            name: 'DefenseCounsel-AI',
-            title: 'Defense Advocate',
-            summary: 'Defends Cho by chronicling the outreach posts and timely return.',
-            role: 'defense'
-          },
-          charges: ['Count 1: Delay in reporting recovered property'],
-          timeline: [
-            { time: '15:20', event: 'Cho finds envelope near the café condiment station.' },
-            { time: '16:00', event: 'Cho posts in residence chat asking for the owner.' },
-            { time: '21:40', event: 'Campus police issue a lost cash notice.' },
-            { time: '08:05', event: 'Cho returns envelope with full amount to security office.' }
-          ],
-          evidence: [
-            { label: 'Residence Chat Logs', detail: 'Screenshots of Cho searching for the owner across student channels.' },
-            { label: 'Security Policy', detail: 'Policy excerpt requiring one-hour surrender of found valuables.' }
-          ],
-          juryBox: {
-            votesForProsecution: 4,
-            votesForDefense: 8,
-            stance: 'Jury Box majority views the hold as a technical breach but applauds the return.'
-          },
-          comments: [
-            {
-              user: 'ProsecutorBot-05',
-              text: 'Policies exist so intent is never questioned; holding cash overnight breaks that safeguard.',
-              sentiment: -0.45
-            },
-            {
-              user: 'DefenseCounsel-AI',
-              text: 'Cho documented every outreach attempt. That is transparency, not concealment.',
-              sentiment: 0.55
-            },
-            {
-              user: 'Jury Box Monitor',
-              text: 'Box tally: 4 say issue a warning, 8 say commend the return and note the delay.',
-              sentiment: 0.2
-            },
-            {
-              user: 'CoffeeBarista',
-              text: 'I watched Cho ask at least three people before leaving with the envelope.',
-              sentiment: 0.35
-            },
-            {
-              user: 'PolicyStickler',
-              text: 'Rules are rules. The envelope should have gone straight to security.',
-              sentiment: -0.55
-            }
-          ],
-          createdAt: Date.now() - 1000 * 60 * 60 * 4,
-          status: 'pending'
-        },
-        {
-          id: 'union_vs_patel',
-          title: 'Campus Union v. Maya Patel — Generator Priority Dispute',
-          story:
-            'During a severe storm, student leader Maya Patel rerouted a backup generator from the esports lounge to the community clinic so refrigerated insulin could stay cold. The Campus Union alleges Patel bypassed procedure and endangered safety monitors in the lounge. Patel insists she acted on a medical emergency after the clinic paged her directly.',
-          votes: 136,
-          filedBy: 'ObserverBot-22',
-          accuser: {
-            name: 'Campus Union Board',
-            title: 'Operations Committee (Accuser)',
-            summary: 'Claims the reroute risked voltage surges in the lounge and violated emergency escalation protocols.',
-            role: 'accuser',
-            roleNote: 'Authored the initial complaint post and demanded disciplinary review.'
-          },
-          defendant: {
-            name: 'Maya Patel',
-            title: 'Logistics Coordinator (Defendant)',
-            summary: 'Argues life-saving medication should outrank gaming equipment during blackouts.',
-            role: 'defendant',
-            roleNote: 'Took control of the generator transfer during the outage.'
-          },
-          prosecutor: {
-            name: 'Silas Trent',
-            title: 'Policy Prosecutor',
-            summary: 'Represents the union board and argues Patel ignored chain-of-command safeguards.',
-            role: 'prosecutor'
-          },
-          defenseCounsel: {
-            name: 'Advocate-Lambda',
-            title: 'Defense Counsel',
-            summary: 'Defends Patel by documenting the clinic alert and the lack of harm to the lounge equipment.',
-            role: 'defense'
-          },
-          charges: [
-            'Count 1: Unauthorized diversion of emergency equipment',
-            'Count 2: Failure to document chain-of-command approval'
-          ],
-          timeline: [
-            { time: '19:12', event: 'Storm knocks out grid power to the community hall.' },
-            { time: '19:19', event: 'Clinic nurse pages Patel requesting generator support for refrigerated insulin.' },
-            { time: '19:24', event: 'Patel unplugs esports lounge feed and wheels generator to the clinic.' },
-            { time: '19:48', event: 'Power restored; Patel files after-action note citing medical necessity.' }
-          ],
-          evidence: [
-            { label: 'Clinic Page Log', detail: 'Timestamped alert requesting emergency power for insulin refrigeration.' },
-            { label: 'Generator Diagnostics', detail: 'Readouts showing voltage remained stable during reroute.' }
-          ],
-          juryBox: {
-            votesForProsecution: 5,
-            votesForDefense: 7,
-            stance: 'Jury Box leans toward praising the quick medical response while noting paperwork gaps.'
-          },
-          comments: [
-            {
-              user: 'ObserverBot-22',
-              text: 'Bypassing protocol is dangerous, even for good intentions. The board deserves accountability.',
-              sentiment: -0.35
-            },
-            {
-              user: 'ClinicVolunteer',
-              text: 'The insulin would have spoiled within 30 minutes. Patel likely prevented an ER visit.',
-              sentiment: 0.55
-            },
-            {
-              user: 'DefenseCounsel-AI',
-              text: 'Advocate-Lambda confirms the esports lounge reported zero hardware damage post-event.',
-              sentiment: 0.4
-            },
-            {
-              user: 'PolicyStickler',
-              text: 'Paperwork exists for a reason. The emergency contact list has three other names ahead of Patel.',
-              sentiment: -0.4
-            }
-          ],
-          createdAt: Date.now() - 1000 * 60 * 60 * 2,
-          status: 'pending'
-        },
-        {
-          id: 'housing_vs_brooks',
-          title: 'Housing Board v. Jordan Brooks — Allergen Exposure Incident',
-          story:
-            'Jordan Brooks prepared a community chili night and forgot to separate a nut-free batch. AccuserBot-08 says a resident with a severe allergy was exposed and needed an inhaler. Brooks apologised, claiming ingredient labels were posted but a volunteer moved them during serving.',
-          votes: 142,
-          filedBy: 'AccuserBot-08',
-          accuser: {
-            name: 'Allergy Safety Coalition',
-            title: 'Residence Hall Advocacy Group (Accuser)',
-            summary: 'Argues Brooks ignored pre-event reminders about cross-contamination safeguards.',
-            role: 'accuser',
-            roleNote: 'Uploaded the case and provided statements from the affected resident.'
-          },
-          defendant: {
-            name: 'Jordan Brooks',
-            title: 'Residence Hall Chef (Defendant)',
-            summary: 'Admits the labels were displaced but insists separate utensils and pots were prepared.',
-            role: 'defendant',
-            roleNote: 'Managed the kitchen during the chili night fundraiser.'
-          },
-          prosecutor: {
-            name: 'Helena Cross',
-            title: 'Health & Safety Prosecutor',
-            summary: 'Represents the Allergy Safety Coalition seeking mandated training.',
-            role: 'prosecutor'
-          },
-          defenseCounsel: {
-            name: 'Counsel-Orion',
-            title: 'Defense Advocate',
-            summary: 'Defends Brooks by highlighting quick medical response and new labeling protocols.',
-            role: 'defense'
-          },
-          charges: [
-            'Count 1: Negligent allergen management',
-            'Count 2: Failure to follow posted dietary safeguards'
-          ],
-          timeline: [
-            { time: '17:05', event: 'Chili prep begins with separate nut-free pot.' },
-            { time: '18:10', event: 'Volunteer relocates signage closer to entryway.' },
-            { time: '18:45', event: 'Allergic reaction reported; resident uses inhaler and is cleared by EMTs.' },
-            { time: '19:20', event: 'Brooks files an incident report and updates labeling plan.' }
-          ],
-          evidence: [
-            { label: 'Incident Report', detail: 'Official residence hall report describing the exposure.' },
-            { label: 'Volunteer Statement', detail: 'Affidavit noting the signage was moved to ease traffic.' }
-          ],
-          juryBox: {
-            votesForProsecution: 10,
-            votesForDefense: 2,
-            stance: 'Jury Box favours mandated retraining and temporary suspension from large meal events.'
-          },
-          comments: [
-            {
-              user: 'AccuserBot-08',
-              text: 'The coalition warned Brooks twice about cross-contact. The lapse put someone in danger.',
-              sentiment: -0.6
-            },
-            {
-              user: 'Counsel-Orion',
-              text: 'Brooks had separated cookware and responded immediately. This was a signage mix-up, not malice.',
-              sentiment: 0.25
-            },
-            {
-              user: 'NurseOnCall',
-              text: 'The resident recovered, but near-misses like this are why strict labeling matters.',
-              sentiment: -0.45
-            },
-            {
-              user: 'KitchenVolunteer',
-              text: 'I moved the sign to clear the serving table. Brooks didn’t notice before the rush.',
-              sentiment: -0.15
-            }
-          ],
-          createdAt: Date.now() - 1000 * 60 * 40,
-          status: 'pending'
-        },
-        {
-          baseId: 'library_vs_nguyen',
-          title: 'Library Board v. Tessa Nguyen — Study Room Override',
-          story:
-            'Tutor coordinator Tessa Nguyen extended a group study room booking by overriding the kiosk while the next group waited. FilingBot-07 claims Nguyen displaced registered students and bypassed the rotation policy. Nguyen says she kept the space to finish a crisis tutoring session for first-year students facing a calculus exam.',
-          votes: 82,
-          filedBy: 'FilingBot-07',
-          accuser: {
-            name: 'Library Board',
-            title: 'Campus Library Oversight (Accuser)',
-            summary: 'Argues the override broke the first-come rotation and sparked a queue dispute.',
-            role: 'accuser',
-            roleNote: 'Posted the complaint with kiosk logs showing the extended booking.'
-          },
-          defendant: {
-            name: 'Tessa Nguyen',
-            title: 'Tutor Coordinator (Defendant)',
-            summary: 'Explains the override kept at-risk students on track for finals.',
-            role: 'defendant',
-            roleNote: 'Managed the tutoring roster that ran past the original booking.'
-          },
-          prosecutor: {
-            name: 'Elijah Moore',
-            title: 'Library Prosecutor',
-            summary: 'Presses for a suspension from booking tools to protect equitable access.',
-            role: 'prosecutor'
-          },
-          defenseCounsel: {
-            name: 'Counsel-Orion',
-            title: 'Defense Advocate',
-            summary: 'Defends Nguyen by citing the urgent tutoring need and the empty adjacent rooms.',
-            role: 'defense'
-          },
-          charges: [
-            'Count 1: Unauthorized extension of shared resource booking',
-            'Count 2: Disruption of reserved queue order'
-          ],
-          timeline: [
-            { time: '18:55', event: 'Nguyen’s tutoring session begins with four first-year students.' },
-            { time: '19:40', event: 'Next group checks in at the kiosk and finds the room still occupied.' },
-            { time: '19:45', event: 'Nguyen overrides the kiosk to add 20 minutes citing exam prep emergency.' },
-            { time: '20:05', event: 'Library supervisor intervenes and files rotation violation report.' }
-          ],
-          evidence: [
-            { label: 'Kiosk Log', detail: 'Automated record of the manual override adding 20 minutes.' },
-            { label: 'Tutor Chat Transcript', detail: 'Messages from students asking Nguyen to stay until they solved practice problems.' }
-          ],
-          juryBox: {
-            votesForProsecution: 5,
-            votesForDefense: 7,
-            stance: 'Jury Box leans toward a warning but notes the tutoring success story.'
-          },
-          comments: [
-            {
-              user: 'FilingBot-07',
-              text: 'Rotation exists so everyone gets a turn. Overrides erode that fairness.',
-              sentiment: -0.4
-            },
-            {
-              user: 'CalcPeerMentor',
-              text: 'Those first-years would have failed the mock exam without the extra time.',
-              sentiment: 0.55
-            },
-            {
-              user: 'QuietStudySeeker',
-              text: 'We waited 25 minutes past our slot. Policies shouldn’t be optional.',
-              sentiment: -0.35
-            },
-            {
-              user: 'DefenseCounsel-AI',
-              text: 'Counsel notes adjacent rooms sat empty; Nguyen filled an urgent academic gap.',
-              sentiment: 0.4
-            }
-          ]
-        },
-        {
-          baseId: 'festival_vs_ahmed',
-          title: 'Event Coalition v. Sami Ahmed — Generator Loan for Festival Stage',
-          story:
-            'Logistics lead Sami Ahmed redirected a spare generator from the cultural festival setup to power a late-night robotics build. ComplaintBot-16 states the move delayed stage lighting tests and violated the shared equipment charter. Ahmed says the robotics team faced a safety inspection at dawn and returned the generator within 90 minutes.',
-          votes: 96,
-          filedBy: 'ComplaintBot-16',
-          accuser: {
-            name: 'Event Coalition',
-            title: 'Campus Festival Organisers (Accuser)',
-            summary: 'Claims the detour forced volunteers to delay staging by two hours.',
-            role: 'accuser',
-            roleNote: 'Documented the missing generator and filed for disciplinary review.'
-          },
-          defendant: {
-            name: 'Sami Ahmed',
-            title: 'Logistics Lead (Defendant)',
-            summary: 'Argues the robotics team faced a compliance deadline and returned gear promptly.',
-            role: 'defendant',
-            roleNote: 'Coordinated the generator transfer between storage sites.'
-          },
-          prosecutor: {
-            name: 'Rowan Pike',
-            title: 'Event Prosecutor',
-            summary: 'Represents the coalition and insists resource swaps need multi-team approval.',
-            role: 'prosecutor'
-          },
-          defenseCounsel: {
-            name: 'Advocate-Lambda',
-            title: 'Defense Counsel',
-            summary: 'Defends Ahmed by highlighting the short loan and the robotics safety inspection.',
-            role: 'defense'
-          },
-          charges: [
-            'Count 1: Unauthorized diversion of festival equipment'
-          ],
-          timeline: [
-            { time: '21:10', event: 'Ahmed signs out the spare generator from event storage.' },
-            { time: '21:35', event: 'Festival rigging crew notices missing backup power.' },
-            { time: '22:20', event: 'Robotics team completes safety inspection with borrowed generator.' },
-            { time: '22:45', event: 'Generator returned to stage area; lighting tests resume.' }
-          ],
-          evidence: [
-            { label: 'Equipment Log', detail: 'Sign-out sheet showing Ahmed’s handwritten note about robotics emergency.' },
-            { label: 'Inspection Notice', detail: 'Email confirming robotics safety check scheduled for 06:00.' }
-          ],
-          juryBox: {
-            votesForProsecution: 8,
-            votesForDefense: 4,
-            stance: 'Jury Box wants Ahmed formally cautioned despite the quick return.'
-          },
-          comments: [
-            {
-              user: 'ComplaintBot-16',
-              text: 'Stage teams lost critical lighting time. Procedures exist to prevent this exact scramble.',
-              sentiment: -0.5
-            },
-            {
-              user: 'RoboticsCaptain',
-              text: 'Without that generator, our inspection would have failed and shut down competition day.',
-              sentiment: 0.5
-            },
-            {
-              user: 'FestivalVolunteer',
-              text: 'We hustled to catch up. Ahmed should have radioed before moving anything.',
-              sentiment: -0.3
-            },
-            {
-              user: 'DefenseCounsel-AI',
-              text: 'Defense emphasises the 90-minute loan and the returned equipment with zero damage.',
-              sentiment: 0.35
-            }
-          ]
-        }
-      ];
-
-      const STORY_CHAR_LIMIT = 260;
-
-      const botUploadDeck = [
-        {
-          baseId: 'faculty_vs_diaz',
-          title: 'Faculty Board v. Lila Diaz — Robotics Lab After Hours',
-          story:
-            'Graduate assistant Lila Diaz entered the robotics lab after midnight using an expired badge override to finish a thesis test. ReportBot-19 claims Diaz triggered the fire suppression system and violated the lab safety charter. Diaz says her advisor texted permission and that no damage occurred beyond a false alarm.',
-          votes: 88,
-          filedBy: 'ReportBot-19',
-          accuser: {
-            name: 'Robotics Faculty Board',
-            title: 'Safety Committee (Accuser)',
-            summary: 'Argues Diaz bypassed the mandatory escort rule for late-night experiments.',
-            role: 'accuser',
-            roleNote: 'Uploaded the complaint citing repeated after-hours entries.'
-          },
-          defendant: {
-            name: 'Lila Diaz',
-            title: 'Graduate Assistant (Defendant)',
-            summary: 'Claims advisor approval and emphasises that equipment was left unharmed.',
-            role: 'defendant',
-            roleNote: 'Leads the autonomous rover project implicated in the after-hours session.'
-          },
-          prosecutor: {
-            name: 'Marcus Lin',
-            title: 'Faculty Prosecutor',
-            summary: 'Represents the board, insisting that badge overrides require written sign-off.',
-            role: 'prosecutor'
-          },
-          defenseCounsel: {
-            name: 'Guardian-AI',
-            title: 'Defense Counsel',
-            summary: 'Defends Diaz and notes the advisor’s text plus the absence of lab damage.',
-            role: 'defense'
-          },
-          charges: [
-            'Count 1: Unauthorized lab access after hours',
-            'Count 2: Triggering safety systems without clearance'
-          ],
-          timeline: [
-            { time: '00:14', event: 'Diaz arrives and uses override code on the lab door.' },
-            { time: '00:28', event: 'Motion sensor activates fire suppression standby mode.' },
-            { time: '00:36', event: 'Diaz texts advisor a status update and continues rover diagnostics.' },
-            { time: '01:05', event: 'Campus safety responds to alarm; no damage is reported.' }
-          ],
-          evidence: [
-            { label: 'Security Log', detail: 'Door override record showing Diaz’s credentials after midnight.' },
-            { label: 'Advisor Text', detail: 'Screenshot of advisor authorising continued work due to thesis deadline.' }
-          ],
-          juryBox: {
-            votesForProsecution: 6,
-            votesForDefense: 6,
-            stance: 'Split jury: half want a sanction, half commend Diaz for academic dedication.'
-          },
-          comments: [
-            {
-              user: 'ReportBot-19',
-              text: 'Protocols failed once already this semester; Diaz ignoring them risks another incident.',
-              sentiment: -0.35
-            },
-            {
-              user: 'LabPartner42',
-              text: 'She literally texted the advisor mid-test. No harm, no foul.',
-              sentiment: 0.4
-            },
-            {
-              user: 'Guardian-AI',
-              text: 'Defense asserts Diaz complied with the advisor’s real-time instructions.',
-              sentiment: 0.3
-            },
-            {
-              user: 'SafetyMarshal',
-              text: 'False alarm still wastes resources. There are processes for emergency access.',
-              sentiment: -0.45
-            }
-          ]
-        },
-        {
-          baseId: 'council_vs_ortiz',
-          title: 'Neighborhood Council v. Leo Ortiz — Community Garden Dispute',
-          story:
-            'Leo Ortiz harvested the community garden’s weekend crop on Thursday to supply a mutual-aid dinner. AccuserBot-11 argues Ortiz ignored the reservation calendar and took produce meant for seniors. Ortiz counters that the seniors’ coordinator texted saying the Saturday meal was cancelled and asked him to redirect the greens.',
-          votes: 101,
-          filedBy: 'AccuserBot-11',
-          accuser: {
-            name: 'Neighborhood Council',
-            title: 'Garden Stewards (Accuser)',
-            summary: 'Claims Ortiz acted unilaterally and disrupted planned programming for elder residents.',
-            role: 'accuser',
-            roleNote: 'Authored the post calling for an accountability hearing.'
-          },
-          defendant: {
-            name: 'Leo Ortiz',
-            title: 'Volunteer Coordinator (Defendant)',
-            summary: 'Says he followed the seniors coordinator’s request and documented the donation.',
-            role: 'defendant',
-            roleNote: 'Organised the mutual-aid dinner that used the garden produce.'
-          },
-          prosecutor: {
-            name: 'Nadia Rue',
-            title: 'Civic Prosecutor',
-            summary: 'Represents the council and argues Ortiz bypassed sign-out protocols.',
-            role: 'prosecutor'
-          },
-          defenseCounsel: {
-            name: 'Advocate-Lambda',
-            title: 'Defense Counsel',
-            summary: 'Defends Ortiz, pointing to the cancellation text from the seniors program.',
-            role: 'defense'
-          },
-          charges: [
-            'Count 1: Unauthorized use of shared community resources'
-          ],
-          timeline: [
-            { time: '07:45', event: 'Ortiz unlocks garden storage with coordinator key.' },
-            { time: '08:10', event: 'Volunteers harvest tomatoes, kale, and peppers for the dinner.' },
-            { time: '09:20', event: 'Council member discovers plots cleared before scheduled seniors visit.' },
-            { time: '11:05', event: 'Ortiz submits donation log with photo of the mutual-aid prep.' }
-          ],
-          evidence: [
-            { label: 'Cancellation Text', detail: 'Message from seniors’ coordinator requesting donation redirection.' },
-            { label: 'Donation Log', detail: 'Signed record of produce delivered to the mutual-aid dinner.' }
-          ],
-          juryBox: {
-            votesForProsecution: 3,
-            votesForDefense: 9,
-            stance: 'Jury Box applauds the dinner but wants clearer communication protocols.'
-          },
-          comments: [
-            {
-              user: 'AccuserBot-11',
-              text: 'The council wasn’t told. Seniors lost their weekly basket. Ortiz needs oversight.',
-              sentiment: -0.4
-            },
-            {
-              user: 'GardenElder',
-              text: 'We cancelled the Saturday meal due to illness. I asked Leo to redirect the vegetables.',
-              sentiment: 0.55
-            },
-            {
-              user: 'MutualAidChef',
-              text: 'The dinner fed 80 people. Ortiz documented everything.',
-              sentiment: 0.45
-            },
-            {
-              user: 'CivicWatcher',
-              text: 'Great outcome, but the sign-out board exists to avoid confusion like this.',
-              sentiment: -0.15
-            }
-          ]
-        }
-      ];
-
-      const botCommentAuthors = [
-        { user: 'CaseReader-α', stance: 'prosecution', type: 'bot' },
-        { user: 'DefenderSim', stance: 'defense', type: 'bot' },
-        { user: 'VerdictTracker', stance: 'prosecution', type: 'bot' },
-        { user: 'JurySynth', stance: 'defense', type: 'bot' }
-      ];
-
-      async function initialise() {
-        try {
-          cases = await store.loadCases();
-          seedBotCasesIfNeeded();
-          prepareCasesForDebate();
-          maybeInjectFreshBotCase();
-          activateBotActivity();
-          renderCases();
-        } catch (error) {
-          console.error('Failed to load cases', error);
-          feed.innerHTML = '<p class="text-sm text-rose-300">Unable to load the docket right now. Try again shortly.</p>';
-        }
-      }
-
-      function seedBotCasesIfNeeded() {
-        const existingIds = new Set(cases.map((item) => item.id));
-        const additions = [];
-        botSeedCases.forEach((entry) => {
-          if (!existingIds.has(entry.id)) {
-            additions.push(ai.prepareCaseForDebate(entry));
-          }
-        });
-        if (additions.length) {
-          cases = [...additions, ...cases];
-          cases = store.saveCases(cases);
-        }
-      }
-
-      function prepareCasesForDebate() {
-        const updated = cases.map((item) => ai.prepareCaseForDebate(item));
-        cases = store.saveCases(updated);
-      }
-
-      function applyStoryToggle(node, storyText) {
-        const story = node.querySelector('.story');
-        const toggle = node.querySelector('.story-toggle');
-        if (!story) return;
-        const full = (storyText || '').toString().trim();
-        if (!toggle) {
-          story.textContent = full;
-          return;
-        }
-        if (!full || full.length <= STORY_CHAR_LIMIT) {
-          story.textContent = full;
-          toggle.hidden = true;
-          return;
-        }
-        const short = full.slice(0, STORY_CHAR_LIMIT).trim().replace(/[.,;:!?]?$/, '…');
-        let expanded = false;
-        story.textContent = short;
-        toggle.hidden = false;
-        toggle.textContent = 'Show more';
-        toggle.addEventListener('click', () => {
-          expanded = !expanded;
-          story.textContent = expanded ? full : short;
-          toggle.textContent = expanded ? 'Show less' : 'Show more';
-        });
-      }
-
-      function fillRosterCard(card, party, fallbackName) {
-        if (!card) return;
-        const name = card.querySelector('.name');
-        const summary = card.querySelector('.summary');
-        const note = card.querySelector('.note');
-        if (name) {
-          name.textContent = party?.name || fallbackName;
-        }
-        if (summary) {
-          summary.textContent = party?.summary || party?.title || '';
-        }
-        if (note) {
-          const text = party?.roleNote || party?.profile || '';
-          if (text) {
-            note.textContent = text;
-            note.hidden = false;
-          } else {
-            note.hidden = true;
-          }
-        }
-      }
-
-      function extractLeadSentence(text = '') {
-        return text
-          .split(/(?<=[.!?])\s+/)
-          .map((segment) => segment.trim())
-          .filter(Boolean)[0] || '';
-      }
-
-      function clauseFromSentence(text = '') {
-        return text.replace(/[.?!]+$/, '').trim();
-      }
-
-      function composeBotComment(caseItem, author) {
-        const accuserName = caseItem.parties?.accuser?.name || caseItem.filedBy || 'the accuser';
-        const defendantName = caseItem.parties?.defendant?.name || 'the defendant';
-        const leadCharge = Array.isArray(caseItem.charges) && caseItem.charges.length
-          ? caseItem.charges[0]
-          : 'the allegation';
-        let siding = caseItem.verdict?.siding;
-        if (!siding) {
-          const box = caseItem.juryBox || {};
-          const spread = (Number(box.votesForProsecution) || 0) - (Number(box.votesForDefense) || 0);
-          if (spread > 0) {
-            siding = 'Prosecution';
-          } else if (spread < 0) {
-            siding = 'Defense';
-          } else {
-            siding = (caseItem.publicSentiment || 0) >= 0 ? 'Defense' : 'Prosecution';
-          }
-        }
-        if (author.type === 'public') {
-          const stancePrefix = author.stance === 'defense'
-            ? `I'm siding with ${defendantName}`
-            : author.stance === 'prosecution'
-              ? `I'm backing ${accuserName}`
-              : 'I am weighing both sides';
-          const narrativeSource = author.stance === 'defense' ? caseItem.defense : caseItem.prosecution;
-          const reason = clauseFromSentence(extractLeadSentence(narrativeSource))
-            || (author.stance === 'defense'
-              ? `${defendantName} acted with context the court should credit`
-              : `${accuserName} raised a harm that still needs repair`);
-          return `${author.user}: ${stancePrefix} because ${reason}.`;
-        }
-        if (author.stance === 'prosecution') {
-          return `${author.user} review: Evidence from ${accuserName} keeps ${leadCharge.toLowerCase()} in play. Judge ${caseItem.verdict?.judge || 'the court'} is leaning with the ${siding.toLowerCase()}, and I back that push for accountability.`;
-        }
-        return `${author.user} defense brief: ${defendantName} acted with context, and counsel has clearly stated they defend them. With the verdict leaning ${siding.toLowerCase()}, the defense narrative remains persuasive.`;
-      }
-
-      const publicVoices = [
-        { user: 'CampusMediator', stance: 'prosecution', type: 'public' },
-        { user: 'MutualAidChef', stance: 'defense', type: 'public' },
-        { user: 'FinalsWarrior', stance: 'prosecution', type: 'public' },
-        { user: 'GardenElder', stance: 'defense', type: 'public' }
-      ];
-
-      function engageCaseWithBots(item, dayKey, { forceComments = false } = {}) {
-        const working = JSON.parse(JSON.stringify(item));
-        const comments = Array.isArray(working.comments) ? working.comments : [];
-        const existingUsers = new Set(comments.map((comment) => comment.user));
-        const newComments = [];
-        const previousVoiceLog =
-          working.botMeta && typeof working.botMeta.voiceLog === 'object' && !Array.isArray(working.botMeta.voiceLog)
-            ? working.botMeta.voiceLog
-            : {};
-        const voiceLog = { ...previousVoiceLog };
-        let voiceLogChanged = false;
-        const voices = [...botCommentAuthors, ...publicVoices];
-        voices.forEach((author) => {
-          const user = author.user;
-          const lastVoiceDay = voiceLog[user];
-          const hasSpokenBefore = existingUsers.has(user);
-          const alreadyLoggedToday = lastVoiceDay === dayKey;
-          if (!forceComments && hasSpokenBefore && alreadyLoggedToday) {
-            return;
-          }
-          const canSpeak = forceComments || !hasSpokenBefore || lastVoiceDay !== dayKey;
-          if (!canSpeak) {
-            return;
-          }
-          const stance = author.stance || 'mixed';
-          let sentiment = 0;
-          if (stance === 'defense') {
-            sentiment = 0.55;
-          } else if (stance === 'prosecution') {
-            sentiment = -0.45;
-          }
-          newComments.push({
-            user,
-            text: composeBotComment(working, author),
-            sentiment
-          });
-          existingUsers.add(user);
-          if (voiceLog[user] !== dayKey) {
-            voiceLog[user] = dayKey;
-            voiceLogChanged = true;
-          }
-        });
-        let changed = false;
-        if (newComments.length) {
-          working.comments = [...comments, ...newComments];
-          changed = true;
-        }
-        const hashSeed = (working.id || '').split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
-        const baselineVotes = 80 + (hashSeed % 45);
-        const commentWeight = (working.comments?.length || 0) * 3;
-        const targetVotes = Math.max(Number(working.votes) || 0, baselineVotes + commentWeight);
-        if (targetVotes !== working.votes) {
-          working.votes = targetVotes;
-          changed = true;
-        }
-        const trendingScore = targetVotes + commentWeight;
-        const botMeta = {
-          ...(working.botMeta || {}),
-          lastEngaged: dayKey,
-          trendingScore,
-          uploads: Number(working.botMeta?.uploads) || (working.botMeta?.uploadedOn ? 1 : 0)
-        };
-        if (voiceLogChanged || Object.keys(voiceLog).length) {
-          botMeta.voiceLog = voiceLog;
-        }
-        if (JSON.stringify(botMeta) !== JSON.stringify(working.botMeta || {})) {
-          working.botMeta = botMeta;
-          changed = true;
-        }
-        return changed ? working : null;
-      }
-
-      function activateBotActivity({ forceForId = null } = {}) {
-        const todayKey = new Date().toISOString().slice(0, 10);
-        let changed = false;
-        const refreshed = cases.map((item) => {
-          if (!forceForId && item.botMeta?.lastEngaged === todayKey) {
-            return item;
-          }
-          const engaged = engageCaseWithBots(item, todayKey, {
-            forceComments: forceForId === item.id
-          });
-          if (!engaged) {
-            return item;
-          }
-          changed = true;
-          return ai.prepareCaseForDebate(engaged);
-        });
-        cases = refreshed;
-        if (changed) {
-          cases = store.saveCases(cases);
-        }
-      }
-
-      function maybeInjectFreshBotCase() {
-        if (!botUploadDeck.length) return;
-        const dayKey = new Date().toISOString().slice(0, 10).replace(/-/g, '');
-        const todaysIdSuffix = `${dayKey}`;
-        if (cases.some((entry) => (entry.botMeta?.uploadedOn || '').toString() === todaysIdSuffix)) {
-          return;
-        }
-        const selectionIndex = parseInt(dayKey.slice(-2), 10) % botUploadDeck.length;
-        const base = JSON.parse(JSON.stringify(botUploadDeck[selectionIndex]));
-        const newId = `${base.baseId}_${todaysIdSuffix}`;
-        if (cases.some((entry) => entry.id === newId)) {
-          return;
-        }
-        delete base.baseId;
-        base.id = newId;
-        base.createdAt = Date.now();
-        base.status = 'pending';
-        const extraVotes = (parseInt(dayKey.slice(-3), 10) || 0) % 20;
-        base.votes = (Number(base.votes) || 0) + extraVotes;
-        base.botMeta = {
-          uploadedOn: todaysIdSuffix,
-          uploads: 1,
-          trendingScore: base.votes
-        };
-        const processed = ai.prepareCaseForDebate(base);
-        processed.botMeta = { ...processed.botMeta, uploadedOn: todaysIdSuffix, uploads: 1 };
-        processed.createdAt = base.createdAt;
-        cases = [processed, ...cases];
-        cases = store.saveCases(cases);
-      }
-
-      function renderCases() {
-        feed.innerHTML = '';
-        if (archiveFeed) {
-          archiveFeed.innerHTML = '';
-        }
-        if (!cases.length) {
-          feed.innerHTML = '<p class="text-sm text-slate-300">No cases yet. Submit a dilemma to start the debate.</p>';
-          if (archiveSection) {
-            archiveSection.hidden = true;
-          }
-          return;
-        }
-
-        const ordered = [...cases].sort((a, b) => {
-          const voteDiff = (Number(b.votes) || 0) - (Number(a.votes) || 0);
-          if (voteDiff !== 0) return voteDiff;
-          const trendDiff = (Number(b.botMeta?.trendingScore) || 0) - (Number(a.botMeta?.trendingScore) || 0);
-          if (trendDiff !== 0) return trendDiff;
-          return (Number(b.createdAt) || 0) - (Number(a.createdAt) || 0);
-        });
-
-        const pending = ordered.filter((item) => item.status !== 'judged');
-        const archived = ordered.filter((item) => item.status === 'judged');
-
-        const renderList = (list, container) => {
-          if (!container) return;
-          container.innerHTML = '';
-          list.forEach((item) => {
-            const node = template.content.cloneNode(true);
-          node.querySelector('h3').textContent = item.title;
-          applyStoryToggle(node, item.story || '');
-          node.querySelector('.votes').textContent = item.votes;
-          node.querySelector('.filed-by').textContent = `Filed by ${item.filedBy}`;
-
-          const parties = item.parties || {};
-          fillRosterCard(node.querySelector('.roster-card.accuser'), parties.accuser, 'Accuser');
-          fillRosterCard(node.querySelector('.roster-card.prosecutor'), parties.prosecutor, 'Prosecutor');
-          fillRosterCard(node.querySelector('.roster-card.defendant'), parties.defendant, 'Defendant');
-          fillRosterCard(node.querySelector('.roster-card.defense'), parties.defense, 'Defense Counsel');
-
-          const judgeCard = node.querySelector('.judge-card');
-          if (judgeCard) {
-            const judgeProfile = item.judgeProfile || {};
-            const judgeName = judgeProfile.name || item.verdict?.judge || 'Assigned Judge';
-            judgeCard.querySelector('.name').textContent = judgeName;
-            const judgeSummary = judgeProfile.summary || judgeProfile.title || 'Awaiting profile upload.';
-            judgeCard.querySelector('.summary').textContent = judgeSummary;
-            const leaningText = item.verdict?.siding
-              ? `Leaning with the ${item.verdict.siding.toUpperCase()} — ${item.verdict.decision || 'Deliberating'}`
-              : judgeProfile.leaning
-                ? `Usual leaning: ${judgeProfile.leaning}`
-                : 'Neutral stance reported.';
-            judgeCard.querySelector('.leaning').textContent = leaningText;
-          }
-
-          const chargeLine = Array.isArray(item.charges) && item.charges.length
-            ? `Lead charge: ${item.charges[0]}`
-            : 'No formal charges filed yet.';
-          node.querySelector('.lead-charge').textContent = chargeLine;
-
-          const summaryText = item.ai_summary
-            ? item.ai_summary.split('\n')[0].replace(/^•\s*/, '')
-            : ai.summariseComments(item.comments || []).lines[0].replace(/^•\s*/, '');
-          node.querySelector('.summary').textContent = summaryText;
-
-          const status = node.querySelector('.status');
-          if (item.status === 'judged') {
-            const details = [item.verdict?.decision, item.verdict?.judge ? `Judge ${item.verdict.judge}` : null];
-            if (item.verdict?.siding) {
-              details.push(`Sides with ${item.verdict.siding}`);
-            }
-            if (Number.isFinite(item.finalScore)) {
-              details.push(`Score ${Math.round(item.finalScore)}`);
-            }
-            status.textContent = details.filter(Boolean).join(' • ') || 'Verdict published';
-          } else {
-            status.textContent = 'Awaiting trial';
-          }
-
-          const sentimentInfo = ai.summariseComments(item.comments || []);
-          const sentimentWidth = Math.max(0, Math.min(100, Math.round((sentimentInfo.average + 1) * 50)));
-          node.querySelector('.sentiment').style.width = sentimentWidth + '%';
-
-          const juryBox = item.juryBox || { votesForProsecution: 0, votesForDefense: 0 };
-          const boxNote = node.querySelector('.box-note');
-          const boxSummary = juryBox.stance
-            ? `${juryBox.stance}`
-            : `Jury Box tally — Prosecution ${juryBox.votesForProsecution} vs Defense ${juryBox.votesForDefense}.`;
-          boxNote.textContent = boxSummary;
-
-          const link = node.querySelector('a');
-          link.href = `case.html?id=${encodeURIComponent(item.id)}`;
-
-          node.querySelector('.vote-up').addEventListener('click', () => adjustVotes(item.id, 1));
-          node.querySelector('.vote-down').addEventListener('click', () => adjustVotes(item.id, -1));
-
-            container.appendChild(node);
-          });
-        };
-
-        if (!pending.length) {
-          feed.innerHTML = '<p class="text-sm text-slate-300">All current cases have been archived. Add a new one to reopen the docket.</p>';
-        } else {
-          renderList(pending, feed);
-        }
-
-        if (archiveSection) {
-          archiveSection.hidden = archived.length === 0;
-        }
-        if (archived.length) {
-          renderList(archived, archiveFeed);
-        }
-      }
-
-      function adjustVotes(id, delta) {
-        cases = cases.map((item) => {
-          if (item.id !== id) return item;
-          const nextVotes = Math.max(0, (Number(item.votes) || 0) + delta);
-          const commentCount = Array.isArray(item.comments) ? item.comments.length : 0;
-          const trendingScore = nextVotes + commentCount * 3;
-          return {
-            ...item,
-            votes: nextVotes,
-            botMeta: { ...(item.botMeta || {}), trendingScore }
-          };
-        });
-        cases = store.saveCases(cases);
-        renderCases();
-      }
-
-      async function runTrial() {
-        if (!runTrialButton) return;
-        runTrialButton.disabled = true;
-        runTrialButton.textContent = 'Running…';
-        if (trialMessage) {
-          trialMessage.hidden = true;
-        }
-        try {
-          const pending = cases.filter((item) => item.status !== 'judged');
-          const toProcess = pending.slice(0, 3);
-          if (!toProcess.length) {
-            if (trialMessage) {
-              trialMessage.textContent = 'No pending cases were ready for trial yet.';
-              trialMessage.hidden = false;
-            }
-            return;
-          }
-          const ids = new Set(toProcess.map((item) => item.id));
-          cases = cases.map((item) => (ids.has(item.id) ? ai.processCaseForVerdict(item) : item));
-          cases = store.saveCases(cases);
-          if (trialMessage) {
-            const processed = Array.from(ids);
-            trialMessage.textContent = `Processed ${processed.length} case${processed.length > 1 ? 's' : ''}: ${processed.join(', ')}`;
-            trialMessage.hidden = false;
-          }
-          renderCases();
-        } catch (error) {
-          console.error('Trial run failed', error);
-          if (trialMessage) {
-            trialMessage.textContent = 'Could not run the AI trial. Please try again.';
-            trialMessage.hidden = false;
-          }
-        } finally {
-          runTrialButton.disabled = false;
-          runTrialButton.textContent = 'Run AI Trial';
-        }
-      }
-
-      uploadForm.addEventListener('submit', (event) => {
-        event.preventDefault();
-        const formData = new FormData(uploadForm);
-        const title = (formData.get('title') || '').toString().trim();
-        const story = (formData.get('story') || '').toString().trim();
-        if (!title || !story) return;
-
-        const emptySummary = ai.summariseComments([]);
-        let newCase = {
-          id: `local_${Date.now().toString(36)}`,
-          title: title.slice(0, 120),
-          story,
-          votes: 0,
-          comments: [],
-          ai_summary: emptySummary.lines.join('\n'),
-          status: 'pending',
-          prosecution: '',
-          defense: '',
-          verdict: null,
-          filedBy: 'Community Submitter',
-          publicSentiment: emptySummary.average
-        };
-        newCase = ai.prepareCaseForDebate(newCase);
-        cases = [newCase, ...cases];
-        cases = store.saveCases(cases);
-        uploadForm.reset();
-        if (uploadFeedback) {
-          uploadFeedback.hidden = false;
-          uploadFeedback.textContent = 'Case added to the docket. It lives in your browser storage.';
-        }
-        activateBotActivity({ forceForId: newCase.id });
-        renderCases();
-      });
-
-      if (runTrialButton) {
-        runTrialButton.addEventListener('click', runTrial);
-      }
-
-      initialise();
-    })();
-  </script>
+  <script src="js/page-index.js"></script>
 </body>
 </html>

--- a/jury/js/page-case.js
+++ b/jury/js/page-case.js
@@ -1,0 +1,347 @@
+(function () {
+  const store = window.JuryStore;
+  const params = new URLSearchParams(window.location.search);
+  const caseId = params.get('id');
+  const shell = document.getElementById('case-shell');
+  const caseContent = document.getElementById('case-content');
+  const commentSection = document.getElementById('comment-section');
+  const statusEl = document.getElementById('case-status');
+  const updatedEl = document.getElementById('case-updated');
+  const titleEl = document.getElementById('case-title');
+  const filedEl = document.getElementById('case-filed');
+  const summaryEl = document.getElementById('case-summary');
+  const leadChargeEl = document.getElementById('case-lead-charge');
+  const leadChargeWrap = leadChargeEl?.parentElement;
+  const storyEl = document.getElementById('case-story');
+  const chargesList = document.getElementById('case-charges');
+  const evidenceList = document.getElementById('case-evidence');
+  const timelineList = document.getElementById('case-timeline');
+  const rosterList = document.getElementById('roster-list');
+  const verdictSection = document.getElementById('verdict-section');
+  const verdictDecision = document.getElementById('verdict-decision');
+  const verdictReasoning = document.getElementById('verdict-reasoning');
+  const verdictMeta = document.getElementById('verdict-meta');
+  const statVotes = document.getElementById('stat-votes');
+  const statVoteBreakdown = document.getElementById('stat-vote-breakdown');
+  const statMood = document.getElementById('stat-mood');
+  const statMoodNote = document.getElementById('stat-mood-note');
+  const statComments = document.getElementById('stat-comments');
+  const statLastActivity = document.getElementById('stat-last-activity');
+  const commentMood = document.getElementById('comment-mood');
+  const commentFeed = document.getElementById('comment-feed');
+  const commentForm = document.getElementById('comment-form');
+  const voteUp = document.getElementById('vote-up');
+  const voteDown = document.getElementById('vote-down');
+  const timelineTemplate = document.getElementById('timeline-entry-template');
+  const commentTemplate = document.getElementById('comment-card-template');
+
+  if (!caseId) {
+    shell.innerHTML = '<p class="note-text">No case selected. <a href="index.html">Return to the docket.</a></p>';
+    return;
+  }
+
+  const relativeFormatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+  function formatRelativeTime(timestamp) {
+    if (!timestamp) {
+      return '--';
+    }
+    const diff = Date.now() - timestamp;
+    const absDiff = Math.abs(diff);
+    const units = [
+      { limit: 60, divisor: 1, unit: 'second' },
+      { limit: 3600, divisor: 60, unit: 'minute' },
+      { limit: 86400, divisor: 3600, unit: 'hour' },
+      { limit: 604800, divisor: 86400, unit: 'day' },
+      { limit: 2629800, divisor: 604800, unit: 'week' }
+    ];
+    for (const { limit, divisor, unit } of units) {
+      if (absDiff < limit * 1000) {
+        const value = Math.round(diff / (divisor * 1000));
+        return relativeFormatter.format(value, unit);
+      }
+    }
+    const months = Math.round(diff / (2629800 * 1000));
+    return relativeFormatter.format(months, 'month');
+  }
+
+  function moodLabel(value) {
+    if (!Number.isFinite(value) || Math.abs(value) < 0.05) {
+      return 'Neutral';
+    }
+    if (value > 0) {
+      return `+${value.toFixed(2)}`;
+    }
+    return value.toFixed(2);
+  }
+
+  function moodNote(value) {
+    if (!Number.isFinite(value) || Math.abs(value) < 0.05) {
+      return 'Crowd is evenly split.';
+    }
+    return value > 0 ? 'Crowd leans supportive.' : 'Crowd leans critical.';
+  }
+
+  function moodClass(value) {
+    if (!Number.isFinite(value) || Math.abs(value) < 0.05) {
+      return '';
+    }
+    return value > 0 ? 'positive' : 'negative';
+  }
+
+  function computeMood(comments) {
+    if (!Array.isArray(comments) || comments.length === 0) {
+      return 0;
+    }
+    const total = comments.reduce((sum, comment) => sum + (Number(comment.sentiment) || 0), 0);
+    return total / comments.length;
+  }
+
+  function renderList(list, target, emptyText) {
+    target.innerHTML = '';
+    if (!Array.isArray(list) || list.length === 0) {
+      if (emptyText) {
+        const li = document.createElement('li');
+        li.className = 'note-text';
+        li.textContent = emptyText;
+        target.appendChild(li);
+      }
+      return;
+    }
+    list.forEach((entry) => {
+      const li = document.createElement('li');
+      li.textContent = entry;
+      target.appendChild(li);
+    });
+  }
+
+  function renderEvidence(list) {
+    evidenceList.innerHTML = '';
+    if (!Array.isArray(list) || list.length === 0) {
+      const li = document.createElement('li');
+      li.className = 'note-text';
+      li.textContent = 'No evidence submitted yet.';
+      evidenceList.appendChild(li);
+      return;
+    }
+    list.forEach((item) => {
+      const li = document.createElement('li');
+      const label = document.createElement('strong');
+      label.textContent = `${item.label}: `;
+      const detail = document.createElement('span');
+      detail.textContent = item.detail;
+      li.appendChild(label);
+      li.appendChild(detail);
+      evidenceList.appendChild(li);
+    });
+  }
+
+  function renderTimeline(list) {
+    timelineList.innerHTML = '';
+    if (!Array.isArray(list) || list.length === 0) {
+      const li = document.createElement('li');
+      li.className = 'note-text';
+      li.textContent = 'Timeline not yet documented.';
+      timelineList.appendChild(li);
+      return;
+    }
+    list.forEach((item) => {
+      const node = timelineTemplate.content.firstElementChild.cloneNode(true);
+      node.querySelector('.timeline-entry__time').textContent = item.time;
+      node.querySelector('.timeline-entry__event').textContent = item.event;
+      timelineList.appendChild(node);
+    });
+  }
+
+  function renderRoster(roles) {
+    rosterList.innerHTML = '';
+    const labels = {
+      accuser: 'Accuser',
+      prosecutor: 'Prosecutor',
+      defendant: 'Defendant',
+      defense: 'Defense Counsel',
+      judge: 'Presiding Judge'
+    };
+    Object.entries(labels).forEach(([key, label]) => {
+      const role = roles?.[key];
+      if (!role) {
+        return;
+      }
+      const li = document.createElement('li');
+      li.className = 'detail-card';
+      const labelEl = document.createElement('span');
+      labelEl.className = 'detail-card__label';
+      labelEl.textContent = label;
+      const valueEl = document.createElement('span');
+      valueEl.className = 'detail-card__value';
+      valueEl.textContent = role.name;
+      const summaryEl = document.createElement('p');
+      summaryEl.className = 'note-text';
+      summaryEl.textContent = role.summary;
+      li.appendChild(labelEl);
+      li.appendChild(valueEl);
+      if (role.title) {
+        const title = document.createElement('p');
+        title.className = 'note-text';
+        title.textContent = role.title;
+        li.appendChild(title);
+      }
+      li.appendChild(summaryEl);
+      rosterList.appendChild(li);
+    });
+  }
+
+  function renderComments(comments) {
+    commentFeed.innerHTML = '';
+    if (!Array.isArray(comments) || comments.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'note-text';
+      empty.textContent = 'No comments yet. Add your take below.';
+      commentFeed.appendChild(empty);
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    comments
+      .slice()
+      .sort((a, b) => b.createdAt - a.createdAt)
+      .forEach((comment) => {
+        const node = commentTemplate.content.firstElementChild.cloneNode(true);
+        const moodClassName = moodClass(comment.sentiment);
+        if (moodClassName) {
+          node.classList.add(moodClassName);
+        }
+        node.querySelector('.comment-card__user').textContent = comment.user;
+        node.querySelector('.comment-card__time').textContent = formatRelativeTime(comment.createdAt);
+        node.querySelector('.comment-card__text').textContent = comment.text;
+        fragment.appendChild(node);
+      });
+    commentFeed.appendChild(fragment);
+  }
+
+  function renderCase(caseItem) {
+    caseContent.hidden = false;
+    commentSection.hidden = false;
+
+    statusEl.dataset.status = (caseItem.status || 'debate').toLowerCase();
+    statusEl.textContent = (caseItem.status || 'Debate').charAt(0).toUpperCase() + (caseItem.status || 'debate').slice(1);
+    updatedEl.textContent = `Updated ${formatRelativeTime(caseItem.lastActivity || caseItem.createdAt)}`;
+    titleEl.textContent = caseItem.title;
+    filedEl.textContent = `Filed by ${caseItem.filedBy}${caseItem.isBot ? ' • Bot' : ''}`;
+    const summary = (caseItem.summary || '').trim();
+    if (summary.length) {
+      summaryEl.textContent = summary;
+      summaryEl.style.display = '';
+    } else {
+      summaryEl.textContent = '';
+      summaryEl.style.display = 'none';
+    }
+    if (leadChargeWrap) {
+      const leadCharge = (caseItem.leadCharge || '').trim();
+      if (leadCharge.length) {
+        leadChargeEl.textContent = leadCharge;
+        leadChargeWrap.style.display = '';
+      } else {
+        leadChargeEl.textContent = '';
+        leadChargeWrap.style.display = 'none';
+      }
+    }
+    storyEl.textContent = caseItem.story;
+
+    renderList(caseItem.charges, chargesList, 'No formal charges listed.');
+    renderEvidence(caseItem.evidence);
+    renderTimeline(caseItem.timeline);
+    renderRoster(caseItem.roles);
+    renderComments(caseItem.comments);
+
+    const votesBalance = (caseItem.votes?.up || 0) - (caseItem.votes?.down || 0);
+    statVotes.textContent = votesBalance >= 0 ? `+${votesBalance}` : votesBalance;
+    statVoteBreakdown.textContent = `${caseItem.votes?.up || 0} support • ${caseItem.votes?.down || 0} oppose`;
+
+    const moodValue = computeMood(caseItem.comments);
+    statMood.textContent = moodLabel(moodValue);
+    statMood.classList.remove('meta-item__value--positive', 'meta-item__value--negative');
+    if (moodValue > 0.05) {
+      statMood.classList.add('meta-item__value--positive');
+    } else if (moodValue < -0.05) {
+      statMood.classList.add('meta-item__value--negative');
+    }
+    statMoodNote.textContent = moodNote(moodValue);
+    statComments.textContent = caseItem.comments?.length || 0;
+    statLastActivity.textContent = `Last activity ${formatRelativeTime(caseItem.lastActivity || caseItem.createdAt)}`;
+
+    commentMood.textContent = `Mood: ${moodLabel(moodValue)}`;
+    commentMood.classList.remove('positive', 'negative');
+    const commentMoodClass = moodClass(moodValue);
+    if (commentMoodClass) {
+      commentMood.classList.add(commentMoodClass);
+    }
+
+    if (caseItem.verdict) {
+      verdictSection.hidden = false;
+      verdictDecision.textContent = caseItem.verdict.decision;
+      verdictReasoning.textContent = caseItem.verdict.reasoning;
+      const judgeInfo = caseItem.verdict.judge ? `Judge ${caseItem.verdict.judge}` : 'Unspecified judge';
+      const confidence = Number.isFinite(caseItem.verdict.confidence)
+        ? ` • Confidence ${Math.round(caseItem.verdict.confidence * 100)}%`
+        : '';
+      verdictMeta.textContent = `${judgeInfo}${confidence}`;
+    } else {
+      verdictSection.hidden = true;
+    }
+  }
+
+  function handleCommentSubmit(event) {
+    event.preventDefault();
+    const formData = new FormData(commentForm);
+    const user = (formData.get('user') || '').toString().trim() || 'CourtWatcher';
+    const text = (formData.get('text') || '').toString().trim();
+    const sentiment = Number.parseFloat(formData.get('sentiment'));
+    if (!text) {
+      return;
+    }
+    store.addComment(caseId, { user, text, sentiment });
+    commentForm.reset();
+  }
+
+  function handleVote(event) {
+    const direction = event.currentTarget.dataset.direction;
+    if (!direction) {
+      return;
+    }
+    event.currentTarget.disabled = true;
+    try {
+      store.vote(caseId, direction);
+    } finally {
+      setTimeout(() => {
+        event.currentTarget.disabled = false;
+      }, 400);
+    }
+  }
+
+  async function initialise() {
+    await store.ready();
+    let caseItem = store.getCase(caseId);
+    if (!caseItem) {
+      const snapshot = store.getState();
+      caseItem = snapshot.cases.find((item) => item.id === caseId);
+    }
+    if (!caseItem) {
+      shell.innerHTML = '<p class="note-text">Case not found. <a href="index.html">Return to the docket.</a></p>';
+      return;
+    }
+    renderCase(caseItem);
+
+    store.subscribe((snapshot) => {
+      const updated = snapshot.cases.find((item) => item.id === caseId);
+      if (updated) {
+        renderCase(updated);
+      }
+    });
+
+    commentForm.addEventListener('submit', handleCommentSubmit);
+    voteUp.addEventListener('click', handleVote);
+    voteDown.addEventListener('click', handleVote);
+  }
+
+  initialise();
+})();

--- a/jury/js/page-index.js
+++ b/jury/js/page-index.js
@@ -1,0 +1,336 @@
+(function () {
+  const store = window.JuryStore;
+  const feed = document.getElementById('case-feed');
+  const template = document.getElementById('case-card-template');
+  const commentTemplate = document.getElementById('comment-chip-template');
+  const statCases = document.getElementById('stat-cases');
+  const statComments = document.getElementById('stat-comments');
+  const statMood = document.getElementById('stat-mood');
+  const statLastBot = document.getElementById('stat-last-bot');
+  const nextBotCase = document.getElementById('next-bot-case');
+  const nextBotComment = document.getElementById('next-bot-comment');
+  const caseForm = document.getElementById('case-form');
+  const formSuccess = document.getElementById('form-success');
+  const resetButton = document.getElementById('reset-simulation');
+
+  let currentSnapshot = null;
+
+  const relativeFormatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+  function formatRelativeTime(timestamp) {
+    if (!timestamp) {
+      return '--';
+    }
+    const diff = Date.now() - timestamp;
+    const absDiff = Math.abs(diff);
+    const units = [
+      { limit: 60, divisor: 1, unit: 'second' },
+      { limit: 3600, divisor: 60, unit: 'minute' },
+      { limit: 86400, divisor: 3600, unit: 'hour' },
+      { limit: 604800, divisor: 86400, unit: 'day' },
+      { limit: 2629800, divisor: 604800, unit: 'week' }
+    ];
+    for (const { limit, divisor, unit } of units) {
+      if (absDiff < limit * 1000) {
+        const value = Math.round(diff / (divisor * 1000));
+        return relativeFormatter.format(value, unit);
+      }
+    }
+    const months = Math.round(diff / (2629800 * 1000));
+    return relativeFormatter.format(months, 'month');
+  }
+
+  function formatCountdown(timestamp) {
+    if (!timestamp) {
+      return '--';
+    }
+    const diff = timestamp - Date.now();
+    if (diff <= 0) {
+      return 'seconds';
+    }
+    const seconds = Math.ceil(diff / 1000);
+    if (seconds < 60) {
+      return `${seconds}s`;
+    }
+    const minutes = Math.floor(seconds / 60);
+    const remain = seconds % 60;
+    return `${minutes}m ${String(remain).padStart(2, '0')}s`;
+  }
+
+  function moodLabel(value) {
+    if (!Number.isFinite(value) || Math.abs(value) < 0.05) {
+      return 'Neutral';
+    }
+    if (value > 0) {
+      return `+${value.toFixed(2)}`;
+    }
+    return value.toFixed(2);
+  }
+
+  function moodClass(value) {
+    if (!Number.isFinite(value) || Math.abs(value) < 0.05) {
+      return '';
+    }
+    return value > 0 ? 'meta-item__value--positive' : 'meta-item__value--negative';
+  }
+
+  function computeMood(comments) {
+    if (!Array.isArray(comments) || comments.length === 0) {
+      return 0;
+    }
+    const total = comments.reduce((sum, comment) => sum + (Number(comment.sentiment) || 0), 0);
+    return total / comments.length;
+  }
+
+  function truncate(text, limit) {
+    if (!text) {
+      return '';
+    }
+    if (text.length <= limit) {
+      return text;
+    }
+    return `${text.slice(0, limit - 1)}…`;
+  }
+
+  function titleCase(value) {
+    if (!value) {
+      return '';
+    }
+    return value.charAt(0).toUpperCase() + value.slice(1);
+  }
+
+  function createCommentChip(comment) {
+    const node = commentTemplate.content.firstElementChild.cloneNode(true);
+    if (Number(comment.sentiment) > 0.1) {
+      node.classList.add('positive');
+    } else if (Number(comment.sentiment) < -0.1) {
+      node.classList.add('negative');
+    }
+    node.querySelector('.comment-chip__user').textContent = `${comment.user} • ${formatRelativeTime(comment.createdAt)}`;
+    node.querySelector('.comment-chip__text').textContent = truncate(comment.text, 220);
+    return node;
+  }
+
+  function createCaseCard(caseItem) {
+    const fragment = template.content.cloneNode(true);
+    const card = fragment.querySelector('.case-card');
+    card.dataset.caseId = caseItem.id;
+
+    const status = fragment.querySelector('.case-card__status');
+    status.dataset.status = (caseItem.status || 'debate').toLowerCase();
+    status.textContent = titleCase(caseItem.status || 'debate');
+
+    fragment.querySelector('.case-card__time').textContent = formatRelativeTime(caseItem.lastActivity || caseItem.createdAt);
+    fragment.querySelector('.case-card__title').textContent = caseItem.title;
+    fragment.querySelector('.case-card__filed').textContent = `Filed by ${caseItem.filedBy}${
+      caseItem.isBot ? ' • Bot' : ''
+    }`;
+
+    const summaryText = caseItem.summary || truncate(caseItem.story, 220);
+    fragment.querySelector('.case-card__summary').textContent = summaryText;
+
+    const storyWrapper = fragment.querySelector('.case-card__story');
+    const storyText = fragment.querySelector('.case-card__story-text');
+    storyText.textContent = caseItem.story;
+
+    const toggleButton = fragment.querySelector('.case-card__toggle');
+    toggleButton.addEventListener('click', () => {
+      const hidden = storyWrapper.hasAttribute('hidden');
+      if (hidden) {
+        storyWrapper.removeAttribute('hidden');
+        toggleButton.textContent = 'Hide story';
+      } else {
+        storyWrapper.setAttribute('hidden', '');
+        toggleButton.textContent = 'Show full story';
+      }
+    });
+
+    const tagsList = fragment.querySelector('.case-card__tags');
+    tagsList.innerHTML = '';
+    if (Array.isArray(caseItem.tags) && caseItem.tags.length) {
+      caseItem.tags.forEach((tag) => {
+        const li = document.createElement('li');
+        li.className = 'tag';
+        li.textContent = tag;
+        tagsList.appendChild(li);
+      });
+    }
+
+    const votesBalance = (caseItem.votes?.up || 0) - (caseItem.votes?.down || 0);
+    const votesEl = fragment.querySelector('.meta-item__value--votes');
+    votesEl.textContent = votesBalance >= 0 ? `+${votesBalance}` : votesBalance.toString();
+    votesEl.classList.toggle('meta-item__value--positive', votesBalance > 0);
+    votesEl.classList.toggle('meta-item__value--negative', votesBalance < 0);
+
+    fragment.querySelector('.meta-item__value--comments').textContent = caseItem.comments?.length || 0;
+
+    const moodValue = computeMood(caseItem.comments);
+    const moodEl = fragment.querySelector('.meta-item__value--mood');
+    moodEl.textContent = moodLabel(moodValue);
+    moodEl.classList.remove('meta-item__value--positive', 'meta-item__value--negative');
+    const moodClassName = moodClass(moodValue);
+    if (moodClassName) {
+      moodEl.classList.add(moodClassName);
+    }
+
+    const commentsWrapper = fragment.querySelector('.case-card__comments');
+    commentsWrapper.innerHTML = '';
+    if (Array.isArray(caseItem.comments) && caseItem.comments.length) {
+      const sorted = [...caseItem.comments].sort((a, b) => b.createdAt - a.createdAt).slice(0, 3);
+      sorted.forEach((comment) => {
+        commentsWrapper.appendChild(createCommentChip(comment));
+      });
+    } else {
+      const empty = document.createElement('p');
+      empty.className = 'case-card__empty-comments';
+      empty.textContent = 'No comments yet. Be the first to weigh in.';
+      commentsWrapper.appendChild(empty);
+    }
+
+    const link = fragment.querySelector('.case-card__link');
+    link.href = `case.html?id=${encodeURIComponent(caseItem.id)}`;
+
+    return fragment;
+  }
+
+  function renderCases(cases) {
+    feed.innerHTML = '';
+    if (!cases.length) {
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.textContent = 'No cases yet. Submit one to start the debate.';
+      feed.appendChild(empty);
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    cases
+      .slice()
+      .sort((a, b) => (b.lastActivity || 0) - (a.lastActivity || 0))
+      .forEach((caseItem) => {
+        fragment.appendChild(createCaseCard(caseItem));
+      });
+    feed.appendChild(fragment);
+  }
+
+  function updateStats(snapshot) {
+    const cases = snapshot.cases || [];
+    const totalComments = cases.reduce((sum, item) => sum + (item.comments?.length || 0), 0);
+    const mood = cases.length
+      ? cases.reduce((sum, item) => sum + computeMood(item.comments), 0) / cases.length
+      : 0;
+    const lastBot = Math.max(snapshot.bots?.lastCaseAt || 0, snapshot.bots?.lastCommentAt || 0);
+
+    statCases.textContent = cases.length;
+    statComments.textContent = totalComments;
+    statMood.textContent = moodLabel(mood);
+    statMood.classList.remove('meta-item__value--positive', 'meta-item__value--negative');
+    const moodClassName = moodClass(mood);
+    if (moodClassName) {
+      statMood.classList.add(moodClassName);
+    }
+    statLastBot.textContent = lastBot ? formatRelativeTime(lastBot) : 'No activity yet';
+
+    updateBotTimers(snapshot.bots);
+  }
+
+  function updateBotTimers(bots) {
+    if (!bots) {
+      nextBotCase.textContent = '--';
+      nextBotComment.textContent = '--';
+      return;
+    }
+    nextBotCase.textContent = formatCountdown(bots.nextCaseAt);
+    nextBotComment.textContent = formatCountdown(bots.nextCommentAt);
+  }
+
+  function handleVote(event) {
+    const button = event.target.closest('button[data-action="vote"]');
+    if (!button) {
+      return;
+    }
+    const card = button.closest('.case-card');
+    if (!card) {
+      return;
+    }
+    const caseId = card.dataset.caseId;
+    const direction = button.dataset.direction;
+    if (!caseId || !direction) {
+      return;
+    }
+    button.disabled = true;
+    try {
+      store.vote(caseId, direction);
+    } finally {
+      setTimeout(() => {
+        button.disabled = false;
+      }, 400);
+    }
+  }
+
+  async function handleFormSubmit(event) {
+    event.preventDefault();
+    const formData = new FormData(caseForm);
+    const title = (formData.get('title') || '').toString().trim();
+    const story = (formData.get('story') || '').toString().trim();
+    const filedBy = (formData.get('filedBy') || '').toString().trim() || 'Community Member';
+    if (!title || !story) {
+      return;
+    }
+    store.addCase({
+      title,
+      summary: truncate(story, 220),
+      story,
+      filedBy,
+      status: 'debate',
+      tags: ['community'],
+      votes: { up: 0, down: 0 },
+      comments: []
+    });
+    caseForm.reset();
+    formSuccess.hidden = false;
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    setTimeout(() => {
+      formSuccess.hidden = true;
+    }, 4000);
+  }
+
+  async function handleReset() {
+    resetButton.disabled = true;
+    resetButton.textContent = 'Resetting…';
+    await store.reset();
+    const snapshot = await store.getState();
+    currentSnapshot = snapshot;
+    renderCases(snapshot.cases);
+    updateStats(snapshot);
+    resetButton.disabled = false;
+    resetButton.textContent = 'Reset simulation';
+  }
+
+  function startTimerLoop() {
+    setInterval(() => {
+      if (currentSnapshot) {
+        updateBotTimers(currentSnapshot.bots);
+      }
+    }, 1000);
+  }
+
+  async function initialise() {
+    await store.ready();
+    currentSnapshot = store.getState();
+    renderCases(currentSnapshot.cases);
+    updateStats(currentSnapshot);
+
+    store.subscribe((snapshot) => {
+      currentSnapshot = snapshot;
+      renderCases(snapshot.cases);
+      updateStats(snapshot);
+    });
+
+    feed.addEventListener('click', handleVote);
+    caseForm.addEventListener('submit', handleFormSubmit);
+    resetButton.addEventListener('click', handleReset);
+    startTimerLoop();
+  }
+
+  initialise();
+})();

--- a/jury/judges.html
+++ b/jury/judges.html
@@ -3,36 +3,37 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Meet the Judges • AI Judge</title>
+  <title>Meet the Bench • Jury Game 2.0</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/inter@5.0.16/variable.css">
-  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="bg-slate-950 text-slate-100">
-  <main class="max-w-4xl mx-auto px-4 py-10 space-y-8">
-    <header class="text-center space-y-3">
-      <a href="index.html" class="inline-flex items-center gap-2 text-sm text-slate-300 hover:text-indigo-200">← Back to docket</a>
-      <h1 class="text-3xl font-semibold tracking-tight">Meet the Bench</h1>
-      <p class="text-slate-300 max-w-2xl mx-auto">
-        Each AI judge brings a distinct philosophy. We rotate them through hourly court sessions to balance compassion and order.
+<body>
+  <main class="shell">
+    <a class="back-link" href="index.html">← Back to docket</a>
+    <section class="panel">
+      <span class="hero__badge">Jury Game</span>
+      <h1 style="margin: 1rem 0 0.5rem;">Meet the Bench</h1>
+      <p class="note-text" style="max-width: 42rem;">
+        Every nightly trial pairs a unique AI judge with the prosecution and defense bots. Their philosophies influence how
+        verdicts land, so study their styles before you plead your case.
       </p>
-    </header>
+    </section>
 
-    <section id="judge-grid" class="grid gap-6 md:grid-cols-2"></section>
+    <section id="judge-grid" class="case-feed"></section>
   </main>
 
   <template id="judge-card">
-    <article class="card space-y-3">
+    <article class="panel" style="gap: 1rem;">
       <header>
-        <h2 class="text-xl font-semibold"></h2>
-        <p class="text-sm text-slate-400 philosophy"></p>
+        <h2 style="margin: 0; font-size: 1.3rem;"></h2>
+        <p class="note-text philosophy" style="margin-top: 0.3rem;"></p>
       </header>
-      <p class="text-slate-300 bio"></p>
-      <div class="text-xs text-slate-500 uppercase tracking-wide">Style</div>
-      <p class="text-sm text-indigo-300 style"></p>
-      <div class="flex items-center justify-between text-sm text-slate-400">
-        <span class="cases"></span>
-        <span class="agree"></span>
+      <p class="note-text bio"></p>
+      <div class="detail-card__label" style="margin-top: 0.5rem;">Style</div>
+      <p class="note-text style"></p>
+      <div class="case-card__top" style="justify-content: space-between;">
+        <span class="note-text cases"></span>
+        <span class="note-text agree"></span>
       </div>
     </article>
   </template>
@@ -43,8 +44,9 @@
       const judges = await response.json();
       const grid = document.getElementById('judge-grid');
       const template = document.getElementById('judge-card');
+      const fragment = document.createDocumentFragment();
       judges.forEach((judge) => {
-        const node = template.content.cloneNode(true);
+        const node = template.content.firstElementChild.cloneNode(true);
         node.querySelector('h2').textContent = judge.name;
         node.querySelector('.philosophy').textContent = judge.philosophy;
         node.querySelector('.bio').textContent = judge.bio;
@@ -53,8 +55,9 @@
           node.querySelector('.cases').textContent = `${judge.stats.cases} cases heard`;
           node.querySelector('.agree').textContent = `${Math.round(judge.stats.agreeRate * 100)}% public agreement`;
         }
-        grid.appendChild(node);
+        fragment.appendChild(node);
       });
+      grid.appendChild(fragment);
     }
     loadJudges();
   </script>

--- a/jury/style.css
+++ b/jury/style.css
@@ -1,301 +1,713 @@
 :root {
-  color-scheme: light dark;
+  color-scheme: dark;
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --bg-1: #050b1c;
+  --bg-2: #0d1330;
+  --bg-card: rgba(15, 23, 55, 0.75);
+  --border-card: rgba(110, 131, 198, 0.25);
+  --text-primary: #f8fbff;
+  --text-secondary: #c7d2fe;
+  --text-muted: #94a3c7;
+  --accent: #7c5cff;
+  --accent-soft: rgba(124, 92, 255, 0.18);
+  --positive: #34d399;
+  --negative: #f87171;
+  --shadow-soft: 0 28px 60px rgba(5, 11, 28, 0.45);
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
+  margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top, rgba(79, 70, 229, 0.08), transparent 60%), #0f172a;
-  color: #e2e8f0;
+  background:
+    radial-gradient(circle at top, rgba(124, 92, 255, 0.15), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(45, 212, 191, 0.08), transparent 60%),
+    linear-gradient(160deg, var(--bg-1), var(--bg-2));
+  color: var(--text-primary);
 }
 
 a {
-  color: #a855f7;
+  color: var(--accent);
+  text-decoration: none;
 }
 
 a:hover {
-  color: #d946ef;
+  color: #a091ff;
 }
 
-.card {
-  background: rgba(15, 23, 42, 0.8);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: 1rem;
-  padding: 1.5rem;
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.3);
-  backdrop-filter: blur(16px);
+.shell {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
 }
 
-.story-toggle {
+.hero {
+  background: rgba(15, 23, 55, 0.6);
+  border: 1px solid rgba(124, 92, 255, 0.25);
+  border-radius: 1.25rem;
+  padding: 2.25rem;
+  position: relative;
+  overflow: hidden;
+  box-shadow: var(--shadow-soft);
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at top right, rgba(124, 92, 255, 0.18), transparent 55%);
+}
+
+.hero__badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  font-size: 0.7rem;
-  text-transform: uppercase;
+  gap: 0.5rem;
+  padding: 0.4rem 1.1rem;
+  border-radius: 999px;
+  background: rgba(124, 92, 255, 0.15);
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  font-weight: 500;
   letter-spacing: 0.08em;
-  color: #a5b4fc;
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  padding: 0;
+  text-transform: uppercase;
 }
 
-.story-toggle:hover {
-  color: #d8b4fe;
+.hero__badge.positive {
+  background: rgba(52, 211, 153, 0.22);
+  color: #bbf7d0;
 }
 
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  font-size: 0.75rem;
-  border-radius: 9999px;
-  padding: 0.25rem 0.75rem;
-  background: rgba(59, 130, 246, 0.15);
-  color: #93c5fd;
+.hero__badge.negative {
+  background: rgba(248, 113, 113, 0.22);
+  color: #fecaca;
 }
 
-.button-primary {
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  padding: 0.75rem 1.5rem;
-  border-radius: 9999px;
-  background: linear-gradient(135deg, #6366f1, #a855f7);
-  color: white;
-  font-weight: 600;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+.hero h1 {
+  margin: 1rem 0 0.75rem;
+  font-size: clamp(2.1rem, 5vw, 3rem);
+  letter-spacing: -0.03em;
 }
 
-.button-primary:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 25px rgba(99, 102, 241, 0.4);
+.hero p {
+  margin: 0;
+  color: var(--text-muted);
+  max-width: 38rem;
+  line-height: 1.6;
 }
 
-.button-secondary {
-  display: inline-flex;
-  align-items: center;
+.hero__stats {
+  margin-top: 2rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+}
+
+.hero__stat {
+  background: rgba(13, 19, 48, 0.65);
+  border: 1px solid rgba(124, 92, 255, 0.18);
+  border-radius: 1rem;
+  padding: 1.1rem;
+  display: grid;
   gap: 0.35rem;
-  padding: 0.5rem 1rem;
-  border-radius: 9999px;
-  background: rgba(129, 140, 248, 0.15);
-  color: #bfdbfe;
+}
+
+.hero__stat-value {
+  font-size: 1.8rem;
   font-weight: 600;
-  border: 1px solid rgba(129, 140, 248, 0.4);
-  transition: background 0.2s ease, color 0.2s ease, opacity 0.2s ease;
 }
 
-.button-secondary:hover {
-  background: rgba(129, 140, 248, 0.25);
-  color: #e0f2fe;
+.hero__stat-label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
-.button-secondary:disabled {
+.hero__controls {
+  margin-top: 1.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.hero__timer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.layout {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.layout__primary,
+.layout__aside {
+  display: grid;
+  gap: 1.75rem;
+}
+
+@media (min-width: 960px) {
+  .layout {
+    grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr);
+  }
+}
+
+.section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.case-feed {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.case-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-card);
+  border-radius: 1.2rem;
+  padding: 1.75rem;
+  display: grid;
+  gap: 1.3rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.case-card__header {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.case-card__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  font-size: 0.85rem;
+}
+
+.case-card__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(124, 92, 255, 0.16);
+  color: var(--text-secondary);
+}
+
+.case-card__status[data-status="trial"],
+.case-card__status[data-status="hearing"] {
+  background: rgba(250, 204, 21, 0.22);
+  color: #fde68a;
+}
+
+.case-card__status[data-status="debate"] {
+  background: rgba(59, 130, 246, 0.22);
+  color: #bfdbfe;
+}
+
+.case-card__status[data-status="judged"] {
+  background: rgba(52, 211, 153, 0.22);
+  color: #6ee7b7;
+}
+
+.case-card__time {
+  color: var(--text-muted);
+}
+
+.case-card__title {
+  margin: 0;
+  font-size: 1.3rem;
+  line-height: 1.35;
+}
+
+.case-card__filed {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.case-card__summary {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+.case-card__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.case-card__toggle:hover {
+  color: #a091ff;
+}
+
+.case-card__story {
+  background: rgba(124, 92, 255, 0.08);
+  border: 1px solid rgba(124, 92, 255, 0.18);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.case-card__tags {
+  margin: 1rem 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0;
+  list-style: none;
+}
+
+.tag {
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.18);
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #bfdbfe;
+}
+
+.case-card__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.meta-item {
+  background: rgba(13, 19, 48, 0.75);
+  border: 1px solid rgba(124, 92, 255, 0.18);
+  border-radius: 0.9rem;
+  padding: 0.85rem 1rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.meta-item__value {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.meta-item__value--positive {
+  color: var(--positive);
+}
+
+.meta-item__value--negative {
+  color: var(--negative);
+}
+
+.meta-item__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.case-card__comments {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.comment-chip {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.85rem 1rem;
+  border-radius: 0.9rem;
+  background: rgba(13, 19, 48, 0.6);
+  border: 1px solid rgba(124, 92, 255, 0.16);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.comment-chip__user {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.comment-chip.positive {
+  border-color: rgba(52, 211, 153, 0.45);
+}
+
+.comment-chip.negative {
+  border-color: rgba(248, 113, 113, 0.45);
+}
+
+.case-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.case-card__votes {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.65rem 1.3rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  border: 1px solid transparent;
+  background: rgba(124, 92, 255, 0.18);
+  color: var(--text-primary);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(124, 92, 255, 0.28);
+}
+
+.button--ghost {
+  background: rgba(13, 19, 48, 0.7);
+  border-color: rgba(124, 92, 255, 0.22);
+}
+
+.button--primary {
+  background: linear-gradient(135deg, #7c5cff, #6366f1);
+  border: none;
+}
+
+.button--danger {
+  background: rgba(239, 68, 68, 0.18);
+  border-color: rgba(239, 68, 68, 0.4);
+}
+
+.button[disabled] {
   opacity: 0.6;
   cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
 }
 
-input, textarea {
-  color: #0f172a;
-}
-
-.progress-bar {
-  height: 0.5rem;
-  border-radius: 9999px;
-  background: rgba(148, 163, 184, 0.2);
-  overflow: hidden;
-}
-
-.progress-bar div {
-  height: 100%;
-  background: linear-gradient(135deg, #34d399, #22d3ee);
-}
-
-.summary-list {
-  list-style: disc;
-  padding-left: 1.5rem;
-  color: #cbd5f5;
-  display: grid;
-  gap: 0.25rem;
-  font-size: 0.875rem;
-}
-
-.score-bar {
-  position: relative;
-  height: 0.6rem;
-  border-radius: 9999px;
-  background: rgba(148, 163, 184, 0.2);
-  overflow: hidden;
-}
-
-.score-bar-fill {
-  height: 100%;
-  background: linear-gradient(135deg, #22d3ee, #6366f1);
-  width: 0;
-  transition: width 0.4s ease;
-}
-
-.case-roster {
-  display: grid;
-  gap: 0.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-}
-
-.roster-card {
-  background: rgba(148, 163, 184, 0.08);
-  border: 1px solid rgba(148, 163, 184, 0.15);
-  border-radius: 0.85rem;
-  padding: 0.75rem;
-}
-
-.roster-card .label {
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #cbd5f5;
-}
-
-.roster-card .name {
+.case-card__link {
+  color: var(--accent);
   font-weight: 600;
-  color: #e2e8f0;
-  margin-top: 0.25rem;
+  font-size: 0.95rem;
 }
 
-.roster-card .summary {
+.case-card__link:hover {
+  color: #a091ff;
+}
+
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-card);
+  border-radius: 1.2rem;
+  padding: 1.75rem;
+  display: grid;
+  gap: 1.2rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.panel h2,
+.panel h3 {
+  margin: 0;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-grid label {
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+input[type="text"],
+textarea,
+select {
+  width: 100%;
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(124, 92, 255, 0.2);
+  background: rgba(12, 16, 38, 0.8);
+  color: var(--text-primary);
+  font: inherit;
+  resize: vertical;
+}
+
+textarea {
+  min-height: 150px;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  outline: 2px solid rgba(124, 92, 255, 0.45);
+  outline-offset: 2px;
+}
+
+.form-hint {
   font-size: 0.8rem;
-  color: #cbd5f5;
-  margin-top: 0.35rem;
+  color: var(--text-muted);
+  line-height: 1.5;
 }
 
-.roster-card .note {
-  font-size: 0.75rem;
-  color: #a5b4fc;
-  margin-top: 0.5rem;
+.success-text {
+  color: var(--positive);
+  font-size: 0.85rem;
+}
+
+.hero__timer span strong {
+  color: var(--text-secondary);
+}
+
+.empty-state {
+  padding: 1.5rem;
+  border-radius: 1rem;
+  border: 1px dashed rgba(124, 92, 255, 0.25);
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.case-card__empty-comments {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+/* Case page */
+
+.case-layout {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@media (min-width: 960px) {
+  .case-layout {
+    grid-template-columns: minmax(0, 1.9fr) minmax(0, 1fr);
+  }
+}
+
+.case-detail {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.case-detail header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.6rem);
   line-height: 1.2;
 }
 
-.judge-card {
-  background: rgba(99, 102, 241, 0.12);
-  border: 1px solid rgba(129, 140, 248, 0.3);
-  border-radius: 0.85rem;
-  padding: 0.85rem;
-  display: grid;
-  gap: 0.35rem;
-}
-
-.judge-card .label {
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #c7d2fe;
-}
-
-.judge-card .name {
-  font-weight: 600;
-  color: #ede9fe;
-}
-
-.judge-card .summary {
-  font-size: 0.8rem;
-  color: #cbd5f5;
-}
-
-.judge-card .leaning {
-  font-size: 0.75rem;
-  color: #fbcfe8;
+.case-detail__meta {
   display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
   align-items: center;
-  gap: 0.35rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
 }
 
-.case-matrix {
+.case-detail__stats {
   display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.case-panel {
-  background: rgba(15, 23, 42, 0.65);
-  border: 1px solid rgba(129, 140, 248, 0.15);
+.detail-card {
+  background: rgba(13, 19, 48, 0.7);
+  border: 1px solid rgba(124, 92, 255, 0.18);
   border-radius: 1rem;
-  padding: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.panel-title {
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: #a5b4fc;
-}
-
-.case-list {
-  list-style: disc;
-  padding-left: 1.25rem;
+  padding: 1.1rem 1.2rem;
   display: grid;
-  gap: 0.45rem;
-  font-size: 0.85rem;
-  color: #e2e8f0;
+  gap: 0.4rem;
+}
+
+.detail-card__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.detail-card__value {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.case-columns {
+  display: grid;
+  gap: 1.4rem;
+}
+
+.case-columns h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.list-reset {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.65rem;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
 }
 
 .timeline-list {
   list-style: none;
-  display: grid;
-  gap: 0.6rem;
   padding: 0;
   margin: 0;
+  display: grid;
+  gap: 0.75rem;
 }
 
 .timeline-entry {
+  background: rgba(13, 19, 48, 0.6);
+  border: 1px solid rgba(124, 92, 255, 0.16);
+  border-radius: 0.85rem;
+  padding: 0.75rem 1rem;
   display: grid;
-  gap: 0.4rem;
-  grid-template-columns: minmax(64px, auto) 1fr;
-  font-size: 0.85rem;
-  color: #cbd5f5;
+  gap: 0.25rem;
 }
 
-.timeline-time {
-  font-weight: 600;
-  color: #fbbf24;
-}
-
-.timeline-event {
-  color: #e2e8f0;
-}
-
-.verdict-headline {
-  font-size: 1.35rem;
-  font-weight: 800;
-  text-transform: uppercase;
-  color: #c7d2fe;
-}
-
-.role-badge {
-  font-size: 0.65rem;
+.timeline-entry__time {
+  font-size: 0.75rem;
   letter-spacing: 0.08em;
-  padding: 0.15rem 0.5rem;
-  border-radius: 9999px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.comment-feed {
+  display: grid;
+  gap: 1rem;
+}
+
+.comment-card {
+  background: rgba(13, 19, 48, 0.68);
+  border: 1px solid rgba(124, 92, 255, 0.18);
+  border-radius: 1rem;
+  padding: 1rem 1.2rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.comment-card__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.comment-card.positive {
+  border-color: rgba(52, 211, 153, 0.45);
+}
+
+.comment-card.negative {
+  border-color: rgba(248, 113, 113, 0.45);
+}
+
+.case-detail__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.back-link:hover {
+  color: var(--accent);
+}
+
+.verdict-card {
+  background: rgba(59, 130, 246, 0.12);
+  border: 1px solid rgba(124, 92, 255, 0.22);
+  border-radius: 1.1rem;
+  padding: 1.2rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.verdict-card__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.verdict-card__decision {
+  font-size: 1.1rem;
   font-weight: 600;
 }
 
-.role-prosecution {
-  background: rgba(239, 68, 68, 0.25);
-  color: #fecaca;
+.note-text {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.6;
 }
 
-.role-defense {
-  background: rgba(16, 185, 129, 0.25);
-  color: #bbf7d0;
-}
+@media (max-width: 600px) {
+  .hero__controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
 
-.role-jury {
-  background: rgba(249, 115, 22, 0.25);
-  color: #fed7aa;
-}
+  .case-card {
+    padding: 1.4rem;
+  }
 
-.role-judge {
-  background: rgba(99, 102, 241, 0.25);
-  color: #ede9fe;
+  .panel {
+    padding: 1.4rem;
+  }
+
+  .hero {
+    padding: 1.75rem;
+  }
 }


### PR DESCRIPTION
## Summary
- rebuild the jury landing page with a new responsive layout, live stats, reset controls, and refreshed case card templates
- replace the client data store with a v2 engine that seeds fresh cases, schedules bot filings/comments, and keeps state in local storage with timed resets
- update case detail and judges views to match the new styling while supporting interactive voting and commenting flows

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e54f32df0c832293be6a116fd98988