### PR TITLE
Add realm events, relics, alliances, and onboarding for phase 2

### DIFF
--- a/war/index.html
+++ b/war/index.html
@@ -16,8 +16,13 @@
     <div id="app">
       <div class="pixel-grid-overlay" aria-hidden="true"></div>
       <header class="app-header">
-        <div class="app-title">Rune &amp; Ration</div>
-        <div class="app-subtitle">Citadel Reconstruction Protocol</div>
+        <div class="app-header__row">
+          <div>
+            <div class="app-title">Rune &amp; Ration</div>
+            <div class="app-subtitle">Citadel Reconstruction Protocol</div>
+          </div>
+          <button class="realm-event" id="realm-event" type="button" aria-live="polite"></button>
+        </div>
         <p class="app-subtitle">
           Stabilize resources, prepare formations, and tune your command deck to
           survive the siege.
@@ -32,6 +37,7 @@
         <button class="tab-button" data-tab="army">Army</button>
         <button class="tab-button" data-tab="deck">Deck</button>
         <button class="tab-button" data-tab="battle">Battle</button>
+        <button class="tab-button" data-tab="alliance">Alliance</button>
       </nav>
 
       <main class="panel" id="panel" aria-live="polite"></main>
@@ -40,6 +46,8 @@
         Prototype build • Deterministic auto-battles v0.1
       </footer>
     </div>
+
+    <div class="onboarding-overlay hidden" id="onboarding-overlay" aria-live="assertive"></div>
 
     <script type="module" src="./src/main.js"></script>
   </body>

--- a/war/src/data/events.js
+++ b/war/src/data/events.js
@@ -1,0 +1,62 @@
+export const realmEvents = [
+  {
+    id: "blood-moon",
+    name: "Blood Moon",
+    description:
+      "Souls spill freely while armies strike with reckless abandon. Mana surges but food spoils faster.",
+    durationHours: 6,
+    resourceMultipliers: {
+      souls: 1.5,
+      mana: 1.2,
+      food: 0.8,
+    },
+    battleModifiers: {
+      player: { attackMultiplier: 1.12, moraleBonus: 1 },
+      ghost: { attackMultiplier: 1.05 },
+    },
+  },
+  {
+    id: "verdant-tide",
+    name: "Verdant Tide",
+    description:
+      "Fungal groves flourish, feeding troops and lending resilience. Arcane output steadies but crystals flow slower.",
+    durationHours: 6,
+    resourceMultipliers: {
+      food: 1.4,
+      gold: 1.1,
+      crystals: 0.85,
+    },
+    battleModifiers: {
+      player: { defenseMultiplier: 1.1, healBonus: 4 },
+      ghost: { defenseMultiplier: 1.05 },
+    },
+  },
+  {
+    id: "emberwake",
+    name: "Emberwake",
+    description:
+      "The forge blazes white hot. Crystal lattices scream, empowering command cards while upkeep strains supplies.",
+    durationHours: 6,
+    resourceMultipliers: {
+      crystals: 1.5,
+      mana: 1.1,
+      gold: 0.9,
+    },
+    battleModifiers: {
+      player: { attackMultiplier: 1.08, varianceBonus: 0.2 },
+      ghost: { controlBonus: 1 },
+    },
+  },
+];
+
+export const realmEventById = Object.fromEntries(realmEvents.map((event) => [event.id, event]));
+
+export const getRealmEvent = (id) => realmEventById[id] ?? realmEvents[0];
+
+export const getNextRealmEventId = (currentId) => {
+  if (!currentId) return realmEvents[0].id;
+  const index = realmEvents.findIndex((event) => event.id === currentId);
+  if (index === -1) return realmEvents[0].id;
+  const nextIndex = (index + 1) % realmEvents.length;
+  return realmEvents[nextIndex].id;
+};

--- a/war/src/data/relics.js
+++ b/war/src/data/relics.js
@@ -1,0 +1,28 @@
+export const relicCatalog = [
+  {
+    id: "ember-signet",
+    name: "Ember Signet",
+    description: "Crystalized forge heat woven into a ring. Increases mana flow and weapon ferocity.",
+    cost: { gold: 120, crystals: 60, mana: 40 },
+    economy: { manaFlat: 0.6 },
+    battle: { attackMultiplier: 0.06 },
+  },
+  {
+    id: "verdant-heart",
+    name: "Verdant Heart",
+    description: "A living core harvested from the undergrowth. Sustains troops and bolsters healing.",
+    cost: { gold: 90, food: 120, souls: 10 },
+    economy: { foodFlat: 0.9 },
+    battle: { healBonus: 5, defenseMultiplier: 0.04 },
+  },
+  {
+    id: "gloom-censer",
+    name: "Gloom Censer",
+    description: "A censer of chained souls that whisper battle insight. Enhances souls and card control.",
+    cost: { gold: 140, souls: 18, mana: 55 },
+    economy: { soulsFlat: 0.25 },
+    battle: { controlBonus: 1.5, moraleBonus: 1 },
+  },
+];
+
+export const relicById = Object.fromEntries(relicCatalog.map((relic) => [relic.id, relic]));

--- a/war/src/state/initialState.js
+++ b/war/src/state/initialState.js
@@ -2,6 +2,7 @@ import { cards } from "../data/cards.js";
 import { buildingDefinitions } from "../data/buildings.js";
 import { unitList } from "../data/units.js";
 import { ghostArmies } from "../data/ghosts.js";
+import { realmEvents } from "../data/events.js";
 
 const defaultResource = (label, amount, baseRate) => ({
   label,
@@ -10,8 +11,10 @@ const defaultResource = (label, amount, baseRate) => ({
   rate: baseRate,
 });
 
+const initialEvent = realmEvents[0];
+
 export const createInitialState = () => ({
-  version: 1,
+  version: 2,
   lastTick: Date.now(),
   resources: {
     mana: defaultResource("Mana", 120, 2),
@@ -54,5 +57,34 @@ export const createInitialState = () => ({
   battle: {
     selectedGhostId: ghostArmies[0].id,
     lastResult: null,
+  },
+  realm: {
+    activeEventId: initialEvent.id,
+    eventExpiresAt: Date.now() + initialEvent.durationHours * 60 * 60 * 1000,
+    lastRotationAt: Date.now(),
+  },
+  relics: {
+    crafted: [],
+  },
+  alliance: {
+    name: "Echo Lattice",
+    rank: 823,
+    weeklyGoal: 9000,
+    contributed: 4820,
+    lastSynced: Date.now(),
+    featuredRaid: {
+      ghostId: ghostArmies[1]?.id ?? ghostArmies[0].id,
+      progress: 0.34,
+    },
+    leaderboard: [
+      { name: "Echo Lattice", score: 4820 },
+      { name: "Iron Chorus", score: 4550 },
+      { name: "Gloom Harvest", score: 4410 },
+      { name: "Obsidian Choir", score: 3980 },
+    ],
+  },
+  onboarding: {
+    completed: false,
+    currentStep: 0,
   },
 });

--- a/war/src/state/persistence/firebase.js
+++ b/war/src/state/persistence/firebase.js
@@ -1,0 +1,116 @@
+const CLOUD_STORAGE_KEY = "rune-ration-cloud";
+
+const hasLocalStorage = () => {
+  try {
+    return typeof localStorage !== "undefined";
+  } catch (error) {
+    return false;
+  }
+};
+
+const readFromStorage = (key) => {
+  if (!hasLocalStorage()) return null;
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch (error) {
+    console.warn("Failed to load Firebase snapshot", error);
+    return null;
+  }
+};
+
+const writeToStorage = (key, value) => {
+  if (!hasLocalStorage()) return false;
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+    return true;
+  } catch (error) {
+    console.warn("Failed to persist Firebase snapshot", error);
+    return false;
+  }
+};
+
+export const loadFirebaseSnapshot = async () => {
+  return readFromStorage(CLOUD_STORAGE_KEY);
+};
+
+export const saveFirebaseSnapshot = async (state) => {
+  return writeToStorage(CLOUD_STORAGE_KEY, state);
+};
+
+export const mergeStateWithCloud = (localState, cloudState) => {
+  if (!cloudState) return localState;
+  if (!localState) return structuredClone(cloudState);
+
+  const merged = structuredClone(localState);
+
+  merged.relics = {
+    crafted: Array.from(
+      new Set([...(localState.relics?.crafted ?? []), ...(cloudState.relics?.crafted ?? [])])
+    ),
+  };
+
+  merged.onboarding = {
+    completed: Boolean(localState.onboarding?.completed || cloudState.onboarding?.completed),
+    currentStep: localState.onboarding?.currentStep ?? 0,
+  };
+
+  const localEventEnd = localState.realm?.eventExpiresAt ?? 0;
+  const cloudEventEnd = cloudState.realm?.eventExpiresAt ?? 0;
+  merged.realm =
+    cloudEventEnd > localEventEnd
+      ? { ...localState.realm, ...cloudState.realm }
+      : structuredClone(localState.realm);
+
+  const combinedLeaderboard = [...(cloudState.alliance?.leaderboard ?? [])];
+  if (localState.alliance?.leaderboard) {
+    localState.alliance.leaderboard.forEach((entry) => {
+      const existing = combinedLeaderboard.find((cloudEntry) => cloudEntry.name === entry.name);
+      if (existing) {
+        existing.score = Math.max(existing.score, entry.score);
+      } else {
+        combinedLeaderboard.push(structuredClone(entry));
+      }
+    });
+  }
+
+  merged.alliance = {
+    ...cloudState.alliance,
+    ...localState.alliance,
+    contributed: Math.max(
+      cloudState.alliance?.contributed ?? 0,
+      localState.alliance?.contributed ?? 0
+    ),
+    leaderboard: combinedLeaderboard
+      .filter((entry) => entry?.name)
+      .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+      .slice(0, 8),
+  };
+
+  if (
+    (cloudState.battle?.lastResult?.timestamp ?? 0) >
+    (localState.battle?.lastResult?.timestamp ?? 0)
+  ) {
+    merged.battle = {
+      ...localState.battle,
+      lastResult: cloudState.battle.lastResult,
+    };
+  }
+
+  return merged;
+};
+
+let pendingSave = null;
+
+export const queueFirebaseSave = (state) => {
+  if (!hasLocalStorage()) return;
+  if (pendingSave) {
+    clearTimeout(pendingSave);
+  }
+  const snapshot = JSON.parse(JSON.stringify(state));
+  pendingSave = setTimeout(() => {
+    saveFirebaseSnapshot(snapshot);
+    pendingSave = null;
+  }, 500);
+};

--- a/war/styles/base.css
+++ b/war/styles/base.css
@@ -70,6 +70,13 @@ body {
   gap: 8px;
 }
 
+.app-header__row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .app-title {
   font-family: var(--font-display);
   font-size: 18px;
@@ -82,6 +89,62 @@ body {
 .app-subtitle {
   font-size: 16px;
   color: var(--color-muted);
+}
+
+.realm-event {
+  align-self: flex-start;
+  border: none;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(255, 120, 73, 0.18), rgba(47, 166, 139, 0.28));
+  color: var(--color-text);
+  padding: 10px 14px;
+  font-family: var(--font-body);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.06);
+  cursor: pointer;
+  display: grid;
+  grid-template-columns: auto;
+  gap: 4px;
+  min-width: 160px;
+  position: relative;
+}
+
+.realm-event:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.realm-event__name {
+  font-size: 12px;
+  color: var(--color-emerald);
+}
+
+.realm-event__timer {
+  font-size: 14px;
+  font-weight: bold;
+}
+
+.realm-event__tooltip {
+  position: absolute;
+  inset: auto auto -8px 50%;
+  transform: translate(-50%, 100%);
+  background: rgba(11, 16, 33, 0.96);
+  border: var(--pixel-border);
+  border-radius: 16px;
+  padding: 12px;
+  width: clamp(220px, 40vw, 280px);
+  box-shadow: 0 12px 24px rgba(5, 6, 13, 0.6);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 3;
+}
+
+.realm-event:hover .realm-event__tooltip,
+.realm-event:focus-visible .realm-event__tooltip,
+.realm-event[aria-expanded="true"] .realm-event__tooltip {
+  opacity: 1;
 }
 
 .resource-bar {
@@ -175,6 +238,19 @@ body {
   box-shadow: 0 0 12px rgba(255, 120, 73, 0.25);
 }
 
+.tab-button--pulse {
+  animation: tabPulse 1.2s ease-in-out infinite;
+}
+
+@keyframes tabPulse {
+  0% {
+    box-shadow: 0 0 0 rgba(255, 120, 73, 0);
+  }
+  100% {
+    box-shadow: 0 0 18px rgba(255, 120, 73, 0.45);
+  }
+}
+
 .panel {
   background: var(--color-panel);
   border: var(--pixel-border);
@@ -215,6 +291,11 @@ body {
   border-radius: var(--border-radius);
   padding: clamp(12px, 3.5vw, 16px);
   border: 1px solid rgba(47, 166, 139, 0.25);
+}
+
+.panel-section + .panel-section {
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  padding-top: 18px;
 }
 
 .panel-section h3 {
@@ -634,6 +715,240 @@ body {
 .battle-summary {
   color: var(--color-muted);
   margin: 8px 0;
+}
+
+.relic-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.relic-card {
+  border: var(--pixel-border);
+  border-radius: 16px;
+  padding: 12px;
+  background: rgba(12, 19, 39, 0.9);
+  display: grid;
+  gap: 8px;
+  position: relative;
+}
+
+.relic-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 14px;
+  pointer-events: none;
+}
+
+.relic-card--owned {
+  box-shadow: 0 0 0 2px rgba(47, 166, 139, 0.35);
+}
+
+.relic-card header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.relic-card h3 {
+  margin: 0;
+  font-size: 16px;
+  text-transform: uppercase;
+}
+
+.relic-card footer {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.relic-effects {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.relic-pill {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(47, 166, 139, 0.18);
+  color: var(--color-emerald);
+}
+
+.alliance-panel {
+  display: grid;
+  gap: 16px;
+}
+
+.alliance-metrics {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.metric-card {
+  background: rgba(10, 17, 34, 0.9);
+  border-radius: 16px;
+  border: var(--pixel-border);
+  padding: 12px;
+  display: grid;
+  gap: 6px;
+}
+
+.metric-card strong {
+  font-size: 20px;
+}
+
+.leaderboard {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.leaderboard li {
+  display: flex;
+  justify-content: space-between;
+  background: rgba(8, 12, 26, 0.8);
+  border-radius: 12px;
+  padding: 8px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.battle-timeline {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.battle-timeline__controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.battle-timeline__slider {
+  flex: 1;
+}
+
+.battle-timeline__rounds {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.battle-round-pill {
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(255, 120, 73, 0.18);
+  border: 1px solid rgba(255, 120, 73, 0.25);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.battle-round-pill.active {
+  background: rgba(47, 166, 139, 0.22);
+  border-color: rgba(47, 166, 139, 0.45);
+  color: var(--color-emerald);
+}
+
+.battle-log__round {
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  margin: 6px 0;
+  background: rgba(9, 12, 24, 0.75);
+}
+
+.battle-log__round[data-active="true"] {
+  box-shadow: 0 0 0 2px rgba(47, 166, 139, 0.3);
+}
+
+.battle-visual-shake {
+  animation: battleShake 0.45s ease;
+}
+
+.battle-visual-glow {
+  animation: battleGlow 0.9s ease;
+}
+
+@keyframes battleShake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-6px);
+  }
+  50% {
+    transform: translateX(6px);
+  }
+  75% {
+    transform: translateX(-3px);
+  }
+}
+
+@keyframes battleGlow {
+  0% {
+    box-shadow: 0 0 0 rgba(255, 120, 73, 0);
+  }
+  40% {
+    box-shadow: 0 0 24px rgba(255, 120, 73, 0.5);
+  }
+  100% {
+    box-shadow: 0 0 0 rgba(255, 120, 73, 0);
+  }
+}
+
+.onboarding-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 5, 12, 0.75);
+  backdrop-filter: blur(6px);
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  z-index: 10;
+}
+
+.onboarding-overlay.hidden {
+  display: none;
+}
+
+.onboarding-card {
+  background: rgba(12, 18, 34, 0.95);
+  border-radius: 20px;
+  border: var(--pixel-border);
+  width: min(360px, 90vw);
+  padding: 24px;
+  display: grid;
+  gap: 16px;
+  text-align: left;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+}
+
+.onboarding-card h2 {
+  margin: 0;
+  font-size: 18px;
+  color: var(--color-emerald);
+  font-family: var(--font-display);
+}
+
+.onboarding-card p {
+  margin: 0;
+  font-size: 16px;
+}
+
+.onboarding-card footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- add a rotating realm event banner with tooltip, countdown, and resource modifiers that feed into battles
- extend the build view with a relic foundry, new relic data, and onboarding guidance while enhancing the battle log timeline
- introduce the alliance outpost tab plus Firebase-style persistence merging to sync leaderboard progress

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee8ad2fa3883229cff37a0689a9c80